### PR TITLE
LPC11U37H_401 target support added to build_travis.py and build_release.py

### DIFF
--- a/workspace_tools/build_release.py
+++ b/workspace_tools/build_release.py
@@ -44,6 +44,7 @@ OFFICIAL_MBED_LIBRARY_BUILD = (
     ('XADOW_M0',     ('ARM', 'uARM','GCC_ARM','GCC_CR')),
     ('ARCH_GPRS',    ('ARM', 'uARM', 'GCC_ARM', 'GCC_CR', 'IAR')),
     ('LPC4337',      ('ARM',)),
+    ('LPC11U37H_401', ('ARM', 'uARM','GCC_ARM','GCC_CR', 'IAR')),
 
     ('KL05Z',        ('ARM', 'uARM', 'GCC_ARM', 'IAR')),
     ('KL25Z',        ('ARM', 'GCC_ARM', 'IAR')),

--- a/workspace_tools/build_travis.py
+++ b/workspace_tools/build_travis.py
@@ -57,6 +57,7 @@ build_list = (
     { "target": "UBLOX_C027",    "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
     { "target": "LPC11U35_501",  "toolchains": "GCC_ARM", "libs": ["dsp", "fat"] },
     { "target": "LPC11U68",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
+    { "target": "LPC11U37H_401",  "toolchains": "GCC_ARM", "libs": ["dsp", "fat"] },
 
     { "target": "KL05Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
     { "target": "KL25Z",         "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "usb", "fat"] },


### PR DESCRIPTION
LPC11U37H_401 target support added to build_travis.py and build_release.py