### PR TITLE
Add readme.html to every exported project

### DIFF
--- a/workspace_tools/export/__init__.py
+++ b/workspace_tools/export/__init__.py
@@ -84,6 +84,8 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
 
     zip_path = None
     if report['success']:
+        # add readme file to every offline export.
+        open(tempdir+"\\README.html",'w').write('<meta http-equiv="refresh" content="0; url=http://developer.mbed.org/handbook/ExportToOfflineToolchain#%s#%s"/>'% (target,ide))
         zip_path = zip_working_directory_and_clean_up(tempdir, destination, project_name, clean)
 
     return zip_path, report


### PR DESCRIPTION
#Problem 
Some offline exporters are having issues, (Think BLE and the need for a 3rd party flash algorithm with Keil V4), currently there is no good way to help people out

#Solution 
Add a readme.html to every offline exporter that redirects people to a page where we keep a list of the known errata for each platform and compiler. Part of the web address is the platform and compiler so they will automatically jump down the page to where their platform and compiler are. 

