### PR TITLE
Fixes to get LPC4330 GCC based builds to run

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/system_LPC43xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC43XX/system_LPC43xx.c
@@ -150,11 +150,9 @@ void SystemInit(void)
     SCB->VTOR = (unsigned int) &g_pfnVectors;
 #endif
 
-#if !defined(TOOLCHAIN_GCC)
 #if defined(__FPU_PRESENT) && __FPU_PRESENT == 1
     /* Initialize floating point */
     fpuInit();
-#endif
 #endif
 
     SystemSetupPins(pre_clock_mux, COUNT_OF(pre_clock_mux)); /* Configure pins */
@@ -367,7 +365,7 @@ void fpuInit(void)
 
 static void WaitUs(uint32_t us)
 {
-    uint32_t  cyc = us * CPU_NANOSEC(1000) / 4;
+    volatile uint32_t  cyc = us * CPU_NANOSEC(1000) / 4;
     while (cyc--)
         ;
 }


### PR DESCRIPTION
I was getting Hard Faults in even the simplest of samples before I made
these fixes.

* WaitUs() did nothing on optimized builds.  I added the volatile
  qualifier to the cyc variable to make sure that the delay loop
  doesn't get optimized out.
* I removed the #ifdef which skipped the fpuInit() call when building
  with GCC.