### PR TITLE
Fix and enable the PLL for the LPC812

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/system_LPC8xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/system_LPC8xx.c
@@ -102,21 +102,26 @@
 */
 #define CLOCK_SETUP     1	// 1 == IRC: 2 == System Oscillator 12Mhz Xtal:
 
+//WH Fixed to use PLL
 #if (CLOCK_SETUP == 1)
+//use PLL for IRC
 	#define SYSOSCCTRL_Val        0x00000000              // Reset: 0x000
 	#define WDTOSCCTRL_Val        0x00000000              // Reset: 0x000
-	#define SYSPLLCTRL_Val        0x00000041              // Reset: 0x000
-	#define SYSPLLCLKSEL_Val      0x00000000              // Reset: 0x000
-	#define MAINCLKSEL_Val        0x00000000              // Reset: 0x000
-	#define SYSAHBCLKDIV_Val      0x00000001              // Reset: 0x001
+	#define SYSPLLCTRL_Val        0x00000004              // Reset: 0x000  MSEL=4 => M=5; PSEL=0 => 2P=2; PLLCLKOUT = (12x5) = 60MHz
+	#define SYSPLLCLKSEL_Val      0x00000000              // Reset: 0x000  Select IRC
+	#define MAINCLKSEL_Val        0x00000003              // Reset: 0x000  MainClock = PLLCLKOUT
+	#define SYSAHBCLKDIV_Val      0x00000002              // Reset: 0x001  DIV=2 => SYSTEMCORECLK = 60 / 2 = 30MHz
+
 #elif (CLOCK_SETUP == 2)         
+//use PLL for XTAL
 	#define SYSOSCCTRL_Val        0x00000000              // Reset: 0x000
 	#define WDTOSCCTRL_Val        0x00000000              // Reset: 0x000
-	#define SYSPLLCTRL_Val        0x00000040              // Reset: 0x000
-	#define SYSPLLCLKSEL_Val      0x00000001              // Reset: 0x000
-	#define MAINCLKSEL_Val        0x00000003              // Reset: 0x000
-	#define SYSAHBCLKDIV_Val      0x00000001              // Reset: 0x001
+	#define SYSPLLCTRL_Val        0x00000004              // Reset: 0x000 MSEL=4 => M=5; PSEL=0 => 2P=2; PLLCLKOUT = (12x5) = 60MHz
+	#define SYSPLLCLKSEL_Val      0x00000001              // Reset: 0x000 Select XTAL
+	#define MAINCLKSEL_Val        0x00000003              // Reset: 0x000 MainClock = PLLCLKOUT
+	#define SYSAHBCLKDIV_Val      0x00000002              // Reset: 0x001 DIV=2 => SYSTEMCORECLK = 60 / 2 = 30MHz
 #endif
+//WH
 
 /*
 //-------- <<< end of configuration section >>> ------------------------------
@@ -245,9 +250,11 @@
 /*----------------------------------------------------------------------------
   Clock Variable definitions
  *----------------------------------------------------------------------------*/
+//WH Added MainClock
+uint32_t MainClock = __MAIN_CLOCK;         /*!< Main Clock Frequency */
 uint32_t SystemCoreClock = __SYSTEM_CLOCK;/*!< System Clock Frequency (Core Clock)*/
 
-
+//WH Replaced SystemCoreClock with MainClock
 /*----------------------------------------------------------------------------
   Clock functions
  *----------------------------------------------------------------------------*/
@@ -278,48 +285,48 @@ void SystemCoreClockUpdate (void)            /* Get Core Clock Frequency      */
 
   switch (LPC_SYSCON->MAINCLKSEL & 0x03) {
     case 0:                             /* Internal RC oscillator             */
-      SystemCoreClock = __IRC_OSC_CLK;
+      MainClock = __IRC_OSC_CLK;
       break;
     case 1:                             /* Input Clock to System PLL          */
       switch (LPC_SYSCON->SYSPLLCLKSEL & 0x03) {
           case 0:                       /* Internal RC oscillator             */
-            SystemCoreClock = __IRC_OSC_CLK;
+            MainClock = __IRC_OSC_CLK;
             break;
           case 1:                       /* System oscillator                  */
-            SystemCoreClock = __SYS_OSC_CLK;
+            MainClock = __SYS_OSC_CLK;
             break;
           case 2:                       /* Reserved                           */
-            SystemCoreClock = 0;
+            MainClock = 0;
             break;
           case 3:                       /* CLKIN pin                          */
-            SystemCoreClock = __CLKIN_CLK;
+            MainClock = __CLKIN_CLK;
             break;
       }
       break;
     case 2:                             /* WDT Oscillator                     */
-      SystemCoreClock = wdt_osc;
+      MainClock = wdt_osc;
       break;
     case 3:                             /* System PLL Clock Out               */
       switch (LPC_SYSCON->SYSPLLCLKSEL & 0x03) {
           case 0:                       /* Internal RC oscillator             */
-            SystemCoreClock = __IRC_OSC_CLK * ((LPC_SYSCON->SYSPLLCTRL & 0x01F) + 1);
+            MainClock = __IRC_OSC_CLK * ((LPC_SYSCON->SYSPLLCTRL & 0x01F) + 1);
             break;
           case 1:                       /* System oscillator                  */
-            SystemCoreClock = __SYS_OSC_CLK * ((LPC_SYSCON->SYSPLLCTRL & 0x01F) + 1);
+            MainClock = __SYS_OSC_CLK * ((LPC_SYSCON->SYSPLLCTRL & 0x01F) + 1);
             break;
           case 2:                       /* Reserved                           */
-            SystemCoreClock = 0;
+            MainClock = 0;
             break;
           case 3:                       /* CLKIN pin                          */
-            SystemCoreClock = __CLKIN_CLK * ((LPC_SYSCON->SYSPLLCTRL & 0x01F) + 1);
+            MainClock = __CLKIN_CLK * ((LPC_SYSCON->SYSPLLCTRL & 0x01F) + 1);
             break;
       }
-      break;
+      break;     
   }
 
-  SystemCoreClock /= LPC_SYSCON->SYSAHBCLKDIV;
-
+  SystemCoreClock = MainClock / LPC_SYSCON->SYSAHBCLKDIV;
 }
+//WH
 
 /**
  * Initialize the system

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/system_LPC8xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/system_LPC8xx.c
@@ -102,7 +102,7 @@
 */
 #define CLOCK_SETUP     1	// 1 == IRC: 2 == System Oscillator 12Mhz Xtal:
 
-//WH Fixed to use PLL
+//Fixed to use PLL
 #if (CLOCK_SETUP == 1)
 //use PLL for IRC
 	#define SYSOSCCTRL_Val        0x00000000              // Reset: 0x000
@@ -121,7 +121,6 @@
 	#define MAINCLKSEL_Val        0x00000003              // Reset: 0x000 MainClock = PLLCLKOUT
 	#define SYSAHBCLKDIV_Val      0x00000002              // Reset: 0x001 DIV=2 => SYSTEMCORECLK = 60 / 2 = 30MHz
 #endif
-//WH
 
 /*
 //-------- <<< end of configuration section >>> ------------------------------
@@ -250,11 +249,10 @@
 /*----------------------------------------------------------------------------
   Clock Variable definitions
  *----------------------------------------------------------------------------*/
-//WH Added MainClock
 uint32_t MainClock = __MAIN_CLOCK;         /*!< Main Clock Frequency */
 uint32_t SystemCoreClock = __SYSTEM_CLOCK;/*!< System Clock Frequency (Core Clock)*/
 
-//WH Replaced SystemCoreClock with MainClock
+//Replaced SystemCoreClock with MainClock
 /*----------------------------------------------------------------------------
   Clock functions
  *----------------------------------------------------------------------------*/
@@ -326,7 +324,6 @@ void SystemCoreClockUpdate (void)            /* Get Core Clock Frequency      */
 
   SystemCoreClock = MainClock / LPC_SYSCON->SYSAHBCLKDIV;
 }
-//WH
 
 /**
  * Initialize the system

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/system_LPC8xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/system_LPC8xx.h
@@ -30,7 +30,6 @@ extern "C" {
 
 #include <stdint.h>
 
-//WH
 extern uint32_t MainClock;           /*!< Main Clock Frequency                 */
 extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/system_LPC8xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/system_LPC8xx.h
@@ -30,6 +30,8 @@ extern "C" {
 
 #include <stdint.h>
 
+//WH
+extern uint32_t MainClock;           /*!< Main Clock Frequency                 */
 extern uint32_t SystemCoreClock;     /*!< System Clock Frequency (Core Clock)  */
 
 

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
@@ -117,9 +117,10 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     /* Peripheral reset control to UART, a "1" bring it out of reset. */
     LPC_SYSCON->PRESETCTRL &= ~(0x1 << (3 + uart_n));
     LPC_SYSCON->PRESETCTRL |=  (0x1 << (3 + uart_n));
-    
-    UARTSysClk = SystemCoreClock / LPC_SYSCON->UARTCLKDIV;
-    
+
+//WH    
+    UARTSysClk = MainClock / LPC_SYSCON->UARTCLKDIV;    
+
     // set default baud rate and format
     serial_baud  (obj, 9600);
     serial_format(obj, 8, ParityNone, 1);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
@@ -118,7 +118,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     LPC_SYSCON->PRESETCTRL &= ~(0x1 << (3 + uart_n));
     LPC_SYSCON->PRESETCTRL |=  (0x1 << (3 + uart_n));
 
-//WH    
+    // Derive UART Clock from MainClock    
     UARTSysClk = MainClock / LPC_SYSCON->UARTCLKDIV;    
 
     // set default baud rate and format


### PR DESCRIPTION
The LPC812 was running on the IRC at 12MHz rather than at the rated and expected 30MHz. The PLL settings were fixed and the MainClock and SystemCoreClock calculation was fixed.
The serial_api was fixed to use the correct MainClock value. Enjoy a speed increase of 2.5 !