### PR TITLE
[API] Added option to modify RTC source

### DIFF
--- a/libraries/mbed/api/rtc_time.h
+++ b/libraries/mbed/api/rtc_time.h
@@ -69,6 +69,15 @@ extern "C" {
  */
 void set_time(time_t t);
 
+/** Attach an external RTC to be used for the C time functions
+ *
+ * @param read_rtc pointer to function which returns current UNIX timestamp
+ * @param write_rtc pointer to function which sets current UNIX timestamp, can be NULL
+ * @param init_rtc pointer to funtion which initializes RTC, can be NULL
+ * @param isenabled_rtc pointer to function wich returns if the rtc is enabled, can be NULL
+ */
+void attach_rtc(time_t (*read_rtc)(void), void (*write_rtc)(time_t), void (*init_rtc)(void), int (*isenabled_rtc)(void));
+
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/mbed/api/rtc_time.h
+++ b/libraries/mbed/api/rtc_time.h
@@ -71,6 +71,8 @@ void set_time(time_t t);
 
 /** Attach an external RTC to be used for the C time functions
  *
+ * Do not call this function from an interrupt while an RTC read/write operation may be occurring 
+ *
  * @param read_rtc pointer to function which returns current UNIX timestamp
  * @param write_rtc pointer to function which sets current UNIX timestamp, can be NULL
  * @param init_rtc pointer to funtion which initializes RTC, can be NULL

--- a/libraries/mbed/common/rtc_time.c
+++ b/libraries/mbed/common/rtc_time.c
@@ -47,11 +47,9 @@ time_t time(time_t *timer)
         }
     }
     
-    time_t t;
+    time_t t = 0;
     if (_rtc_read != NULL) {
         t = _rtc_read();
-    } else {
-        t = 0;
     }
 
     if (timer != NULL) {
@@ -76,10 +74,12 @@ clock_t clock() {
 }
 
 void attach_rtc(time_t (*read_rtc)(void), void (*write_rtc)(time_t), void (*init_rtc)(void), int (*isenabled_rtc)(void)) {
+    __disable_irq();
     _rtc_read = read_rtc;
     _rtc_write = write_rtc;
     _rtc_init = init_rtc;
     _rtc_isenabled = isenabled_rtc;
+    __enable_irq();
 }
 
 

--- a/libraries/mbed/common/rtc_time.c
+++ b/libraries/mbed/common/rtc_time.c
@@ -19,6 +19,18 @@
 #include "rtc_time.h"
 #include "us_ticker_api.h"
 
+#if DEVICE_RTC
+static void (*_rtc_init)(void) = rtc_init;
+static int (*_rtc_isenabled)(void) = rtc_isenabled;
+static time_t (*_rtc_read)(void) = rtc_read;
+static void (*_rtc_write)(time_t t) = rtc_write;
+#else
+static void (*_rtc_init)(void) = NULL;
+static int (*_rtc_isenabled)(void) = NULL;
+static time_t (*_rtc_read)(void) = NULL;
+static void (*_rtc_write)(time_t t) = NULL;
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -29,15 +41,18 @@ time_t time(time_t *timer)
 #endif
 
 {
-#if DEVICE_RTC
-    if (!(rtc_isenabled())) {
-        set_time(0);
+    if (_rtc_isenabled != NULL) {
+        if (!(_rtc_isenabled())) {
+            set_time(0);
+        }
     }
-    time_t t = rtc_read();
-
-#else
-    time_t t = 0;
-#endif
+    
+    time_t t;
+    if (_rtc_read != NULL) {
+        t = _rtc_read();
+    } else {
+        t = 0;
+    }
 
     if (timer != NULL) {
         *timer = t;
@@ -46,10 +61,12 @@ time_t time(time_t *timer)
 }
 
 void set_time(time_t t) {
-#if DEVICE_RTC
-    rtc_init();
-    rtc_write(t);
-#endif
+    if (_rtc_init != NULL) {
+        _rtc_init();
+    }
+    if (_rtc_write != NULL) {
+        _rtc_write(t);
+    }
 }
 
 clock_t clock() {
@@ -57,6 +74,15 @@ clock_t clock() {
     t /= 1000000 / CLOCKS_PER_SEC; // convert to processor time
     return t;
 }
+
+void attach_rtc(time_t (*read_rtc)(void), void (*write_rtc)(time_t), void (*init_rtc)(void), int (*isenabled_rtc)(void)) {
+    _rtc_read = read_rtc;
+    _rtc_write = write_rtc;
+    _rtc_init = init_rtc;
+    _rtc_isenabled = isenabled_rtc;
+}
+
+
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Initially from Karls question here:
http://developer.mbed.org/questions/6337/setTime-and-time-exported-with-__weak-fo/#answer6545?compage=1#c15936.
Currently the C time functions only work with internal RTC. Sometimes
you either want to use an external one, or your target does not even
have an internal RTC. I added function attach_rtc(...) where the default
functions can be overridden at runtime.

Verified it to work properly with LPC1768/LPC11u24, both with and without DS1307 RTC connected and used as source for time. I don't think the init and isenabled functions are really important to have, but you can just set them as NULL (did so myself when testing).