### PR TITLE
[LPC1114] remove reset pin name to protect people. [LPC824] I2C pin names were crossed

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11XX/PinNames.h
@@ -78,7 +78,7 @@ typedef enum {
     P3_5  = (3 << PORT_SHIFT) | (5  << PIN_SHIFT) | 0x48,
 
     // mbed DIP Pin Names (CQ board)
-    p4  = P0_0,
+//    p4  = P0_0,
     p5  = P0_9,
     p6  = P0_8,
     p7  = P0_6,
@@ -114,7 +114,7 @@ typedef enum {
     USBRX = P1_6,
 
     // mbed DIP Pin Names (LPCXpresso LPC1114)
-    xp4  = P0_0,
+//    xp4  = P0_0,
     xp5  = P0_9,
     xp6  = P0_8,
     xp7  = P2_11,
@@ -173,7 +173,7 @@ typedef enum {
 	dp16 = P1_7,
 	dp17 = P1_8,
 	dp18 = P1_9,
-	dp23 = P0_0,
+//	dp23 = P0_0,
 	dp24 = P0_1,
 	dp25 = P0_2,
 	dp26 = P0_3,
@@ -194,7 +194,7 @@ typedef enum {
 	dip16 = P1_7,
 	dip17 = P1_8,
 	dip18 = P1_9,
-	dip23 = P0_0,
+//	dip23 = P0_0,
 	dip24 = P0_1,
 	dip25 = P0_2,
 	dip26 = P0_3,

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_LPC824/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_LPC824/PeripheralNames.h
@@ -30,7 +30,7 @@ extern "C" {
 #define MBED_UART0        P0_7, P0_18
 #define MBED_UARTUSB      USBTX, USBRX
 
-#define MBED_I2C0         P0_10, P0_11
+#define MBED_I2C0         P0_11, P0_10
 
 typedef enum {
     ADC_0 = 0,

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_LPC824/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_LPC824/PinNames.h
@@ -102,10 +102,10 @@ typedef enum {
     USBRX = P0_18,
     
     // I2C pins
-    SDA = P0_10,
-    SCL = P0_11,
-    I2C_SDA = P0_10,
-    I2C_SCL = P0_11,
+    SCL = P0_10,
+    SDA = P0_11,
+    I2C_SCL = P0_10,
+    I2C_SDA = P0_11,
     
     // Not connected
     NC = (int)0xFFFFFFFF,

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PeripheralNames.h
@@ -30,7 +30,7 @@ extern "C" {
 #define MBED_UART0        P0_7, P0_18
 #define MBED_UARTUSB      USBTX, USBRX
 
-#define MBED_I2C0         P0_10, P0_11
+#define MBED_I2C0         P0_11, P0_10
 
 typedef enum {
     ADC_0 = 0,

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PinNames.h
@@ -102,10 +102,10 @@ typedef enum {
     USBRX = P0_18,
     
     // I2C pins
-    SDA = P0_10,
-    SCL = P0_11,
-    I2C_SDA = P0_10,
-    I2C_SCL = P0_11,
+    SCL = P0_10,
+    SDA = P0_11,
+    I2C_SCL = P0_10,
+    I2C_SDA = P0_11,
     
     // Not connected
     NC = (int)0xFFFFFFFF,


### PR DESCRIPTION
On LPC1114 platforms, if user set P0_0 as DigitalOut and set it to low, LPC1114 will be in reset condition. To avoid this situation, p4, xp4 and dp23 was removed from PinNames.h.

On LPC824 platforms, I2C pin names were crossed.