### PR TITLE
HAL - NRF51822 - us ticker fix for the #839

### DIFF
--- a/libraries/mbed/common/us_ticker_api.c
+++ b/libraries/mbed/common/us_ticker_api.c
@@ -70,7 +70,7 @@ void us_ticker_insert_event(ticker_event_t *obj, timestamp_t timestamp, uint32_t
     ticker_event_t *prev = NULL, *p = head;
     while (p != NULL) {
         /* check if we come before p */
-        if ((signedTimestamp_t)(timestamp - p->timestamp) < 0) {
+        if ((int)(timestamp - p->timestamp) < 0) {
             break;
         }
         /* go to the next element */

--- a/libraries/mbed/hal/us_ticker_api.h
+++ b/libraries/mbed/hal/us_ticker_api.h
@@ -23,7 +23,6 @@ extern "C" {
 #endif
 
 typedef uint32_t timestamp_t;
-typedef int32_t  signedTimestamp_t; /* The signed version of the above declaration. */
 
 uint32_t us_ticker_read(void);
 

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/us_ticker.c
@@ -18,7 +18,6 @@
 #include "cmsis.h"
 #include "PeripheralNames.h"
 #include "app_timer.h"
-#include "projectconfig.h"
 
 static bool           us_ticker_inited          = false;
 static volatile bool  us_ticker_appTimerRunning = false;
@@ -30,8 +29,7 @@ void us_ticker_init(void)
         return;
     }
 
-    APP_TIMER_INIT(CFG_TIMER_PRESCALER, CFG_TIMER_MAX_INSTANCE, CFG_TIMER_OPERATION_QUEUE_SIZE, CFG_SCHEDULER_ENABLE);
-
+APP_TIMER_INIT(0 /*CFG_TIMER_PRESCALER*/ , 1 /*CFG_TIMER_MAX_INSTANCE*/, 1 /*CFG_TIMER_OPERATION_QUEUE_SIZE*/, false /*CFG_SCHEDULER_ENABLE*/);
     us_ticker_inited = true;
 }
 


### PR DESCRIPTION
There was a project header file which does not exist in mbed SDK, neither
some defines used from it most probably. This commit reverts those parts.

@rgrover If APP_TIMER_INIT should be initialized differently, send a new PR. I used values which were there before the 839 PR