### PR TITLE
Targets - gpio_is_connected() for STM targets where it was not implemented

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F070RB/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F070RB/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/gpio_object.h
@@ -64,6 +64,11 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F302R8/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F303RE/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F303RE/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F334R8/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L053R8/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_L152RE/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/gpio_object.h
@@ -62,6 +62,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/gpio_object.h
@@ -46,6 +46,10 @@ static inline int gpio_read(gpio_t *obj) {
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
Should be available for all mbed targets