### PR TITLE
Update us_ticker.c

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/LPC8xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/LPC8xx.h
@@ -368,22 +368,45 @@ typedef struct {                            /*!< (@ 0x40028000) WKT Structure   
 } LPC_WKT_TypeDef;
 /*@}*/ /* end of group LPC8xx_WKT */
 
-
 /*------------- Multi-Rate Timer(MRT) --------------------------------------------------*/
-typedef struct {
-__IO uint32_t INTVAL;
-__IO uint32_t TIMER;
-__IO uint32_t CTRL;
-__IO uint32_t STAT;
-} MRT_Channel_cfg_Type;
-
-typedef struct {
-  MRT_Channel_cfg_Type Channel[4];
-   uint32_t Reserved0[1];
-  __IO uint32_t IDLE_CH;
-  __IO uint32_t IRQ_FLAG;
+//New, Copied from lpc824
+/**
+  * @brief Multi-Rate Timer (MRT) (MRT)
+  */
+typedef struct {                                    /*!< (@ 0x40004000) MRT Structure                                          */
+  __IO uint32_t  INTVAL0;                           /*!< (@ 0x40004000) MRT0 Time interval value register. This value
+                                                         is loaded into the TIMER0 register.                                   */
+  __I  uint32_t  TIMER0;                            /*!< (@ 0x40004004) MRT0 Timer register. This register reads the
+                                                         value of the down-counter.                                            */
+  __IO uint32_t  CTRL0;                             /*!< (@ 0x40004008) MRT0 Control register. This register controls
+                                                         the MRT0 modes.                                                       */
+  __IO uint32_t  STAT0;                             /*!< (@ 0x4000400C) MRT0 Status register.                                  */
+  __IO uint32_t  INTVAL1;                           /*!< (@ 0x40004010) MRT0 Time interval value register. This value
+                                                         is loaded into the TIMER0 register.                                   */
+  __I  uint32_t  TIMER1;                            /*!< (@ 0x40004014) MRT0 Timer register. This register reads the
+                                                         value of the down-counter.                                            */
+  __IO uint32_t  CTRL1;                             /*!< (@ 0x40004018) MRT0 Control register. This register controls
+                                                         the MRT0 modes.                                                       */
+  __IO uint32_t  STAT1;                             /*!< (@ 0x4000401C) MRT0 Status register.                                  */
+  __IO uint32_t  INTVAL2;                           /*!< (@ 0x40004020) MRT0 Time interval value register. This value
+                                                         is loaded into the TIMER0 register.                                   */
+  __I  uint32_t  TIMER2;                            /*!< (@ 0x40004024) MRT0 Timer register. This register reads the
+                                                         value of the down-counter.                                            */
+  __IO uint32_t  CTRL2;                             /*!< (@ 0x40004028) MRT0 Control register. This register controls
+                                                         the MRT0 modes.                                                       */
+  __IO uint32_t  STAT2;                             /*!< (@ 0x4000402C) MRT0 Status register.                                  */
+  __IO uint32_t  INTVAL3;                           /*!< (@ 0x40004030) MRT0 Time interval value register. This value
+                                                         is loaded into the TIMER0 register.                                   */
+  __I  uint32_t  TIMER3;                            /*!< (@ 0x40004034) MRT0 Timer register. This register reads the
+                                                         value of the down-counter.                                            */
+  __IO uint32_t  CTRL3;                             /*!< (@ 0x40004038) MRT0 Control register. This register controls
+                                                         the MRT0 modes.                                                       */
+  __IO uint32_t  STAT3;                             /*!< (@ 0x4000403C) MRT0 Status register.                                  */
+  __I  uint32_t  RESERVED0[45];
+  __I  uint32_t  IDLE_CH;                           /*!< (@ 0x400040F4) Idle channel register. This register returns
+                                                         the number of the first idle channel.                                 */
+  __IO uint32_t  IRQ_FLAG;                          /*!< (@ 0x400040F8) Global interrupt flag register                         */
 } LPC_MRT_TypeDef;
-
 
 /*------------- Universal Asynchronous Receiver Transmitter (USART) -----------*/
 /** @addtogroup LPC8xx_UART LPC8xx Universal Asynchronous Receiver/Transmitter

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/us_ticker.c
@@ -17,77 +17,89 @@
 #include "us_ticker_api.h"
 #include "PeripheralNames.h"
 
-#define US_TICKER_TIMER_IRQn     SCT_IRQn
+//New, using MRT instead of SCT, needed to free up SCT for PWM
+//Ported from LPC824 libs
+static int us_ticker_inited = 0;
+static int ticker_expired = 0;
+int MRT_Clock_MHz;
 
-int us_ticker_inited = 0;
+#define US_TICKER_TIMER_IRQn     MRT_IRQn
 
 void us_ticker_init(void) {
-    if (us_ticker_inited) return;
+    
+    if (us_ticker_inited)
+        return;
+
     us_ticker_inited = 1;
+
+    // Calculate MRT clock value (MRT has no prescaler)
+    MRT_Clock_MHz = (SystemCoreClock / 1000000);
+
+    // Enable the MRT clock
+    LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 10);
+
+    // Clear peripheral reset the MRT
+    LPC_SYSCON->PRESETCTRL |= (1 << 7);
+
+    // Force load interval value (Bit 0-30 is interval value, Bit 31 is Force Load bit)     
+    LPC_MRT->INTVAL0 = 0xFFFFFFFFUL;
+    // Enable Ch0 interrupt, Mode 0 is Repeat Interrupt
+    LPC_MRT->CTRL0 = (0x0 << 1) | (0x1 << 0);
+
+    // Force load interval value (Bit 0-30 is interval value, Bit 31 is Force Load bit)     
+    LPC_MRT->INTVAL1 = 0x80000000UL;
+    // Disable ch1 interrupt, Mode 0 is Repeat Interrupt
+    LPC_MRT->CTRL1 = (0x0 << 1) | (0x0 << 0);
     
-    // Enable the SCT clock
-    LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 8);
-    
-    // Clear peripheral reset the SCT:
-    LPC_SYSCON->PRESETCTRL |= (1 << 8);
-    
-    // Unified counter (32 bits)
-    LPC_SCT->CONFIG |= 1;
-    
-    // halt and clear the counter
-    LPC_SCT->CTRL_L |= (1 << 2) | (1 << 3);
-    
-    // System Clock (12)MHz -> us_ticker (1)MHz
-    LPC_SCT->CTRL_L |= ((SystemCoreClock/1000000 - 1) << 5);
-    
-    // unhalt the counter:
-    //    - clearing bit 2 of the CTRL register
-    LPC_SCT->CTRL_L &= ~(1 << 2);
-    
+    // Set MRT interrupt vector
     NVIC_SetVector(US_TICKER_TIMER_IRQn, (uint32_t)us_ticker_irq_handler);
     NVIC_EnableIRQ(US_TICKER_TIMER_IRQn);
 }
 
+//TIMER0 is used for us ticker and timers (Timer, wait(), wait_us() etc)
 uint32_t us_ticker_read() {
+    
     if (!us_ticker_inited)
         us_ticker_init();
-    
-    return LPC_SCT->COUNT_U;
+
+    // Generate ticker value
+    // MRT source clock is SystemCoreClock (30MHz) and MRT is a 31-bit countdown timer
+    // Calculate expected value using number of expired times to mimic a 32bit timer @ 1 MHz
+    return (0x7FFFFFFFUL - LPC_MRT->TIMER0)/MRT_Clock_MHz + (ticker_expired * (0x80000000UL/MRT_Clock_MHz));
 }
 
+//TIMER1 is used for Timestamped interrupts (Ticker(), Timeout())
 void us_ticker_set_interrupt(timestamp_t timestamp) {
-    // halt the counter: 
-    //    - setting bit 2 of the CTRL register
-    LPC_SCT->CTRL_L |= (1 << 2);
     
-    // set timestamp in compare register
-    LPC_SCT->MATCH[0].U = (uint32_t)timestamp;
+    // MRT source clock is SystemCoreClock (30MHz) and MRT is a 31-bit countdown timer    
+    // Force load interval value (Bit 0-30 is interval value, Bit 31 is Force Load bit)
+    // Note: The MRT has less counter headroom available than the typical mbed 32bit timer @ 1 MHz.
+    //       The calculated counter interval until the next timestamp will be truncated and an
+    //       'early' interrupt will be generated in case the max required count interval exceeds
+    //       the available 31 bits space. However, the mbed us_ticker interrupt handler will 
+    //       check current time against the next scheduled timestamp and simply re-issue the
+    //       same interrupt again when needed. The calculated counter interval will now be smaller.
+    LPC_MRT->INTVAL1 = (((timestamp - us_ticker_read()) * MRT_Clock_MHz) | 0x80000000UL);
     
-    // unhalt the counter:
-    //    - clearing bit 2 of the CTRL register
-    LPC_SCT->CTRL_L &= ~(1 << 2);
+    // Enable interrupt 
+    LPC_MRT->CTRL1 |= 1;
+}
+
+//Disable Timestamped interrupts triggered by TIMER1
+void us_ticker_disable_interrupt() {
+    //Timer1 for Timestamped interrupts (31 bits downcounter @ SystemCoreClock)    
+    LPC_MRT->CTRL1 &= ~1;
+}
+
+void us_ticker_clear_interrupt() {
     
-    // if events are not enabled, enable them
-    if (!(LPC_SCT->EVEN & 0x01)) {
-        
-        // comb mode = match only
-        LPC_SCT->EVENT[0].CTRL = (1 << 12);
-        
-        // ref manual:
-        //   In simple applications that do not 
-        //   use states, write 0x01 to this 
-        //   register to enable an event
-        LPC_SCT->EVENT[0].STATE |= 0x1;
-        
-        // enable events
-        LPC_SCT->EVEN |= 0x1;
+    //Timer1 for Timestamped interrupts (31 bits downcounter @ SystemCoreClock)
+    if (LPC_MRT->STAT1 & 1)
+        LPC_MRT->STAT1 = 1;
+    
+    //Timer0 for us counter (31 bits downcounter @ SystemCoreClock)
+    if (LPC_MRT->STAT0 & 1) {
+        LPC_MRT->STAT0 = 1;
+        ticker_expired++;
     }
-}
-
-void us_ticker_disable_interrupt(void) {
-    LPC_SCT->EVEN &= ~1;
-}
-
-void us_ticker_clear_interrupt(void) {
-    LPC_SCT->EVFLAG = 1;
 }


### PR DESCRIPTION
Using MRT instead of SCT, needed to free up SCT for PWM
Code ported from LPC824 libs