### PR TITLE
On-Board SD Card support for LPC11U37H_401 board

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U37H_401/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_LPC11U37H_401/PinNames.h
@@ -139,6 +139,12 @@ typedef enum {
     SDA= P0_5, // same port as A4
     SCL= P0_4, // same port as A5
     
+    //SD Card pins
+    SDMOSI = P0_9,
+    SDMISO = P0_8,
+    SDSCLK = P1_29,
+    SDSSEL = P1_12,
+    
     // Not connected
     NC = (int)0xFFFFFFFF,
 } PinName;

--- a/libraries/tests/mbed/dir_sd/main.cpp
+++ b/libraries/tests/mbed/dir_sd/main.cpp
@@ -79,6 +79,8 @@ int main()
       defined(TARGET_NUCLEO_L053R8) || \
       defined(TARGET_NUCLEO_L152RE)
     SDFileSystem sd(D11, D12, D13, D10, "sd");
+#elif defined(TARGET_LPC11U37H_401)
+    SDFileSystem sd(SDMOSI, SDMISO, SDSCLK, SDSSEL, "sd");
 #else
     SDFileSystem sd(p11, p12, p13, p14, "sd");
 #endif

--- a/libraries/tests/mbed/sd/main.cpp
+++ b/libraries/tests/mbed/sd/main.cpp
@@ -49,6 +49,9 @@ SDFileSystem sd(D11, D12, D13, D10, "sd");
 #elif defined(TARGET_RZ_A1H)
 SDFileSystem sd(P8_5, P8_6, P8_3, P8_4, "sd");
 
+#elif defined(TARGET_LPC11U37H_401)
+SDFileSystem sd(SDMOSI, SDMISO, SDSCLK, SDSSEL, "sd");
+    
 #else
 SDFileSystem sd(p11, p12, p13, p14, "sd");
 #endif

--- a/libraries/tests/mbed/sd_perf_fatfs/main.cpp
+++ b/libraries/tests/mbed/sd_perf_fatfs/main.cpp
@@ -48,6 +48,9 @@ SDFileSystem sd(D11, D12, D13, D10, "sd");
 #elif defined(TARGET_LPC1549)
 SDFileSystem sd(D11, D12, D13, D10, "sd");
 
+#elif defined(TARGET_LPC11U37H_401)
+SDFileSystem sd(SDMOSI, SDMISO, SDSCLK, SDSSEL, "sd");
+
 #else
 SDFileSystem sd(p11, p12, p13, p14, "sd");
 #endif

--- a/libraries/tests/mbed/sd_perf_fhandle/main.cpp
+++ b/libraries/tests/mbed/sd_perf_fhandle/main.cpp
@@ -48,6 +48,9 @@ SDFileSystem sd(D11, D12, D13, D10, "sd");
 #elif defined(TARGET_LPC1549)
 SDFileSystem sd(D11, D12, D13, D10, "sd");
 
+#elif defined(TARGET_LPC11U37H_401)
+SDFileSystem sd(SDMOSI, SDMISO, SDSCLK, SDSSEL, "sd");
+    
 #else
 SDFileSystem sd(p11, p12, p13, p14, "sd");
 #endif

--- a/libraries/tests/mbed/sd_perf_stdio/main.cpp
+++ b/libraries/tests/mbed/sd_perf_stdio/main.cpp
@@ -48,6 +48,9 @@ SDFileSystem sd(D11, D12, D13, D10, "sd");
 #elif defined(TARGET_LPC1549)
 SDFileSystem sd(D11, D12, D13, D10, "sd");
 
+#elif defined(TARGET_LPC11U37H_401)
+SDFileSystem sd(SDMOSI, SDMISO, SDSCLK, SDSSEL, "sd");
+    
 #else
 SDFileSystem sd(p11, p12, p13, p14, "sd");
 #endif


### PR DESCRIPTION
On-Board SD Card support for LPC11U37H_401 board, test cases related to SD Card updated too.