### PR TITLE
Fix export_test.py extra_symbols issue.

### DIFF
--- a/workspace_tools/export_test.py
+++ b/workspace_tools/export_test.py
@@ -55,7 +55,7 @@ def test_export(toolchain, target, expected_error=None):
     temp_dir = join(base_dir, "temp")
     mkdir(temp_dir)
 
-    zip_path, report = export(USER_PRJ, USR_PRJ_NAME, toolchain, target, base_dir, temp_dir, False, fake_build_url_resolver)
+    zip_path, report = export(USER_PRJ, USR_PRJ_NAME, toolchain, target, base_dir, temp_dir, False, None, fake_build_url_resolver)
 
     if report['success']:
         move(zip_path, join(EXPORT_DIR, "export_%s_%s.zip" % (toolchain, target)))


### PR DESCRIPTION
Apparently the export() function takes an extra_symbols parameter that wasn't being passed, causing runtime errors. This fixes it.