### PR TITLE
Filesystem stat functionality

### DIFF
--- a/libraries/fs/fat/FATDirHandle.cpp
+++ b/libraries/fs/fat/FATDirHandle.cpp
@@ -44,6 +44,9 @@ struct dirent *FATDirHandle::readdir() {
 
     FRESULT res = f_readdir(&dir, &finfo);
 
+    // Check if we are handling file or directory
+    cur_entry.d_type = (finfo.fattrib & AM_DIR) ? DT_DIR : DT_REG;
+
 #if _USE_LFN
     if(res != 0 || finfo.fname[0]==0) {
         return NULL;

--- a/libraries/fs/fat/FATFileSystem.cpp
+++ b/libraries/fs/fat/FATFileSystem.cpp
@@ -151,3 +151,24 @@ int FATFileSystem::unmount() {
     FRESULT res = f_mount(_fsid, NULL);
     return res == 0 ? 0 : -1;
 }
+
+int FATFileSystem::stat(const char* path, struct stat* buf) {
+    FILINFO finfo;
+    FRESULT f_result = f_stat(path, &finfo);
+    if(f_result == FR_OK) {
+        // Translate time from FatFS to POSIX's time_t format
+        struct tm timeinfo;
+        timeinfo.tm_sec  = finfo.ftime & 0x1F;         // seconds after the minute (0-59)
+        timeinfo.tm_min  = (finfo.ftime >> 5) & 0x3F;  // minutes after the hour   (0-59)
+        timeinfo.tm_hour = (finfo.ftime >> 11) & 0x1F; // hours since midnight     (0-23)
+        timeinfo.tm_mday = finfo.fdate & 0x1F;         // day of the month         (1-31)
+        timeinfo.tm_mon  = (finfo.fdate >> 5) & 0x0F;  // months since January     (0-11)
+        timeinfo.tm_year = (finfo.fdate >> 9) & 0x7F;  // years                    (since 1900)
+        timeinfo.tm_year += 80; // Note: in fdate year origin from 1980 (0..127)
+
+        // Set stat structure:
+        buf->st_mtime = mktime(&timeinfo);
+        buf->st_size  = finfo.fsize;
+    }
+    return (int)f_result;
+}

--- a/libraries/fs/fat/FATFileSystem.cpp
+++ b/libraries/fs/fat/FATFileSystem.cpp
@@ -157,7 +157,7 @@ int FATFileSystem::stat(const char* path, struct stat* buf) {
     FRESULT f_result = f_stat(path, &finfo);
     if(f_result == FR_OK) {
         // Translate time from FatFS to POSIX's time_t format
-        struct tm timeinfo;
+        struct tm timeinfo = {0};
         timeinfo.tm_sec  = finfo.ftime & 0x1F;         // seconds after the minute (0-59)
         timeinfo.tm_min  = (finfo.ftime >> 5) & 0x3F;  // minutes after the hour   (0-59)
         timeinfo.tm_hour = (finfo.ftime >> 11) & 0x1F; // hours since midnight     (0-23)
@@ -166,8 +166,10 @@ int FATFileSystem::stat(const char* path, struct stat* buf) {
         timeinfo.tm_year = (finfo.fdate >> 9) & 0x7F;  // years                    (since 1900)
         timeinfo.tm_year += 80; // Note: in fdate year origin from 1980 (0..127)
 
-        // Set stat structure:
-        buf->st_mtime = mktime(&timeinfo);
+        const time_t mkt = mktime(&timeinfo);
+        const time_t MKTIME_ERR = (time_t)-1;
+        // Set struct stat
+        buf->st_mtime = mkt == MKTIME_ERR ? 0 : mkt;
         buf->st_size  = finfo.fsize;
     }
     return (int)f_result;

--- a/libraries/fs/fat/FATFileSystem.h
+++ b/libraries/fs/fat/FATFileSystem.h
@@ -88,6 +88,7 @@ public:
     virtual int disk_write(const uint8_t * buffer, uint64_t sector, uint8_t count) = 0;
     virtual int disk_sync() { return 0; }
     virtual uint64_t disk_sectors() = 0;
+    virtual int stat(const char *path, struct stat *buf);
 
 };
 

--- a/libraries/mbed/api/DirHandle.h
+++ b/libraries/mbed/api/DirHandle.h
@@ -26,8 +26,27 @@ typedef int mode_t;
 
 #include "FileHandle.h"
 
+/*
+ * File types
+ */
+#define DT_UNKNOWN       0
+#define DT_FIFO          1
+#define DT_CHR           2
+#define DT_DIR           4
+#define DT_BLK           6
+#define DT_REG           8
+#define DT_LNK          10
+#define DT_SOCK         12
+#define DT_WHT          14
+
+// DT_DIR      This is a directory.
+// DT_REG      This is a regular file.
+// DT_UNKNOWN  The file type is unknown.
+
 struct dirent {
-    char d_name[NAME_MAX+1];
+    unsigned char d_type;       /* type of file; not supported
+                                   by all file system types */
+    char d_name[NAME_MAX+1];    /* filename */
 };
 
 namespace mbed {

--- a/libraries/mbed/api/DirHandle.h
+++ b/libraries/mbed/api/DirHandle.h
@@ -19,6 +19,12 @@
 #if defined(__ARMCC_VERSION) || defined(__ICCARM__)
 #   define NAME_MAX 255
 typedef int mode_t;
+
+typedef long int __off_t;
+typedef __off_t off_t;
+
+#include <time.h>
+
 struct stat {
     off_t     st_size;    /* total size, in bytes */
     time_t    st_mtime;   /* time of last modification */
@@ -28,7 +34,6 @@ struct stat {
 #   include <sys/syslimits.h>
 #endif
 
-#include <time.h>
 #include "FileHandle.h"
 
 /*

--- a/libraries/mbed/api/DirHandle.h
+++ b/libraries/mbed/api/DirHandle.h
@@ -19,11 +19,16 @@
 #if defined(__ARMCC_VERSION) || defined(__ICCARM__)
 #   define NAME_MAX 255
 typedef int mode_t;
+struct stat {
+    off_t     st_size;    /* total size, in bytes */
+    time_t    st_mtime;   /* time of last modification */
+};
 
 #else
 #   include <sys/syslimits.h>
 #endif
 
+#include <time.h>
 #include "FileHandle.h"
 
 /*
@@ -114,6 +119,7 @@ extern "C" {
     long telldir(DIR*);
     void seekdir(DIR*, long);
     int mkdir(const char *name, mode_t n);
+    int stat(const char *name, struct stat *buf);
 };
 
 #endif /* MBED_DIRHANDLE_H */

--- a/libraries/mbed/api/DirHandle.h
+++ b/libraries/mbed/api/DirHandle.h
@@ -39,10 +39,6 @@ typedef int mode_t;
 #define DT_SOCK         12
 #define DT_WHT          14
 
-// DT_DIR      This is a directory.
-// DT_REG      This is a regular file.
-// DT_UNKNOWN  The file type is unknown.
-
 struct dirent {
     unsigned char d_type;       /* type of file; not supported
                                    by all file system types */

--- a/libraries/mbed/api/FileSystemLike.h
+++ b/libraries/mbed/api/FileSystemLike.h
@@ -96,6 +96,21 @@ public:
      */
     virtual int mkdir(const char *name, mode_t mode) { return -1; }
 
+    /** These functions return information about a file. No permissions are
+     *  required on the file itself, but-in the case of stat() and lstat() - execute
+     *  (search) permission is required on all of the directories in path that
+     *  lead to the file.
+     *
+     *  @param name The name of the directory to create.
+     *  @param buf  Pointer to pre-allocated buffer with stat structure.
+     *
+     *  @returns
+     *    0 on success,
+        !=0 file system specific error,
+     *   -1 on failure (Functionality not supported).
+     */
+    virtual int stat(const char *path, struct stat *buf) { return -1; }
+
     // TODO other filesystem functions (mkdir, rm, rn, ls etc)
 };
 

--- a/libraries/mbed/common/FileSystemLike.cpp
+++ b/libraries/mbed/common/FileSystemLike.cpp
@@ -45,6 +45,7 @@ public:
         n++;
 
         /* Setup cur entry and return a pointer to it */
+        cur_entry.d_type = DT_UNKNOWN;
         std::strncpy(cur_entry.d_name, ptr->getName(), NAME_MAX);
         return &cur_entry;
     }

--- a/libraries/mbed/common/LocalFileSystem.cpp
+++ b/libraries/mbed/common/LocalFileSystem.cpp
@@ -173,6 +173,7 @@ public:
         if (xffind("*", &info)!=0) {
             return NULL;
         }
+        cur_entry.d_type = DT_UNKNOWN;
         memcpy(cur_entry.d_name, info.name, sizeof(info.name));
         return &cur_entry;
     }

--- a/libraries/mbed/common/retarget.cpp
+++ b/libraries/mbed/common/retarget.cpp
@@ -390,6 +390,14 @@ extern "C" int mkdir(const char *path, mode_t mode) {
     return fs->mkdir(fp.fileName(), mode);
 }
 
+extern "C" int stat(const char *path, struct stat *buf) {
+    FilePath fp(path);
+    FileSystemLike *fs = fp.fileSystem();
+    if (fs == NULL) return -1;
+
+    return fs->stat(fp.fileName(), buf);
+}
+
 #if defined(TOOLCHAIN_GCC)
 /* prevents the exception handling name demangling code getting pulled in */
 #include "mbed_error.h"

--- a/libraries/tests/mbed/sd_stat/main.cpp
+++ b/libraries/tests/mbed/sd_stat/main.cpp
@@ -46,7 +46,8 @@ SDFileSystem sd(D11, D12, D13, D10, "sd");
 SDFileSystem sd(p11, p12, p13, p14, "sd");
 #endif
 
-namespace {
+namespace
+{
 }
 
 int main()
@@ -54,38 +55,38 @@ int main()
     bool result = true;
     DIR *dir;
     struct dirent *ent;
-    if ((dir = opendir ("/sd/")) != NULL) {
+    char name[128] = "/sd/";
+    char buffer[32] = {0};
+    if ((dir = opendir(name)) != NULL) {
         // print all the files and directories within directory
-
         printf("type\tmodified          \tsize\tname\r\n");
         while ((ent = readdir (dir)) != NULL) {
             if (ent->d_type == DT_UNKNOWN) {
                 // If we still get unknown SD card file type...
                 result = false;
             }
-            struct stat statinfo;
-            char name[256] = "/sd/";
             strcat(name, ent->d_name);
+
+            struct stat statinfo = {0};
             int res = stat(name, &statinfo);
 
             int f_size = res ? 0 : statinfo.st_size;
             time_t f_mtime = res ? 0 : statinfo.st_mtime;
 
-            char buffer[32] = {0};
             strftime(buffer, 32, "%Y-%m-%d %H:%M%p", localtime(&f_mtime));
 
             // Print file type and name
             bool is_dir = (ent->d_type == DT_DIR);
-            const char *file_dir = is_dir ? "d" : "f";
-            printf("%s\t%s\t%d\t%s\r\n", file_dir, buffer, f_size, ent->d_name);
-
+            const char file_dir = is_dir ? 'd' : 'f';
+            printf("%c\t%s\t%d\t%s\r\n", file_dir, buffer, f_size, ent->d_name);
         }
-        closedir (dir);
+        closedir(dir);
     } else {
         // could not open directory
-        printf("Could not open directory");
+        printf("Could not open directory: %s", name);
         result = false;
     }
 
     notify_completion(result);
+    return 0;
 }

--- a/libraries/tests/mbed/sd_stat/main.cpp
+++ b/libraries/tests/mbed/sd_stat/main.cpp
@@ -1,0 +1,77 @@
+#include "mbed.h"
+#include "SDFileSystem.h"
+#include "test_env.h"
+
+#if defined(TARGET_KL25Z)
+SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
+
+#elif defined(TARGET_KL46Z)
+SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
+
+#elif defined(TARGET_K64F)
+SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
+
+#elif defined(TARGET_K20D50M)
+SDFileSystem sd(PTD2, PTD3, PTD1, PTC2, "sd");
+
+#elif defined(TARGET_nRF51822)
+SDFileSystem sd(p12, p13, p15, p14, "sd");
+
+#elif defined(TARGET_NUCLEO_F030R8) || \
+      defined(TARGET_NUCLEO_F072RB) || \
+      defined(TARGET_NUCLEO_F091RC) || \
+      defined(TARGET_NUCLEO_F103RB) || \
+      defined(TARGET_NUCLEO_F302R8) || \
+      defined(TARGET_NUCLEO_F303RE) || \
+      defined(TARGET_NUCLEO_F334R8) || \
+      defined(TARGET_NUCLEO_F401RE) || \
+      defined(TARGET_NUCLEO_F411RE) || \
+      defined(TARGET_NUCLEO_L053R8) || \
+      defined(TARGET_NUCLEO_L152RE)
+SDFileSystem sd(D11, D12, D13, D10, "sd");
+
+#elif defined(TARGET_DISCO_F051R8)
+SDFileSystem sd(SPI_MOSI, SPI_MISO, SPI_SCK, SPI_CS, "sd");
+
+#elif defined(TARGET_LPC2368)
+SDFileSystem sd(p11, p12, p13, p14, "sd");
+
+#elif defined(TARGET_LPC11U68)
+SDFileSystem sd(D11, D12, D13, D10, "sd");
+
+#elif defined(TARGET_LPC1549)
+SDFileSystem sd(D11, D12, D13, D10, "sd");
+
+#else
+SDFileSystem sd(p11, p12, p13, p14, "sd");
+#endif
+
+namespace {
+}
+
+int main()
+{
+    bool result = true;
+    DIR *dir;
+    struct dirent *ent;
+    if ((dir = opendir ("/sd/")) != NULL) {
+        // print all the files and directories within directory
+        while ((ent = readdir (dir)) != NULL) {
+            if (ent->d_type == DT_UNKNOWN) {
+                // If we still get unknown SD card file type...
+                result = false;
+            }
+            // Print file type and name
+            bool is_dir = (ent->d_type == DT_DIR);
+            const char *file_dir = is_dir ? "dir" : "file";
+            printf("%s:\t%s\r\n", file_dir, ent->d_name);
+        }
+        closedir (dir);
+    } else {
+        // could not open directory
+        printf("Could not open directory");
+        result = false;
+    }    
+    
+    notify_completion(result);
+}

--- a/libraries/tests/mbed/sd_stat/main.cpp
+++ b/libraries/tests/mbed/sd_stat/main.cpp
@@ -56,22 +56,36 @@ int main()
     struct dirent *ent;
     if ((dir = opendir ("/sd/")) != NULL) {
         // print all the files and directories within directory
+
+        printf("type\tmodified          \tsize\tname\r\n");
         while ((ent = readdir (dir)) != NULL) {
             if (ent->d_type == DT_UNKNOWN) {
                 // If we still get unknown SD card file type...
                 result = false;
             }
+            struct stat statinfo;
+            char name[256] = "/sd/";
+            strcat(name, ent->d_name);
+            int res = stat(name, &statinfo);
+
+            int f_size = res ? 0 : statinfo.st_size;
+            time_t f_mtime = res ? 0 : statinfo.st_mtime;
+
+            char buffer[32] = {0};
+            strftime(buffer, 32, "%Y-%m-%d %H:%M%p", localtime(&f_mtime));
+
             // Print file type and name
             bool is_dir = (ent->d_type == DT_DIR);
-            const char *file_dir = is_dir ? "dir" : "file";
-            printf("%s:\t%s\r\n", file_dir, ent->d_name);
+            const char *file_dir = is_dir ? "d" : "f";
+            printf("%s\t%s\t%d\t%s\r\n", file_dir, buffer, f_size, ent->d_name);
+
         }
         closedir (dir);
     } else {
         // could not open directory
         printf("Could not open directory");
         result = false;
-    }    
-    
+    }
+
     notify_completion(result);
 }

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -527,7 +527,15 @@ TESTS = [
         "automated": True,
         "host_test": "wait_us_auto"
     },
-    
+    {
+        "id": "MBED_35", "description": "FileSystem stat functionality",
+        "source_dir": join(TEST_DIR, "mbed", "sd_stat"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB, FS_LIBRARY],
+        "duration": 15,
+        "automated": True,
+        "peripherals": ["SD"]
+    },
+
 
     # CMSIS RTOS tests
     {

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -528,7 +528,7 @@ TESTS = [
         "host_test": "wait_us_auto"
     },
     {
-        "id": "MBED_35", "description": "FileSystem stat functionality",
+        "id": "MBED_35", "description": "FileSystem stat() func",
         "source_dir": join(TEST_DIR, "mbed", "sd_stat"),
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB, FS_LIBRARY],
         "duration": 15,


### PR DESCRIPTION
## Description
Simple detection if file system file is actually file or directory was missing. To do this I followed POSIX's 'struct dirent' and added new standardized field d_type to store type flag.
Please see: http://www.gsp.com/cgi-bin/man.cgi?section=5&topic=dir for 'struct dirent'.
### Things done:
* Extended readdir() function by adding extra field in 'struct dirent' returned .
 * Added new field in 'struct dirent'. New field 'd_type' was added to provide field which could store file type (file, directory, unknown etc.)
 * Added dirent::d_type related file types in header file.
* In code for now we only use this flags to determine if file is actually a file: 
 * DT_UNKNOWN - unknown (in our case mostly 'not supported'),
 * DT_DIR - directory, 
 * DT_REG - regular file.
* Added new test MBED_35 to cover status flag detection.
## How to use it? :)
```c++
SDFileSystem sd(D11, D12, D13, D10, "sd");
int main()
{
    bool result = true;
    DIR *dir;
    struct dirent *ent;
    if ((dir = opendir ("/sd/")) != NULL) {
        // print all the files and directories within directory
        while ((ent = readdir (dir)) != NULL) {
            //////////////////// USAGE ////////////////////
            if (ent->d_type == DT_UNKNOWN) {
                // If we still get unknown SD card file type...
                result = false;
            }
            else {
                // Print file type and name
                bool is_dir = (ent->d_type == DT_DIR);
                const char *file_dir = is_dir ? "dir" : "file";
                printf("%s:\t%s\r\n", file_dir, ent->d_name);
            }
            //////////////////// USAGE ////////////////////
        }
        closedir (dir);
    } else {
        // could not open directory
        printf("Could not open directory");
        result = false;
    }    
    return result;
}
```
### Future work (What we can add to file system functionality)
This functionality could be extended to support stat functionality from <sys/stat.h>, or at least part of it. This pull request is a simple base ground to do stuff below:

* Add support for stat function: 
 * int stat(const char *path, struct stat *buf).
* Related to stat() structures:
 * struct stat itself,
 * At least S_ISDIR, S_ISREG macros,
 * See: http://linux.die.net/man/2/stat.
* Provide a way for users to get file creation time, modification time, file size, file attributes.

### Testing results
```
[git:filesystem-stat-functionality*] c:\Work\mbed-przemek\workspace_tools> git branch
* filesystem-stat-functionality
  host-test-improvements-part-2
  master

[git:filesystem-stat-functionality*] c:\Work\mbed-przemek\workspace_tools> singletest.py -i test_spec.json -M muts_all.json -P -c cp
Building library CMSIS (NUCLEO_F401RE, uARM)
Building library MBED (NUCLEO_F401RE, uARM)
Building library FAT (NUCLEO_F401RE, uARM)
Building project SD_STAT (NUCLEO_F401RE, uARM)
TargetTest::NUCLEO_F401RE::uARM::MBED_35::FileSystem stat functionality [OK] in 1.42 of 15 sec
Building library FAT (NUCLEO_F401RE, uARM)
Building project SD (NUCLEO_F401RE, uARM)
TargetTest::NUCLEO_F401RE::uARM::MBED_A12::SD File System [OK] in 2.42 of 15 sec
Building library FAT (NUCLEO_F401RE, uARM)
Building project SD_PERF_STDIO (NUCLEO_F401RE, uARM)
Compile: main.cpp
Link: sd_perf_stdio
Elf2Bin: sd_perf_stdio
TargetTest::NUCLEO_F401RE::uARM::PERF_1::SD Stdio R/W Speed [OK] in 5.42 of 15 sec
Building library FAT (NUCLEO_F401RE, uARM)
Building project SD_PERF_FHANDLE (NUCLEO_F401RE, uARM)
Compile: main.cpp
Link: sd_perf_fhandle
Elf2Bin: sd_perf_fhandle
TargetTest::NUCLEO_F401RE::uARM::PERF_2::SD FileHandle R/W Speed [OK] in 5.42 of 15 sec
Building library FAT (NUCLEO_F401RE, uARM)
Building project SD_PERF_FATFS (NUCLEO_F401RE, uARM)
Compile: main.cpp
Link: sd_perf_fatfs
Elf2Bin: sd_perf_fatfs
TargetTest::NUCLEO_F401RE::uARM::PERF_3::SD FatFS R/W Speed [OK] in 5.42 of 15 sec
Test summary:
+--------+---------------+-----------+----------+-------------------------------+--------------------+---------------+-------+
| Result | Target        | Toolchain | Test ID  | Test Description              | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------------+-----------+----------+-------------------------------+--------------------+---------------+-------+
| OK     | NUCLEO_F401RE | uARM      | MBED_35  | FileSystem stat functionality |        1.42        |       15      |  1/1  |
| OK     | NUCLEO_F401RE | uARM      | MBED_A12 | SD File System                |        2.42        |       15      |  1/1  |
| OK     | NUCLEO_F401RE | uARM      | PERF_1   | SD Stdio R/W Speed            |        5.42        |       15      |  1/1  |
| OK     | NUCLEO_F401RE | uARM      | PERF_2   | SD FileHandle R/W Speed       |        5.42        |       15      |  1/1  |
| OK     | NUCLEO_F401RE | uARM      | PERF_3   | SD FatFS R/W Speed            |        5.42        |       15      |  1/1  |
+--------+---------------+-----------+----------+-------------------------------+--------------------+---------------+-------+
Result: 5 OK

Completed in 39.05 sec
```