### PR TITLE
[RZ_A1H]Fix a bug that Ether Driver there is a case where the transmission can n...

### DIFF
--- a/libraries/net/eth/lwip-eth/arch/TARGET_RZ_A1H/rza1_emac.c
+++ b/libraries/net/eth/lwip-eth/arch/TARGET_RZ_A1H/rza1_emac.c
@@ -63,7 +63,7 @@ static void rza1_phy_task(void *arg) {
     struct netif *netif = (struct netif*)arg;
     s32_t        connect_sts = 0;   /* 0: disconnect, 1:connect */
     s32_t        link_sts;
-    s32_t        link_mode_new;
+    s32_t        link_mode_new = NEGO_FAIL;
     s32_t        link_mode_old = NEGO_FAIL;
 
     while (1) {
@@ -125,7 +125,6 @@ static err_t rza1_low_level_output(struct netif *netif, struct pbuf *p) {
             }
         }
     }
-    pbuf_free(p);
 
     return err;
 }


### PR DESCRIPTION
Hello,

We fix a bug of Ether Driver as below.
- If Ether driver have been set multiple transmit data without waiting for the received data, Ether driver can not send data correctly .

Regards,
Hamanaka