### PR TITLE
Correct warning when assigning HEAP_START to stack_pointer

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -304,10 +304,10 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #endif
 
 #ifdef __CC_ARM
-extern unsigned char     Image$$RW_IRAM1$$ZI$$Limit[];
+extern uint32_t          Image$$RW_IRAM1$$ZI$$Limit[];
 #define HEAP_START      (Image$$RW_IRAM1$$ZI$$Limit)
 #elif defined(__GNUC__)
-extern unsigned char     __end__[];
+extern uint32_t          __end__[];
 #define HEAP_START      (__end__)
 #elif defined(__ICCARM__)
 #pragma section="HEAP"


### PR DESCRIPTION
This fixes issue #856 reported by @neilt6.

I tested on mbedLPC1768 and mbedLPC11U24 using the GCC_ARM toolchain.