### PR TITLE
Added function to get the timestamp of the next us_ticker event.

### DIFF
--- a/libraries/mbed/common/us_ticker_api.c
+++ b/libraries/mbed/common/us_ticker_api.c
@@ -116,3 +116,7 @@ void us_ticker_remove_event(ticker_event_t *obj) {
 
     __enable_irq();
 }
+
+timestamp_t us_ticker_get_next_timestamp(void) {
+    return head->timestamp;
+}

--- a/libraries/mbed/hal/us_ticker_api.h
+++ b/libraries/mbed/hal/us_ticker_api.h
@@ -43,6 +43,7 @@ void us_ticker_irq_handler(void);
 
 void us_ticker_insert_event(ticker_event_t *obj, timestamp_t timestamp, uint32_t id);
 void us_ticker_remove_event(ticker_event_t *obj);
+timestamp_t us_ticker_get_next_timestamp(void);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
This function will allow us to have a tickless wakeup from deepstop using a low-speed RTC timer.