### PR TITLE
Pass ssel PinName to spi_init() for hardware assisted SSEL control.

### DIFF
--- a/libraries/mbed/api/SPI.h
+++ b/libraries/mbed/api/SPI.h
@@ -58,8 +58,9 @@ public:
      *  @param mosi SPI Master Out, Slave In pin
      *  @param miso SPI Master In, Slave Out pin
      *  @param sclk SPI Clock pin
+     *  @param ssel SPI Clock pin
      */
-    SPI(PinName mosi, PinName miso, PinName sclk, PinName _unused=NC);
+    SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel=NC);
 
     /** Configure the data transmission format
      *

--- a/libraries/mbed/common/SPI.cpp
+++ b/libraries/mbed/common/SPI.cpp
@@ -19,12 +19,12 @@
 
 namespace mbed {
 
-SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName _unused) :
+SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
         _spi(),
         _bits(8),
         _mode(0),
         _hz(1000000) {
-    spi_init(&_spi, mosi, miso, sclk, NC);
+    spi_init(&_spi, mosi, miso, sclk, ssel);
     spi_format(&_spi, _bits, _mode, 0);
     spi_frequency(&_spi, _hz);
 }


### PR DESCRIPTION
Some SPI master implementations control the slave select in hardware. Passing the pin name on to the C HAL for configuration.