### PR TITLE
switching timestamp_t back to 32-bits.

### DIFF
--- a/libraries/mbed/common/us_ticker_api.c
+++ b/libraries/mbed/common/us_ticker_api.c
@@ -70,7 +70,7 @@ void us_ticker_insert_event(ticker_event_t *obj, timestamp_t timestamp, uint32_t
     ticker_event_t *prev = NULL, *p = head;
     while (p != NULL) {
         /* check if we come before p */
-        if ((int64_t)(timestamp - p->timestamp) < 0) {
+        if ((signedTimestamp_t)(timestamp - p->timestamp) < 0) {
             break;
         }
         /* go to the next element */

--- a/libraries/mbed/hal/us_ticker_api.h
+++ b/libraries/mbed/hal/us_ticker_api.h
@@ -22,7 +22,7 @@
 extern "C" {
 #endif
 
-typedef uint64_t timestamp_t;
+typedef uint32_t timestamp_t;
 
 uint32_t us_ticker_read(void);
 

--- a/libraries/mbed/hal/us_ticker_api.h
+++ b/libraries/mbed/hal/us_ticker_api.h
@@ -23,6 +23,7 @@ extern "C" {
 #endif
 
 typedef uint32_t timestamp_t;
+typedef int32_t  signedTimestamp_t; /* The signed version of the above declaration. */
 
 uint32_t us_ticker_read(void);
 

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
@@ -94,13 +94,17 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
 void us_ticker_disable_interrupt(void)
 {
     if (us_ticker_appTimerRunning) {
-        app_timer_stop(us_ticker_appTimerID);
+        if (app_timer_stop(us_ticker_appTimerID) == NRF_SUCCESS) {
+            us_ticker_appTimerRunning = false;
+        }
     }
 }
 
 void us_ticker_clear_interrupt(void)
 {
     if (us_ticker_appTimerRunning) {
-        app_timer_stop(us_ticker_appTimerID);
+        if (app_timer_stop(us_ticker_appTimerID) == NRF_SUCCESS) {
+            us_ticker_appTimerRunning = false;
+        }
     }
 }

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
@@ -40,7 +40,7 @@ uint32_t us_ticker_read()
         us_ticker_init();
     }
 
-    timestamp_t value;
+    uint64_t value;
     app_timer_cnt_get(&value); /* This returns the RTC counter (which is fed by the 32khz crystal clock source) */
     return ((value * 1000000) / (uint32_t)APP_TIMER_CLOCK_FREQ); /* Return a pseudo microsecond counter value.
                                                                   * This is only as precise as the 32khz low-freq
@@ -72,7 +72,7 @@ void us_ticker_set_interrupt(timestamp_t timestamp)
         return;
     }
 
-    timestamp_t currentCounter64;
+    uint64_t currentCounter64;
     app_timer_cnt_get(&currentCounter64);
     uint32_t currentCounter = currentCounter64 & MAX_RTC_COUNTER_VAL;
     uint32_t targetCounter = ((uint32_t)((timestamp * (uint64_t)APP_TIMER_CLOCK_FREQ) / 1000000) + 1) & MAX_RTC_COUNTER_VAL;

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
@@ -18,6 +18,7 @@
 #include "cmsis.h"
 #include "PeripheralNames.h"
 #include "app_timer.h"
+#include "projectconfig.h"
 
 static bool           us_ticker_inited          = false;
 static volatile bool  us_ticker_appTimerRunning = false;
@@ -29,7 +30,7 @@ void us_ticker_init(void)
         return;
     }
 
-    APP_TIMER_INIT(0 /*CFG_TIMER_PRESCALER*/ , 1 /*CFG_TIMER_MAX_INSTANCE*/, 1 /*CFG_TIMER_OPERATION_QUEUE_SIZE*/, false /*CFG_SCHEDULER_ENABLE*/);
+    APP_TIMER_INIT(CFG_TIMER_PRESCALER, CFG_TIMER_MAX_INSTANCE, CFG_TIMER_OPERATION_QUEUE_SIZE, CFG_SCHEDULER_ENABLE);
 
     us_ticker_inited = true;
 }


### PR DESCRIPTION
The underlying us_tickers used for comparison are still 32-bits; keeping a 64-bit timestamp isn't going to be useful.

fixes #838