### PR TITLE
[ HAL ][ SSCI824 ] enabling onboard Oscillator

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/system_LPC8xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/system_LPC8xx.c
@@ -86,7 +86,7 @@
 //                   <2=> Reserved
 //                   <3=> CLKIN. External clock input.
 //   </h>
-#define SYSPLLCLKSEL_Val      0x00000000              // Reset: 0x000
+#define SYSPLLCLKSEL_Val      0x00000001              // Reset: 0x000
 //
 //   <h> Main Clock Source Select Register (MAINCLKSEL)
 //     <o.0..1>   SEL: Clock Source for Main Clock

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PinNames.h
@@ -40,8 +40,8 @@ typedef enum {
     P0_5  = ( 5 << PIN_SHIFT) | 0x0C,
     P0_6  = ( 6 << PIN_SHIFT) | 0x40,
     P0_7  = ( 7 << PIN_SHIFT) | 0x3C,
-    P0_8  = ( 8 << PIN_SHIFT) | 0x38,
-    P0_9  = ( 9 << PIN_SHIFT) | 0x34,
+
+
     P0_10 = (10 << PIN_SHIFT) | 0x20,
     P0_11 = (11 << PIN_SHIFT) | 0x1C,
     P0_12 = (12 << PIN_SHIFT) | 0x08,

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/TARGET_SSCI824/PinNames.h
@@ -40,8 +40,8 @@ typedef enum {
     P0_5  = ( 5 << PIN_SHIFT) | 0x0C,
     P0_6  = ( 6 << PIN_SHIFT) | 0x40,
     P0_7  = ( 7 << PIN_SHIFT) | 0x3C,
-
-
+    P0_8  = ( 8 << PIN_SHIFT) | 0x38,
+    P0_9  = ( 9 << PIN_SHIFT) | 0x34,
     P0_10 = (10 << PIN_SHIFT) | 0x20,
     P0_11 = (11 << PIN_SHIFT) | 0x1C,
     P0_12 = (12 << PIN_SHIFT) | 0x08,


### PR DESCRIPTION
## Description
### This pull request enables SSCI824 target's onboard oscillator

1. The Switch Science mbed LPC824 has onboard crystal oscillator but disabled at CMSIS source
   * Enabled by changing _SYSPLLCLKSEL_Val_ macro
2. Also those clock pins (P0_8 and _9) can be seen as available pins at PinNames.h
   * Disabled by removing those lines


