### PR TITLE
RTX: Main thread should not write MAGIC_WORD to stack

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -547,18 +547,19 @@ osThreadId svcThreadCreate (osThreadDef_t *thread_def, void *argument) {
   U8 priority = thread_def->tpriority - osPriorityIdle + 1;
   P_TCB task_context = &thread_def->tcb;
 
-  /* If "size != 0" use a private user provided stack. */
+  /* Utilize the user provided stack. */
   task_context->stack      = (U32*)thread_def->stack_pointer;
   task_context->priv_stack = thread_def->stacksize;
-  /* Pass parameter 'argv' to 'rt_init_context' */
-  task_context->msg = argument;
-  /* For 'size == 0' system allocates the user stack from the memory pool. */
-  rt_init_context (task_context, priority, (FUNCP)thread_def->pthread);
-
   /* Find a free entry in 'os_active_TCB' table. */
   OS_TID tsk = rt_get_TID ();
   os_active_TCB[tsk-1] = task_context;
   task_context->task_id = tsk;
+  /* Pass parameter 'argv' to 'rt_init_context' */
+  task_context->msg = argument;
+  /* Initialize thread context structure, including the thread's stack. */
+  rt_init_context (task_context, priority, (FUNCP)thread_def->pthread);
+
+  /* Dispatch this task to the scheduler for execution. */
   DBG_TASK_NOTIFY(task_context, __TRUE);
   rt_dispatch (task_context);
 


### PR DESCRIPTION
This is a fix for issue #285.  This fix is similar to that proposed by
@oresths in the original issue.

There is code in rt_init_stack() which compares the task_id against the
value of 1 before writing MAGIC_WORD to the bottom of the stack.  This
is supposed to stop the write from occurring for the main thread but
svcThreadCreate() doesn't initialize the P_TCB's task_id field until
after rt_init_stack() is executed.  If any dynamic memory allocation
has occurred before the main thread is started (from the standard C
startup code) then this write could overwrite data in that allocation.

This change:
* moves the task_id initialization in svcThreadCreate() to happen
  before the call to rt_init_context() is made.
* cleans up some comments in svcThreadCreate() which appear to
  reference older versions of the code which would automatically
  allocate stack memory if size == 0.
* still keeps the call to rt_dispatch() occurring after the call to
  rt_init_context() so that the task is not dispatched to the
  scheduler until the task fields have been populated.

I stepped through the rt_init_stack() code on my mbedLPC1768 after this
change was made to make sure that the write of MAGIC_WORD is now
skipped.
```
(gdb) break HAL_CM.c:95
Breakpoint 1 at 0x482c: file ../../external/mbed/libraries/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c, line 95.
(gdb) c
Continuing.
Note: automatically using hardware breakpoints for read-only addresses.

Breakpoint 1, rt_init_stack (p_TCB=0x10000774 <os_idle_TCB>, task_body=0x4899 <os_idle_demon>)
    at ../../external/mbed/libraries/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c:95
95	  if (p_TCB->task_id != 0x01)
(gdb) p *p_TCB
$1 = {
  cb_type = 0 '\000',
  state = 1 '\001',
  prio = 0 '\000',
  task_id = 255 '\377',
  p_lnk = 0x0 <_reclaim_reent>,
  p_rlnk = 0x0 <_reclaim_reent>,
  p_dlnk = 0x0 <_reclaim_reent>,
  p_blnk = 0x0 <_reclaim_reent>,
  delta_time = 0,
  interval_time = 0,
  events = 0,
  waits = 0,
  msg = 0x0 <_reclaim_reent>,
  stack_frame = 0 '\000',
  reserved = 0 '\000',
  priv_stack = 128,
  tsk_stack = 268437480,
  stack = 0x100007a8 <idle_task_stack>,
  ptask = 0x4899 <os_idle_demon>
}
(gdb) c
Continuing.

Breakpoint 1, rt_init_stack (p_TCB=0x10000120 <os_thread_def_main+16>, task_body=0x620d <__wrap_main()>)
    at ../../external/mbed/libraries/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c:95
95	  if (p_TCB->task_id != 0x01)
(gdb) p *p_TCB
$2 = {
  cb_type = 0 '\000',
  state = 1 '\001',
  prio = 4 '\004',
  task_id = 1 '\001',
  p_lnk = 0x0 <_reclaim_reent>,
  p_rlnk = 0x0 <_reclaim_reent>,
  p_dlnk = 0x0 <_reclaim_reent>,
  p_blnk = 0x0 <_reclaim_reent>,
  delta_time = 0,
  interval_time = 0,
  events = 0,
  waits = 0,
  msg = 0x0 <_reclaim_reent>,
  stack_frame = 0 '\000',
  reserved = 0 '\000',
  priv_stack = 26968,
  tsk_stack = 268467136,
  stack = 0x100012a8,
  ptask = 0x620d <__wrap_main()>
}
(gdb) n
97	}
```
When the p_TCB for ptask==__wrap_main() is encountered, the task_id
now has a value of 1 and the write of MAGIC_WORD on line 96 is
skipped.