### PR TITLE
Update system_nrf51822.c

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/system_nrf51822.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/system_nrf51822.c
@@ -71,7 +71,7 @@ void SystemInit(void)
 
     // Start the external 32khz crystal oscillator.
 
-#ifdef TARGET_DELTA_DFCM_NNN40 || TARGET_HRM1017
+#if defined(TARGET_DELTA_DFCM_NNN40) || defined(TARGET_HRM1017)
     NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_RC << CLOCK_LFCLKSRC_SRC_Pos);
 #else
     NRF_CLOCK->LFCLKSRC             = (CLOCK_LFCLKSRC_SRC_Xtal << CLOCK_LFCLKSRC_SRC_Pos);


### PR DESCRIPTION
Fixed support for mbed HRM1017.
It had been broken Feb.27th.