### PR TITLE
Pinology

### DIFF
--- a/libraries/mbed/api/BusIn.h
+++ b/libraries/mbed/api/BusIn.h
@@ -68,8 +68,6 @@ public:
         return _nc_mask;
     }
 
-    static DigitalIn din_dummy;
-
 #ifdef MBED_OPERATORS
     /** A shorthand for read()
      */

--- a/libraries/mbed/api/BusIn.h
+++ b/libraries/mbed/api/BusIn.h
@@ -83,7 +83,9 @@ public:
 protected:
     DigitalIn* _pin[16];
 
-    /** Mask of NC pins, if bit [n] bit is set to 1, [n] pin in bus is in NC state
+    /** Mask of bus's NC pins
+     * If bit[n] is set to 1 - pin is connected
+     * if bit[n] is cleared - pin is not connected (NC)
      */
     int _nc_mask;
 

--- a/libraries/mbed/api/BusIn.h
+++ b/libraries/mbed/api/BusIn.h
@@ -58,6 +58,16 @@ public:
      */
     void mode(PinMode pull);
 
+    /** Binary mask of bus pins connected to actual pins (not NC pins)
+     *  If bus pin is in NC state make corresponding bit will be cleared (set to 0), else bit will be set to 1
+     *
+     *  @returns
+     *    Binary mask of connected pins
+     */
+    int mask() {
+        return _nc_mask;
+    }
+
     static DigitalIn din_dummy;
 
 #ifdef MBED_OPERATORS
@@ -72,6 +82,10 @@ public:
 
 protected:
     DigitalIn* _pin[16];
+
+    /** Mask of NC pins, if bit [n] bit is set to 1, [n] pin in bus is in NC state
+     */
+    int _nc_mask;
 
     /* disallow copy constructor and assignment operators */
 private:

--- a/libraries/mbed/api/BusIn.h
+++ b/libraries/mbed/api/BusIn.h
@@ -58,10 +58,16 @@ public:
      */
     void mode(PinMode pull);
 
+    static DigitalIn din_dummy;
+
 #ifdef MBED_OPERATORS
     /** A shorthand for read()
      */
     operator int();
+
+    /** Access to particular bit in random-iterator fashion
+     */
+    DigitalIn & operator[] (unsigned int index);
 #endif
 
 protected:

--- a/libraries/mbed/api/BusIn.h
+++ b/libraries/mbed/api/BusIn.h
@@ -77,7 +77,7 @@ public:
 
     /** Access to particular bit in random-iterator fashion
      */
-    DigitalIn & operator[] (unsigned int index);
+    DigitalIn & operator[] (int index);
 #endif
 
 protected:

--- a/libraries/mbed/api/BusInOut.h
+++ b/libraries/mbed/api/BusInOut.h
@@ -82,8 +82,6 @@ public:
         return _nc_mask;
     }
 
-    static DigitalInOut dinout_dummy;
-
 #ifdef MBED_OPERATORS
      /** A shorthand for write()
      */

--- a/libraries/mbed/api/BusInOut.h
+++ b/libraries/mbed/api/BusInOut.h
@@ -98,7 +98,9 @@ public:
 protected:
     DigitalInOut* _pin[16];
 
-    /** Mask of NC pins, if bit [n] bit is set to 1, [n] pin in bus is in NC state
+    /** Mask of bus's NC pins
+     * If bit[n] is set to 1 - pin is connected
+     * if bit[n] is cleared - pin is not connected (NC)
      */
     int _nc_mask;
 

--- a/libraries/mbed/api/BusInOut.h
+++ b/libraries/mbed/api/BusInOut.h
@@ -73,6 +73,18 @@ public:
      */
     void mode(PinMode pull);
 
+    /** Binary mask of bus pins connected to actual pins (not NC pins)
+     *  If bus pin is in NC state make corresponding bit will be cleared (set to 0), else bit will be set to 1
+     *
+     *  @returns
+     *    Binary mask of connected pins
+     */
+    int mask() {
+        return _nc_mask;
+    }
+
+    static DigitalInOut dinout_dummy;
+
 #ifdef MBED_OPERATORS
      /** A shorthand for write()
      */
@@ -87,10 +99,15 @@ public:
 protected:
     DigitalInOut* _pin[16];
 
+    /** Mask of NC pins, if bit [n] bit is set to 1, [n] pin in bus is in NC state
+     */
+    int _nc_mask;
+
     /* disallow copy constructor and assignment operators */
 private:
     BusInOut(const BusInOut&);
     BusInOut & operator = (const BusInOut&);
+    DigitalInOut& operator[] (unsigned int index);
 };
 
 } // namespace mbed

--- a/libraries/mbed/api/BusInOut.h
+++ b/libraries/mbed/api/BusInOut.h
@@ -90,6 +90,10 @@ public:
     BusInOut& operator= (int v);
     BusInOut& operator= (BusInOut& rhs);
 
+    /** Access to particular bit in random-iterator fashion
+    */
+    DigitalInOut& operator[] (int index);
+
     /** A shorthand for read()
      */
     operator int();
@@ -108,7 +112,6 @@ protected:
 private:
     BusInOut(const BusInOut&);
     BusInOut & operator = (const BusInOut&);
-    DigitalInOut& operator[] (unsigned int index);
 };
 
 } // namespace mbed

--- a/libraries/mbed/api/BusInOut.h
+++ b/libraries/mbed/api/BusInOut.h
@@ -51,7 +51,6 @@ public:
      */
     void write(int value);
 
-
     /** Read the value currently output on the bus
      *
      *  @returns

--- a/libraries/mbed/api/BusOut.h
+++ b/libraries/mbed/api/BusOut.h
@@ -66,8 +66,6 @@ public:
         return _nc_mask;
     }
 
-    static DigitalOut dout_dummy;
-
 #ifdef MBED_OPERATORS
     /** A shorthand for write()
      */

--- a/libraries/mbed/api/BusOut.h
+++ b/libraries/mbed/api/BusOut.h
@@ -56,6 +56,16 @@ public:
      */
     int read();
 
+    /** Binary mask of bus pins connected to actual pins (not NC pins)
+     *  If bus pin is in NC state make corresponding bit will be cleared (set to 0), else bit will be set to 1
+     *
+     *  @returns
+     *    Binary mask of connected pins
+     */
+    int mask() {
+        return _nc_mask;
+    }
+
     static DigitalOut dout_dummy;
 
 #ifdef MBED_OPERATORS
@@ -75,6 +85,10 @@ public:
 
 protected:
     DigitalOut* _pin[16];
+
+    /** Mask of NC pins, if bit [n] bit is set to 1, [n] pin in bus is in NC state
+     */
+    int _nc_mask;
 
    /* disallow copy constructor and assignment operators */
 private:

--- a/libraries/mbed/api/BusOut.h
+++ b/libraries/mbed/api/BusOut.h
@@ -76,7 +76,7 @@ public:
 
     /** Access to particular bit in random-iterator fashion
      */
-    DigitalOut& operator[] (unsigned int index);
+    DigitalOut& operator[] (int index);
 
     /** A shorthand for read()
      */

--- a/libraries/mbed/api/BusOut.h
+++ b/libraries/mbed/api/BusOut.h
@@ -86,7 +86,9 @@ public:
 protected:
     DigitalOut* _pin[16];
 
-    /** Mask of NC pins, if bit [n] bit is set to 1, [n] pin in bus is in NC state
+    /** Mask of bus's NC pins
+     * If bit[n] is set to 1 - pin is connected
+     * if bit[n] is cleared - pin is not connected (NC)
      */
     int _nc_mask;
 

--- a/libraries/mbed/api/BusOut.h
+++ b/libraries/mbed/api/BusOut.h
@@ -56,11 +56,17 @@ public:
      */
     int read();
 
+    static DigitalOut dout_dummy;
+
 #ifdef MBED_OPERATORS
     /** A shorthand for write()
      */
     BusOut& operator= (int v);
     BusOut& operator= (BusOut& rhs);
+
+    /** Access to particular bit in random-iterator fashion
+     */
+    DigitalOut& operator[] (unsigned int index);
 
     /** A shorthand for read()
      */

--- a/libraries/mbed/api/DigitalIn.h
+++ b/libraries/mbed/api/DigitalIn.h
@@ -80,6 +80,16 @@ public:
         gpio_mode(&gpio, pull);
     }
 
+    /** Return the output setting, represented as 0 or 1 (int)
+     *
+     *  @returns
+     *    Non zero value if pin is connected to uc GPIO
+     *    0 if gpio object was initialized with NC
+     */
+    int is_connected() {
+        return gpio_is_connected(&gpio);
+    }
+
 #ifdef MBED_OPERATORS
     /** An operator shorthand for read()
      */

--- a/libraries/mbed/api/DigitalInOut.h
+++ b/libraries/mbed/api/DigitalInOut.h
@@ -85,6 +85,16 @@ public:
         gpio_mode(&gpio, pull);
     }
 
+    /** Return the output setting, represented as 0 or 1 (int)
+     *
+     *  @returns
+     *    Non zero value if pin is connected to uc GPIO
+     *    0 if gpio object was initialized with NC
+     */
+    int is_connected() {
+        return gpio_is_connected(&gpio);
+    }
+
 #ifdef MBED_OPERATORS
     /** A shorthand for write()
      */

--- a/libraries/mbed/api/DigitalOut.h
+++ b/libraries/mbed/api/DigitalOut.h
@@ -77,6 +77,16 @@ public:
         return gpio_read(&gpio);
     }
 
+    /** Return the output setting, represented as 0 or 1 (int)
+     *
+     *  @returns
+     *    Non zero value if pin is connected to uc GPIO
+     *    0 if gpio object was initialized with NC
+     */
+    int is_connected() {
+        return gpio_is_connected(&gpio);
+    }
+
 #ifdef MBED_OPERATORS
     /** A shorthand for write()
      */

--- a/libraries/mbed/common/BusIn.cpp
+++ b/libraries/mbed/common/BusIn.cpp
@@ -73,7 +73,7 @@ BusIn::operator int() {
 }
 
 DigitalIn& BusIn::operator[] (int index) {
-    MBED_ASSERT(index < 0 || index >= MBED_BUS_SIZE);
+    MBED_ASSERT(index < 0 || index >= 16);
     MBED_ASSERT(_pin[index]);
     if (index >= 16 || _pin[index] == NULL) {
         return din_dummy;

--- a/libraries/mbed/common/BusIn.cpp
+++ b/libraries/mbed/common/BusIn.cpp
@@ -22,14 +22,22 @@ DigitalIn BusIn::din_dummy(NC);
 BusIn::BusIn(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
+    _nc_mask = 0;
     for (int i=0; i<16; i++) {
         _pin[i] = (pins[i] != NC) ? new DigitalIn(pins[i]) : 0;
+        if (pins[i] != NC) {
+            _nc_mask |= (1 << i);
+        }
     }
 }
 
 BusIn::BusIn(PinName pins[16]) {
+    _nc_mask = 0;
     for (int i=0; i<16; i++) {
         _pin[i] = (pins[i] != NC) ? new DigitalIn(pins[i]) : 0;
+        if (pins[i] != NC) {
+            _nc_mask |= (1 << i);
+        }
     }
 }
 

--- a/libraries/mbed/common/BusIn.cpp
+++ b/libraries/mbed/common/BusIn.cpp
@@ -17,6 +17,8 @@
 
 namespace mbed {
 
+DigitalIn BusIn::din_dummy(NC);
+
 BusIn::BusIn(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
@@ -61,6 +63,16 @@ void BusIn::mode(PinMode pull) {
 BusIn::operator int() {
     return read();
 }
+
+DigitalIn& BusIn::operator[] (unsigned int index) {
+    //MBED_ASSERT(index >= MBED_BUS_SIZE);
+    //MBED_ASSERT(_pin[index]);
+    if (index >= 16 || _pin[index] == NULL) {
+        return din_dummy;
+    }
+    return *_pin[index];
+}
+
 #endif
 
 } // namespace mbed

--- a/libraries/mbed/common/BusIn.cpp
+++ b/libraries/mbed/common/BusIn.cpp
@@ -17,8 +17,6 @@
 
 namespace mbed {
 
-DigitalIn BusIn::din_dummy(NC);
-
 BusIn::BusIn(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
@@ -73,11 +71,8 @@ BusIn::operator int() {
 }
 
 DigitalIn& BusIn::operator[] (int index) {
-    MBED_ASSERT(index < 0 || index >= 16);
+    MBED_ASSERT(index >= 0 && index <= 16);
     MBED_ASSERT(_pin[index]);
-    if (index >= 16 || _pin[index] == NULL) {
-        return din_dummy;
-    }
     return *_pin[index];
 }
 

--- a/libraries/mbed/common/BusIn.cpp
+++ b/libraries/mbed/common/BusIn.cpp
@@ -72,9 +72,9 @@ BusIn::operator int() {
     return read();
 }
 
-DigitalIn& BusIn::operator[] (unsigned int index) {
-    //MBED_ASSERT(index >= MBED_BUS_SIZE);
-    //MBED_ASSERT(_pin[index]);
+DigitalIn& BusIn::operator[] (int index) {
+    MBED_ASSERT(index < 0 || index >= MBED_BUS_SIZE);
+    MBED_ASSERT(_pin[index]);
     if (index >= 16 || _pin[index] == NULL) {
         return din_dummy;
     }

--- a/libraries/mbed/common/BusInOut.cpp
+++ b/libraries/mbed/common/BusInOut.cpp
@@ -103,7 +103,7 @@ BusInOut& BusInOut::operator= (BusInOut& rhs) {
 }
 
 DigitalInOut& BusInOut::operator[] (int index) {
-    MBED_ASSERT(index < 0 || index >= MBED_BUS_SIZE);
+    MBED_ASSERT(index < 0 || index >= 16);
     MBED_ASSERT(_pin[index]);
     if (index >= 16 || _pin[index] == NULL) {
         return dinout_dummy;

--- a/libraries/mbed/common/BusInOut.cpp
+++ b/libraries/mbed/common/BusInOut.cpp
@@ -111,7 +111,6 @@ DigitalInOut& BusInOut::operator[] (unsigned int index) {
     return *_pin[index];
 }
 
-
 BusInOut::operator int() {
     return read();
 }

--- a/libraries/mbed/common/BusInOut.cpp
+++ b/libraries/mbed/common/BusInOut.cpp
@@ -17,8 +17,6 @@
 
 namespace mbed {
 
-DigitalInOut BusInOut::dinout_dummy(NC);
-
 BusInOut::BusInOut(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
@@ -103,11 +101,8 @@ BusInOut& BusInOut::operator= (BusInOut& rhs) {
 }
 
 DigitalInOut& BusInOut::operator[] (int index) {
-    MBED_ASSERT(index < 0 || index >= 16);
+    MBED_ASSERT(index >= 0 && index <= 16);
     MBED_ASSERT(_pin[index]);
-    if (index >= 16 || _pin[index] == NULL) {
-        return dinout_dummy;
-    }
     return *_pin[index];
 }
 

--- a/libraries/mbed/common/BusInOut.cpp
+++ b/libraries/mbed/common/BusInOut.cpp
@@ -102,9 +102,9 @@ BusInOut& BusInOut::operator= (BusInOut& rhs) {
     return *this;
 }
 
-DigitalInOut& BusInOut::operator[] (unsigned int index) {
-    //MBED_ASSERT(index >= MBED_BUS_SIZE);
-    //MBED_ASSERT(_pin[index]);
+DigitalInOut& BusInOut::operator[] (int index) {
+    MBED_ASSERT(index < 0 || index >= MBED_BUS_SIZE);
+    MBED_ASSERT(_pin[index]);
     if (index >= 16 || _pin[index] == NULL) {
         return dinout_dummy;
     }

--- a/libraries/mbed/common/BusInOut.cpp
+++ b/libraries/mbed/common/BusInOut.cpp
@@ -17,17 +17,27 @@
 
 namespace mbed {
 
+DigitalInOut BusInOut::dinout_dummy(NC);
+
 BusInOut::BusInOut(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
+    _nc_mask = 0;
     for (int i=0; i<16; i++) {
         _pin[i] = (pins[i] != NC) ? new DigitalInOut(pins[i]) : 0;
+        if (pins[i] != NC) {
+            _nc_mask |= (1 << i);
+        }
     }
 }
 
 BusInOut::BusInOut(PinName pins[16]) {
+    _nc_mask = 0;
     for (int i=0; i<16; i++) {
         _pin[i] = (pins[i] != NC) ? new DigitalInOut(pins[i]) : 0;
+        if (pins[i] != NC) {
+            _nc_mask |= (1 << i);
+        }
     }
 }
 
@@ -91,6 +101,16 @@ BusInOut& BusInOut::operator= (BusInOut& rhs) {
     write(rhs.read());
     return *this;
 }
+
+DigitalInOut& BusInOut::operator[] (unsigned int index) {
+    //MBED_ASSERT(index >= MBED_BUS_SIZE);
+    //MBED_ASSERT(_pin[index]);
+    if (index >= 16 || _pin[index] == NULL) {
+        return dinout_dummy;
+    }
+    return *_pin[index];
+}
+
 
 BusInOut::operator int() {
     return read();

--- a/libraries/mbed/common/BusOut.cpp
+++ b/libraries/mbed/common/BusOut.cpp
@@ -17,8 +17,6 @@
 
 namespace mbed {
 
-DigitalOut BusOut::dout_dummy(NC);
-
 BusOut::BusOut(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
@@ -79,11 +77,8 @@ BusOut& BusOut::operator= (BusOut& rhs) {
 }
 
 DigitalOut& BusOut::operator[] (int index) {
-    MBED_ASSERT(index < 0 || index >= 16);
+    MBED_ASSERT(index >= 0 && index <= 16);
     MBED_ASSERT(_pin[index]);
-    if (index >= 16 || _pin[index] == NULL) {
-        return dout_dummy;
-    }
     return *_pin[index];
 }
 

--- a/libraries/mbed/common/BusOut.cpp
+++ b/libraries/mbed/common/BusOut.cpp
@@ -78,9 +78,9 @@ BusOut& BusOut::operator= (BusOut& rhs) {
     return *this;
 }
 
-DigitalOut& BusOut::operator[] (unsigned int index) {
-    //MBED_ASSERT(index >= MBED_BUS_SIZE);
-    //MBED_ASSERT(_pin[index]);
+DigitalOut& BusOut::operator[] (int index) {
+    MBED_ASSERT(index < 0 || index >= MBED_BUS_SIZE);
+    MBED_ASSERT(_pin[index]);
     if (index >= 16 || _pin[index] == NULL) {
         return dout_dummy;
     }

--- a/libraries/mbed/common/BusOut.cpp
+++ b/libraries/mbed/common/BusOut.cpp
@@ -17,6 +17,8 @@
 
 namespace mbed {
 
+DigitalOut BusOut::dout_dummy(NC);
+
 BusOut::BusOut(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
@@ -66,6 +68,15 @@ BusOut& BusOut::operator= (int v) {
 BusOut& BusOut::operator= (BusOut& rhs) {
     write(rhs.read());
     return *this;
+}
+
+DigitalOut& BusOut::operator[] (unsigned int index) {
+    //MBED_ASSERT(index >= MBED_BUS_SIZE);
+    //MBED_ASSERT(_pin[index]);
+    if (index >= 16 || _pin[index] == NULL) {
+        return dout_dummy;
+    }
+    return *_pin[index];
 }
 
 BusOut::operator int() {

--- a/libraries/mbed/common/BusOut.cpp
+++ b/libraries/mbed/common/BusOut.cpp
@@ -79,7 +79,7 @@ BusOut& BusOut::operator= (BusOut& rhs) {
 }
 
 DigitalOut& BusOut::operator[] (int index) {
-    MBED_ASSERT(index < 0 || index >= MBED_BUS_SIZE);
+    MBED_ASSERT(index < 0 || index >= 16);
     MBED_ASSERT(_pin[index]);
     if (index >= 16 || _pin[index] == NULL) {
         return dout_dummy;

--- a/libraries/mbed/common/BusOut.cpp
+++ b/libraries/mbed/common/BusOut.cpp
@@ -22,14 +22,22 @@ DigitalOut BusOut::dout_dummy(NC);
 BusOut::BusOut(PinName p0, PinName p1, PinName p2, PinName p3, PinName p4, PinName p5, PinName p6, PinName p7, PinName p8, PinName p9, PinName p10, PinName p11, PinName p12, PinName p13, PinName p14, PinName p15) {
     PinName pins[16] = {p0, p1, p2, p3, p4, p5, p6, p7, p8, p9, p10, p11, p12, p13, p14, p15};
 
+    _nc_mask = 0;
     for (int i=0; i<16; i++) {
         _pin[i] = (pins[i] != NC) ? new DigitalOut(pins[i]) : 0;
+        if (pins[i] != NC) {
+            _nc_mask |= (1 << i);
+        }
     }
 }
 
 BusOut::BusOut(PinName pins[16]) {
+    _nc_mask = 0;
     for (int i=0; i<16; i++) {
         _pin[i] = (pins[i] != NC) ? new DigitalOut(pins[i]) : 0;
+        if (pins[i] != NC) {
+            _nc_mask |= (1 << i);
+        }
     }
 }
 

--- a/libraries/mbed/hal/gpio_api.h
+++ b/libraries/mbed/hal/gpio_api.h
@@ -30,8 +30,7 @@ uint32_t gpio_set(PinName pin);
 
 /* Checks if gpio object is connected (pin was not initialized with NC)
  * @param pin The pin to be set as GPIO
- * @return Non zero value if port is connected to pin
- *         0 if port is initialized with NC
+ * @return 0 if port is initialized with NC
  **/
 int gpio_is_connected(const gpio_t *obj);
 

--- a/libraries/mbed/hal/gpio_api.h
+++ b/libraries/mbed/hal/gpio_api.h
@@ -28,6 +28,13 @@ extern "C" {
  **/
 uint32_t gpio_set(PinName pin);
 
+/* Checks if gpio object is connected (pin was not initialized with NC)
+ * @param pin The pin to be set as GPIO
+ * @return Non zero value if port is connected to pin
+ *         0 if port is initialized with NC
+ **/
+int gpio_is_connected(const gpio_t *obj);
+
 /* GPIO object */
 void gpio_init(gpio_t *obj, PinName pin);
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D50M/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20D50M/gpio_object.h
@@ -46,6 +46,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/gpio_api.c
@@ -30,7 +30,7 @@ uint32_t gpio_set(PinName pin) {
 }
 
 void gpio_init(gpio_t *obj, PinName pin) {
-    obj->pinName = pin;
+    obj->pin = pin;
     if (pin == (PinName)NC)
         return;
 
@@ -42,14 +42,14 @@ void gpio_init(gpio_t *obj, PinName pin) {
 }
 
 void gpio_mode(gpio_t *obj, PinMode mode) {
-    pin_mode(obj->pinName, mode);
+    pin_mode(obj->pin, mode);
 }
 
 void gpio_dir(gpio_t *obj, PinDirection direction) {
-    MBED_ASSERT(obj->pinName != (PinName)NC);
-    uint32_t port = obj->pinName >> GPIO_PORT_SHIFT;
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
     uint32_t gpio_addrs[] = GPIO_BASE_ADDRS;
-    uint32_t pin_num = obj->pinName & 0xFF;
+    uint32_t pin_num = obj->pin & 0xFF;
 
     switch (direction) {
         case PIN_INPUT:

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/gpio_object.h
@@ -25,25 +25,29 @@ extern "C" {
 #endif
 
 typedef struct {
-    PinName pinName;
+    PinName pin;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value) {
-    MBED_ASSERT(obj->pinName != (PinName)NC);
-    uint32_t port = obj->pinName >> GPIO_PORT_SHIFT;
-    uint32_t pin = obj->pinName & 0xFF;
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
+    uint32_t pin = obj->pin & 0xFF;
     uint32_t gpio_addrs[] = GPIO_BASE_ADDRS;
 
     GPIO_HAL_WritePinOutput(gpio_addrs[port], pin, value);
 }
 
 static inline int gpio_read(gpio_t *obj) {
-    MBED_ASSERT(obj->pinName != (PinName)NC);
-    uint32_t port = obj->pinName >> GPIO_PORT_SHIFT;
-    uint32_t pin = obj->pinName & 0xFF;
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
+    uint32_t pin = obj->pin & 0xFF;
     uint32_t gpio_addrs[] = GPIO_BASE_ADDRS;
 
     return (int)GPIO_HAL_ReadPinInput(gpio_addrs[port], pin);
+}
+
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
 }
 
 #ifdef __cplusplus

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/gpio_object.h
@@ -43,6 +43,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_mask_read) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/gpio_object.h
@@ -46,6 +46,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/gpio_object.h
@@ -45,6 +45,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/gpio_object.h
@@ -47,6 +47,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/gpio_object.h
@@ -41,6 +41,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F051R8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F051R8/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F100RB/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F100RB/gpio_object.h
@@ -63,6 +63,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F303VC/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F303VC/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F334C8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F334C8/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F429ZI/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_F429ZI/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_DISCO_L053C8/gpio_object.h
@@ -62,6 +62,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_MTS_MDOT_F405RG/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_MTS_MDOT_F405RG/gpio_object.h
@@ -62,6 +62,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F030R8/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F072RB/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F091RC/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F091RC/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/tests/mbed/bus_out/main.cpp
+++ b/libraries/tests/mbed/bus_out/main.cpp
@@ -1,0 +1,75 @@
+#include "mbed.h"
+#include "test_env.h"
+
+BusOut bus_out(LED1, LED2, LED3, LED4);
+
+int main()
+{
+    notify_start();
+
+    bool result = false;
+
+    for (;;) {
+        const int mask = bus_out.mask();
+        int led_mask = 0x00;
+        if (LED1 != NC) led_mask |= 0x01;
+        if (LED2 != NC) led_mask |= 0x02;
+        if (LED3 != NC) led_mask |= 0x04;
+        if (LED4 != NC) led_mask |= 0x08;
+
+        printf("MBED: BusIn mask: 0x%X\r\n", mask);
+        printf("MBED: BusIn LED mask: 0x%X\r\n", led_mask);
+
+        // Let's check bus's connected pins mask
+        if (mask != led_mask) {
+            break;
+        }
+
+        // Checking if DigitalOut is correctly set as connected
+        for (int i=0; i<4; i++) {
+            printf("MBED: BusOut.bit[%d] is %s\r\n", i, bus_out[i].is_connected() ? "connected" : "not connected");
+        }
+
+        if (LED1 != NC && bus_out[0].is_connected() == 0) {
+            break;
+        }
+        if (LED1 != NC && bus_out[1].is_connected() == 0) {
+            break;
+        }
+        if (LED1 != NC && bus_out[2].is_connected() == 0) {
+            break;
+        }
+        if (LED1 != NC && bus_out[3].is_connected() == 0) {
+            break;
+        }
+
+        // Write mask all LEDs
+        bus_out.write(mask);    // Set all LED's pins in high state
+        if (bus_out.read() != mask) {
+            break;
+        }
+        // Zero all LEDs and see if mask is correctly cleared on all bits
+        bus_out.write(~mask);
+        if (bus_out.read() != 0x00) {
+            break;
+        }
+
+        result = true;
+        break;
+    }
+
+    printf("MBED: Blinking LEDs...\r\n");
+
+    // Just a quick LED blinking...
+    for (int i=0; i<4; i++) {
+        if (bus_out[i].is_connected()) {
+            bus_out[i] = 1;
+        }
+        wait(0.2);
+        if (bus_out[i].is_connected()) {
+            bus_out[i] = 0;
+        }
+    }
+
+    notify_completion(result);
+}

--- a/libraries/tests/mbed/bus_out/main.cpp
+++ b/libraries/tests/mbed/bus_out/main.cpp
@@ -1,7 +1,10 @@
 #include "mbed.h"
 #include "test_env.h"
 
+namespace {
 BusOut bus_out(LED1, LED2, LED3, LED4);
+PinName led_pins[4] = {LED1, LED2, LED3, LED4}; // Temp, used to map pins in bus_out
+}
 
 int main()
 {
@@ -26,21 +29,18 @@ int main()
         }
 
         // Checking if DigitalOut is correctly set as connected
-        for (int i=0; i<4; i++) {
-            printf("MBED: BusOut.bit[%d] is %s\r\n", i, bus_out[i].is_connected() ? "connected" : "not connected");
+        for (int i=0; i < 4; i++) {
+            printf("MBED: BusOut.bit[%d] is %s\r\n",
+                i,
+                (led_pins[i] != NC && bus_out[i].is_connected())
+                    ? "connected"
+                    : "not connected");
         }
 
-        if (LED1 != NC && bus_out[0].is_connected() == 0) {
-            break;
-        }
-        if (LED1 != NC && bus_out[1].is_connected() == 0) {
-            break;
-        }
-        if (LED1 != NC && bus_out[2].is_connected() == 0) {
-            break;
-        }
-        if (LED1 != NC && bus_out[3].is_connected() == 0) {
-            break;
+        for (int i=0; i < 4; i++) {
+            if (led_pins[i] != NC && bus_out[0].is_connected() == 0) {
+                break;
+            }
         }
 
         // Write mask all LEDs
@@ -58,18 +58,25 @@ int main()
         break;
     }
 
-    printf("MBED: Blinking LEDs...\r\n");
+    printf("MBED: Blinking LEDs: \r\n");
 
     // Just a quick LED blinking...
     for (int i=0; i<4; i++) {
-        if (bus_out[i].is_connected()) {
+        if (led_pins[i] != NC && bus_out[i].is_connected()) {
             bus_out[i] = 1;
+            printf("%c", 'A' + i);
+        } else {
+            printf(".");
         }
         wait(0.2);
-        if (bus_out[i].is_connected()) {
+        if (led_pins[i] != NC && bus_out[i].is_connected()) {
             bus_out[i] = 0;
+            printf("%c", 'a' + i);
+        } else {
+            printf(".");
         }
     }
+    printf("\r\n");
 
     notify_completion(result);
 }

--- a/libraries/tests/utest/bus/busout_ut.cpp
+++ b/libraries/tests/utest/bus/busout_ut.cpp
@@ -1,0 +1,87 @@
+#include "TestHarness.h"
+#include <utility>
+#include "mbed.h"
+
+TEST_GROUP(BusOut_mask)
+{
+};
+
+TEST(BusOut_mask, led_1_2_3)
+{
+    BusOut bus_data(LED1, LED2, LED3);
+    CHECK_EQUAL(0x07, bus_data.mask());
+}
+
+TEST(BusOut_mask, led_nc_nc_nc_nc)
+{
+    BusOut bus_data(NC, NC, NC, NC);
+    CHECK_EQUAL(0x00, bus_data.mask());
+}
+
+TEST(BusOut_mask, led_1_2_3_nc_nc)
+{
+    BusOut bus_data(LED1, LED2, LED3, NC, NC);
+    CHECK_EQUAL(0x07, bus_data.mask());
+}
+
+TEST(BusOut_mask, led_1_nc_2_nc_nc_3)
+{
+    BusOut bus_data(LED1, NC, LED2, NC, NC, LED3);
+    CHECK_EQUAL(0x25, bus_data.mask());
+}
+
+///////////////////////////////////////////////////////////////////////////////
+
+TEST_GROUP(BusOut_dummy)
+{
+};
+
+TEST(BusOut_dummy, dummy)
+{
+}
+
+#ifdef MBED_OPERATORS
+TEST_GROUP(BusOut_digitalout_write)
+{
+};
+
+TEST(BusOut_digitalout_write, led_nc)
+{
+    BusOut bus_data(NC);
+    CHECK_EQUAL(false, bus_data[0].is_connected())
+}
+
+
+TEST(BusOut_digitalout_write, led_1_2_3)
+{
+    BusOut bus_data(LED1, LED2, LED3);
+    bus_data[0].write(1);
+    bus_data[1].write(1);
+    bus_data[2].write(1);
+    CHECK(bus_data[0].read());
+    CHECK(bus_data[1].read());
+    CHECK(bus_data[2].read());
+}
+
+TEST(BusOut_digitalout_write, led_1_2_3_nc_nc)
+{
+    BusOut bus_data(LED1, LED2, LED3, NC, NC);
+    bus_data[0].write(0);
+    bus_data[1].write(0);
+    bus_data[2].write(0);
+    CHECK(bus_data[0].read() == 0);
+    CHECK(bus_data[1].read() == 0);
+    CHECK(bus_data[2].read() == 0);
+}
+
+TEST(BusOut_digitalout_write, led_1_nc_2_nc_nc_3)
+{
+    BusOut bus_data(LED1, NC, LED2, NC, NC, LED3);
+    bus_data[0].write(1);
+    bus_data[2].write(0);
+    bus_data[5].write(0);
+    CHECK(bus_data[0].read());
+    CHECK(bus_data[2].read() == 0);
+    CHECK(bus_data[5].read() == 0);
+}
+#endif

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -262,6 +262,14 @@ TESTS = [
         "duration": 15,
     },
 
+    {
+        "id": "MBED_BUSOUT", "description": "BusOut",
+        "source_dir": join(TEST_DIR, "mbed", "bus_out"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True,
+        "duration": 15,
+    },
+
     # Size benchmarks
     {
         "id": "BENCHMARK_1", "description": "Size (c environment)",
@@ -527,7 +535,7 @@ TESTS = [
         "automated": True,
         "host_test": "wait_us_auto"
     },
-    
+
 
     # CMSIS RTOS tests
     {
@@ -896,6 +904,12 @@ TESTS = [
     {
         "id": "UT_3", "description": "General tests",
         "source_dir": join(TEST_DIR, "utest", "general"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB, CPPUTEST_LIBRARY],
+        "automated": False,
+    },
+    {
+        "id": "UT_BUSIO", "description": "BusIn BusOut",
+        "source_dir": join(TEST_DIR, "utest", "bus"),
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB, CPPUTEST_LIBRARY],
         "automated": False,
     },


### PR DESCRIPTION
## Description
This pull requests introduces simple improvements for GPIO HAL functions in mbed SDK.
Improvements introduce:
* new GPIO function: **gpio_is_connected(const gpio_t *obj)** which can determine if gpio pin is set as NC or connected to H/W pin,
* **DigitalIn**, **DigitalOut**, **DigitalInOut** interfaces received is_connected() method,
* **BusIn**, **BusOut**, **BusInOut** interfaces gained new operator[n] which works as 'random access iterator to n'th pin in Bus component.
* **BusIn**, **BusOut**, **BusInOut** interfaces gained new function mask() which returns binary mask of connected pins (easy way to filter in run-time Bus' pins set to **NC**).
* Simple tests added to check if **BusOut::operator[unsigned int]** is working and if **DigitalOut::is_connected()**** is also correctly returning pin state.

## Rationale
Currently if you want to set proper bit(s) in Bus component you have to use write() method which will set all pins. In case you want to set/clear single pin you need to perform some bit operations and set/clear pin you want.

Currently:
```c++
BusOut bus(LED1, LED2, LED3);

// Old way: set LED2
int current_mask = bus.read();
current_mask |= 0x02;
bus.write(current_mask);
```
With this pull request:
```c++
BusOut bus(LED1, LED2, LED3);
bus[1] = 1;    // New API, LED1 = 1

// or safer, if you want to check if pin is not in NC state:

if (bus[1].is_connected()) { // We want to make sure bus.pin[1] is not NC pin (we avoid assertion)
    bus[1] = 1;    // LED1 = 1
}
```
### DigitalOut pin setup check
You can check if DigitalIn, DigitalOut and DigitalInOut component was initialized with NC (not connected) pin name value:
```c++
DigitalOut dout(NC);
bool is_conn = dout.is_connected();    // is_conn == false
```
```c++
DigitalOut dout(LED2);
bool is_conn = dout.is_connected();    // is_conn == true
```
### Bus pin masking
You can get bus pin mask to perform bit-wise operations and see e.g. if groups of pins are connected or not:
```c++
BusOut bus(LED1, NC, LED2, NC, LED3);
const int mask = bus.mask();    // mask = [ 1, 0, 1, 0, 1, 0, 0, ....]

// We can check which pin in bus is actually connected:
if (mask & 0x04) {
    // bus[2] is connected
}
```
### LED blinky example
```c++
BusOut bus_out(LED1, LED2, LED3, LED4);
// Just a quick LED blinking...
for (int i=0; i<4; i++) {
    if (bus_out[i].is_connected()) {
        bus_out[i] = 1;
    }
    wait(0.2);
    if (bus_out[i].is_connected()) {
        bus_out[i] = 0;
    }
}
```

### Testing
```
singletest.py -i test_spec.json -M muts_all.json -n MBED_BUSOUT -V
```
Output for supporting test:
```
Building library CMSIS (K22F, GCC_ARM)
Building library MBED (K22F, GCC_ARM)
Building project BUS_OUT (K22F, GCC_ARM)
Executing 'python host_test.py -d G:\ -f "C:\Work\mbed-przemek\build\test\K22F\GCC_ARM\MBED_BUSOUT\bus_out.bin" -p COM93 -t 15 -C 4 -m K22F'
Test::Output::Start
MBED: Instrumentation: "COM93" and disk: "G:\"
HOST: Copy image onto target...
HOST: Initialize serial port...
HOST: Reset target...
{start}}
MBED: BusIn mask: 0xF
MBED: BusIn LED mask: 0xF
MBED: BusOut.bit[0] is connected
MBED: BusOut.bit[1] is connected
MBED: BusOut.bit[2] is connected
MBED: BusOut.bit[3] is connected
MBED: Blinking LEDs...
{{success}}
{{end}}
Test::Output::Finish
TargetTest::K22F::GCC_ARM::MBED_BUSOUT::BusOut [OK] in 7.29 of 15 sec
Test summary:
+--------+--------+-----------+-------------+------------------+--------------------+---------------+-------+
| Result | Target | Toolchain | Test ID     | Test Description | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+--------+-----------+-------------+------------------+--------------------+---------------+-------+
| OK     | K22F   | GCC_ARM   | MBED_BUSOUT | BusOut           |        7.29        |       15      |  1/1  |
+--------+--------+-----------+-------------+------------------+--------------------+---------------+-------+
Result: 1 OK

Completed in 7.82 sec
```