### PR TITLE
workspace_tools/toolchains/gcc.py: Use 'cortex-m0plus' support for ARM Cortex M0+

### DIFF
--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -34,7 +34,7 @@ class GCC(mbedToolchain):
         mbedToolchain.__init__(self, target, options, notify, macros, silent)
 
         if target.core == "Cortex-M0+":
-            cpu = "cortex-m0"
+            cpu = "cortex-m0plus"
         elif target.core == "Cortex-M4F":
             cpu = "cortex-m4"
         else:


### PR DESCRIPTION
This support is supported by:
- gcc-arm-none-eabi-4_7-2013q1
- gcc-arm-none-eabi-4_9-2014q4