### PR TITLE
Fix stack aligment.

### DIFF
--- a/libraries/rtos/rtos/Thread.cpp
+++ b/libraries/rtos/rtos/Thread.cpp
@@ -33,10 +33,10 @@ Thread::Thread(void (*task)(void const *argument), void *argument,
     _thread_def.stacksize = stack_size;
 #ifndef __MBED_CMSIS_RTOS_CA9
     if (stack_pointer != NULL) {
-        _thread_def.stack_pointer = stack_pointer;
+        _thread_def.stack_pointer = (uint32_t*)stack_pointer;
         _dynamic_stack = false;
     } else {
-        _thread_def.stack_pointer = new unsigned char[stack_size];
+        _thread_def.stack_pointer = new uint32_t[stack_size/sizeof(uint32_t)];
         if (_thread_def.stack_pointer == NULL)
             error("Error allocating the stack memory\n");
         _dynamic_stack = true;

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -243,7 +243,7 @@ typedef struct os_thread_def  {
   os_pthread               pthread;      ///< start address of thread function
   osPriority             tpriority;      ///< initial thread priority
   uint32_t               stacksize;      ///< stack size requirements in bytes
-  unsigned char         *stack_pointer;  ///< pointer to the stack memory block
+  uint32_t               *stack_pointer;  ///< pointer to the stack memory block
   struct OS_TCB          tcb;
 } osThreadDef_t;
 
@@ -337,7 +337,7 @@ int32_t osKernelRunning(void);
 extern osThreadDef_t os_thread_def_##name
 #else                            // define the object
 #define osThreadDef(name, priority, stacksz)  \
-unsigned char os_thread_def_stack_##name [stacksz]; \
+uint32_t os_thread_def_stack_##name [stacksz / sizeof(uint32_t)]; \
 osThreadDef_t os_thread_def_##name = \
 { (name), (priority), (stacksz), (os_thread_def_stack_##name)}
 #endif


### PR DESCRIPTION
Stack should be 8 byte aligned on ARM.
Fix the automatic correction of the alignment in rt_init_stack,
and make sure that all stacks are aligned by the compiler.