### PR TITLE
Update nRF51822.sct

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/TOOLCHAIN_ARM_STD/TARGET_MCU_NORDIC_32K/nRF51822.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/TOOLCHAIN_ARM_STD/TARGET_MCU_NORDIC_32K/nRF51822.sct
@@ -5,7 +5,7 @@
 ;   *(InRoot$$Sections)
 ;   .ANY (+RO)
 ;  }
-;  RW_IRAM1 0x20000000 0x00004000  {
+;  RW_IRAM1 0x20000000 0x00008000  {
 ;   .ANY (+RW +ZI)
 ;  }
 ;}


### PR DESCRIPTION
FIx copy paste error in RAM size when softdevice isn't used