### PR TITLE
Experimental parallel test execution on MUTs (option --parallel)

### DIFF
--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -213,6 +213,7 @@ if __name__ == '__main__':
                                    _opts_shuffle_test_order=opts.shuffle_test_order,
                                    _opts_shuffle_test_seed=opts.shuffle_test_seed,
                                    _opts_test_by_names=opts.test_by_names,
+                                   _opts_peripheral_by_names=opts.peripheral_by_names,
                                    _opts_test_only_peripheral=opts.test_only_peripheral,
                                    _opts_test_only_common=opts.test_only_common,
                                    _opts_verbose_skipped_tests=opts.verbose_skipped_tests,

--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -220,6 +220,7 @@ if __name__ == '__main__':
                                    _opts_verbose=opts.verbose,
                                    _opts_firmware_global_name=opts.firmware_global_name,
                                    _opts_only_build_tests=opts.only_build_tests,
+                                   _opts_parallel_test_exec=opts.parallel_test_exec,
                                    _opts_suppress_summary=opts.suppress_summary,
                                    _opts_test_x_toolchain_summary=opts.test_x_toolchain_summary,
                                    _opts_copy_method=opts.copy_method,

--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -34,7 +34,7 @@ from prettytable import PrettyTable
 from time import sleep, time
 from Queue import Queue, Empty
 from os.path import join, exists, basename
-from threading import Thread
+from threading import Thread, Lock
 from subprocess import Popen, PIPE
 
 # Imports related to mbed build api
@@ -166,6 +166,7 @@ class SingleTestRunner(object):
                  _opts_verbose=False,
                  _opts_firmware_global_name=None,
                  _opts_only_build_tests=False,
+                 _opts_parallel_test_exec=False,
                  _opts_suppress_summary=False,
                  _opts_test_x_toolchain_summary=False,
                  _opts_copy_method=None,
@@ -215,6 +216,7 @@ class SingleTestRunner(object):
         self.opts_verbose = _opts_verbose
         self.opts_firmware_global_name = _opts_firmware_global_name
         self.opts_only_build_tests = _opts_only_build_tests
+        self.opts_parallel_test_exec = _opts_parallel_test_exec
         self.opts_suppress_summary = _opts_suppress_summary
         self.opts_test_x_toolchain_summary = _opts_test_x_toolchain_summary
         self.opts_copy_method = _opts_copy_method
@@ -281,212 +283,249 @@ class SingleTestRunner(object):
             result = False
         return result
 
+    # This will store target / toolchain specific properties
+    test_suite_properties_ext = {}  # target : toolchain
+    # Here we store test results
+    test_summary = []
+    # Here we store test results in extended data structure
+    test_summary_ext = {}
+    execute_thread_slice_lock = Lock()
+
+    def execute_thread_slice(self, q, target, toolchains, clean, test_ids):
+        for toolchain in toolchains:
+            # print target, toolchain
+            # Test suite properties returned to external tools like CI
+            test_suite_properties = {}
+            test_suite_properties['jobs'] = self.opts_jobs
+            test_suite_properties['clean'] = clean
+            test_suite_properties['target'] = target
+            test_suite_properties['test_ids'] = ', '.join(test_ids)
+            test_suite_properties['toolchain'] = toolchain
+            test_suite_properties['shuffle_random_seed'] = self.shuffle_random_seed
+
+            # print '=== %s::%s ===' % (target, toolchain)
+            # Let's build our test
+            if target not in TARGET_MAP:
+                print self.logger.log_line(self.logger.LogType.NOTIF, 'Skipped tests for %s target. Target platform not found'% (target))
+                continue
+
+            T = TARGET_MAP[target]
+            build_mbed_libs_options = ["analyze"] if self.opts_goanna_for_mbed_sdk else None
+            clean_mbed_libs_options = True if self.opts_goanna_for_mbed_sdk or clean or self.opts_clean else None
+
+            try:
+                build_mbed_libs_result = build_mbed_libs(T,
+                                                         toolchain,
+                                                         options=build_mbed_libs_options,
+                                                         clean=clean_mbed_libs_options,
+                                                         jobs=self.opts_jobs)
+
+                if not build_mbed_libs_result:
+                    print self.logger.log_line(self.logger.LogType.NOTIF, 'Skipped tests for %s target. Toolchain %s is not yet supported for this target'% (T.name, toolchain))
+                    continue
+            except ToolException:
+                print self.logger.log_line(self.logger.LogType.ERROR, 'There were errors while building MBED libs for %s using %s'% (target, toolchain))
+                #return self.test_summary, self.shuffle_random_seed, self.test_summary_ext, self.test_suite_properties_ext
+                q.put(target + '_'.join(toolchains))
+                return
+
+            build_dir = join(BUILD_DIR, "test", target, toolchain)
+
+            test_suite_properties['build_mbed_libs_result'] = build_mbed_libs_result
+            test_suite_properties['build_dir'] = build_dir
+            test_suite_properties['skipped'] = []
+
+            # Enumerate through all tests and shuffle test order if requested
+            test_map_keys = sorted(TEST_MAP.keys())
+            if self.opts_shuffle_test_order:
+                random.shuffle(test_map_keys, self.shuffle_random_func)
+                # Update database with shuffle seed f applicable
+                if self.db_logger:
+                    self.db_logger.reconnect();
+                    if self.db_logger.is_connected():
+                        self.db_logger.update_build_id_info(self.db_logger_build_id, _shuffle_seed=self.shuffle_random_func())
+                        self.db_logger.disconnect();
+
+            if self.db_logger:
+                self.db_logger.reconnect();
+                if self.db_logger.is_connected():
+                    # Update MUTs and Test Specification in database
+                    self.db_logger.update_build_id_info(self.db_logger_build_id, _muts=self.muts, _test_spec=self.test_spec)
+                    # Update Extra information in database (some options passed to test suite)
+                    self.db_logger.update_build_id_info(self.db_logger_build_id, _extra=json.dumps(self.dump_options()))
+                    self.db_logger.disconnect();
+
+            for test_id in test_map_keys:
+                test = TEST_MAP[test_id]
+                if self.opts_test_by_names and test_id not in self.opts_test_by_names.split(','):
+                    continue
+
+                if test_ids and test_id not in test_ids:
+                    continue
+
+                if self.opts_test_only_peripheral and not test.peripherals:
+                    if self.opts_verbose_skipped_tests:
+                        print self.logger.log_line(self.logger.LogType.INFO, 'Common test skipped for target %s'% (target))
+                    test_suite_properties['skipped'].append(test_id)
+                    continue
+
+                if self.opts_test_only_common and test.peripherals:
+                    if self.opts_verbose_skipped_tests:
+                        print self.logger.log_line(self.logger.LogType.INFO, 'Peripheral test skipped for target %s'% (target))
+                    test_suite_properties['skipped'].append(test_id)
+                    continue
+
+                if test.automated and test.is_supported(target, toolchain):
+                    if test.peripherals is None and self.opts_only_build_tests:
+                        # When users are using 'build only flag' and test do not have
+                        # specified peripherals we can allow test building by default
+                        pass
+                    elif not self.is_peripherals_available(target, test.peripherals):
+                        if self.opts_verbose_skipped_tests:
+                            if test.peripherals:
+                                print self.logger.log_line(self.logger.LogType.INFO, 'Peripheral %s test skipped for target %s'% (",".join(test.peripherals), target))
+                            else:
+                                print self.logger.log_line(self.logger.LogType.INFO, 'Test %s skipped for target %s'% (test_id, target))
+                        test_suite_properties['skipped'].append(test_id)
+                        continue
+
+                    build_project_options = ["analyze"] if self.opts_goanna_for_tests else None
+                    clean_project_options = True if self.opts_goanna_for_tests or clean or self.opts_clean else None
+
+                    # Detect which lib should be added to test
+                    # Some libs have to compiled like RTOS or ETH
+                    libraries = []
+                    for lib in LIBRARIES:
+                        if lib['build_dir'] in test.dependencies:
+                            libraries.append(lib['id'])
+                    # Build libs for test
+                    for lib_id in libraries:
+                        try:
+                            build_lib(lib_id,
+                                      T,
+                                      toolchain,
+                                      options=build_project_options,
+                                      verbose=self.opts_verbose,
+                                      clean=clean_mbed_libs_options,
+                                      jobs=self.opts_jobs)
+                        except ToolException:
+                            print self.logger.log_line(self.logger.LogType.ERROR, 'There were errors while building library %s'% (lib_id))
+                            #return self.test_summary, self.shuffle_random_seed, self.test_summary_ext, self.test_suite_properties_ext
+                            q.put(target + '_'.join(toolchains))
+                            return
+
+                    test_suite_properties['test.libs.%s.%s.%s'% (target, toolchain, test_id)] = ', '.join(libraries)
+
+                    # TODO: move this 2 below loops to separate function
+                    INC_DIRS = []
+                    for lib_id in libraries:
+                        if 'inc_dirs_ext' in LIBRARY_MAP[lib_id] and LIBRARY_MAP[lib_id]['inc_dirs_ext']:
+                            INC_DIRS.extend(LIBRARY_MAP[lib_id]['inc_dirs_ext'])
+
+                    MACROS = []
+                    for lib_id in libraries:
+                        if 'macros' in LIBRARY_MAP[lib_id] and LIBRARY_MAP[lib_id]['macros']:
+                            MACROS.extend(LIBRARY_MAP[lib_id]['macros'])
+                    MACROS.append('TEST_SUITE_TARGET_NAME="%s"'% target)
+                    MACROS.append('TEST_SUITE_TEST_ID="%s"'% test_id)
+                    test_uuid = uuid.uuid4()
+                    MACROS.append('TEST_SUITE_UUID="%s"'% str(test_uuid))
+
+                    project_name = self.opts_firmware_global_name if self.opts_firmware_global_name else None
+                    try:
+                        path = build_project(test.source_dir,
+                                             join(build_dir, test_id),
+                                             T,
+                                             toolchain,
+                                             test.dependencies,
+                                             options=build_project_options,
+                                             clean=clean_project_options,
+                                             verbose=self.opts_verbose,
+                                             name=project_name,
+                                             macros=MACROS,
+                                             inc_dirs=INC_DIRS,
+                                             jobs=self.opts_jobs)
+                    except ToolException:
+                        project_name_str = project_name if project_name is not None else test_id
+                        print self.logger.log_line(self.logger.LogType.ERROR, 'There were errors while building project %s'% (project_name_str))
+                        # return self.test_summary, self.shuffle_random_seed, self.test_summary_ext, self.test_suite_properties_ext
+                        q.put(target + '_'.join(toolchains))
+                        return
+                    if self.opts_only_build_tests:
+                        # With this option we are skipping testing phase
+                        continue
+
+                    # Test duration can be increased by global value
+                    test_duration = test.duration
+                    if self.opts_extend_test_timeout is not None:
+                        test_duration += self.opts_extend_test_timeout
+
+                    # For an automated test the duration act as a timeout after
+                    # which the test gets interrupted
+                    test_spec = self.shape_test_request(target, path, test_id, test_duration)
+                    test_loops = self.get_test_loop_count(test_id)
+
+                    test_suite_properties['test.duration.%s.%s.%s'% (target, toolchain, test_id)] = test_duration
+                    test_suite_properties['test.loops.%s.%s.%s'% (target, toolchain, test_id)] = test_loops
+                    test_suite_properties['test.path.%s.%s.%s'% (target, toolchain, test_id)] = path
+
+                    # read MUTs, test specification and perform tests
+                    single_test_result, detailed_test_results = self.handle(test_spec, target, toolchain, test_loops=test_loops)
+
+                    # Append test results to global test summary
+                    if single_test_result is not None:
+                        self.test_summary.append(single_test_result)
+
+                    # Prepare extended test results data structure (it can be used to generate detailed test report)
+                    if toolchain not in self.test_summary_ext:
+                        self.test_summary_ext[toolchain] = {}  # test_summary_ext : toolchain
+                    if target not in self.test_summary_ext[toolchain]:
+                        self.test_summary_ext[toolchain][target] = {}    # test_summary_ext : toolchain : target
+                    if target not in self.test_summary_ext[toolchain][target]:
+                        self.test_summary_ext[toolchain][target][test_id] = detailed_test_results    # test_summary_ext : toolchain : target : test_it
+
+            test_suite_properties['skipped'] = ', '.join(test_suite_properties['skipped'])
+            self.test_suite_properties_ext[target][toolchain] = test_suite_properties
+        # return self.test_summary, self.shuffle_random_seed, test_summary_ext, self.test_suite_properties_ext
+        q.put(target + '_'.join(toolchains))
+        return
+
     def execute(self):
         clean = self.test_spec.get('clean', False)
         test_ids = self.test_spec.get('test_ids', [])
-
-        # This will store target / toolchain specific properties
-        test_suite_properties_ext = {}  # target : toolchain
-
-        # Here we store test results
-        test_summary = []
-        # Here we store test results in extended data structure
-        test_summary_ext = {}
+        q = Queue()
 
         # Generate seed for shuffle if seed is not provided in
         self.shuffle_random_seed = round(random.random(), self.SHUFFLE_SEED_ROUND)
         if self.opts_shuffle_test_seed is not None and self.is_shuffle_seed_float():
             self.shuffle_random_seed = round(float(self.opts_shuffle_test_seed), self.SHUFFLE_SEED_ROUND)
 
-        for target, toolchains in self.test_spec['targets'].iteritems():
-            test_suite_properties_ext[target] = {}
-            for toolchain in toolchains:
-                # Test suite properties returned to external tools like CI
-                test_suite_properties = {}
-                test_suite_properties['jobs'] = self.opts_jobs
-                test_suite_properties['clean'] = clean
-                test_suite_properties['target'] = target
-                test_suite_properties['test_ids'] = ', '.join(test_ids)
-                test_suite_properties['toolchain'] = toolchain
-                test_suite_properties['shuffle_random_seed'] = self.shuffle_random_seed
+        if self.opts_parallel_test_exec:
+            ###################################################################
+            # Experimental, parallel test execution per singletest instance.
+            ###################################################################
+            execute_threads = []    # Threads used to build mbed SDL, libs, test cases and execute tests
+            # Note: We are building here in parallel for each target separately!
+            # So we are not building the same thing multiple times and compilers
+            # in separate threads do not collide.
+            # Inside execute_thread_slice() function function handle() will be called to
+            # get information about available MUTs (per target).
+            for target, toolchains in self.test_spec['targets'].iteritems():
+                self.test_suite_properties_ext[target] = {}
+                t = threading.Thread(target=self.execute_thread_slice, args = (q, target, toolchains, clean, test_ids))
+                t.daemon = True
+                t.start()
+                execute_threads.append(t)
 
-                # print '=== %s::%s ===' % (target, toolchain)
-                # Let's build our test
-                if target not in TARGET_MAP:
-                    print self.logger.log_line(self.logger.LogType.NOTIF, 'Skipped tests for %s target. Target platform not found'% (target))
-                    continue
-
-                T = TARGET_MAP[target]
-                build_mbed_libs_options = ["analyze"] if self.opts_goanna_for_mbed_sdk else None
-                clean_mbed_libs_options = True if self.opts_goanna_for_mbed_sdk or clean or self.opts_clean else None
-
-                try:
-                    build_mbed_libs_result = build_mbed_libs(T,
-                                                             toolchain,
-                                                             options=build_mbed_libs_options,
-                                                             clean=clean_mbed_libs_options,
-                                                             jobs=self.opts_jobs)
-
-                    if not build_mbed_libs_result:
-                        print self.logger.log_line(self.logger.LogType.NOTIF, 'Skipped tests for %s target. Toolchain %s is not yet supported for this target'% (T.name, toolchain))
-                        continue
-                except ToolException:
-                    print self.logger.log_line(self.logger.LogType.ERROR, 'There were errors while building MBED libs for %s using %s'% (target, toolchain))
-                    return test_summary, self.shuffle_random_seed, test_summary_ext, test_suite_properties_ext
-
-                build_dir = join(BUILD_DIR, "test", target, toolchain)
-
-                test_suite_properties['build_mbed_libs_result'] = build_mbed_libs_result
-                test_suite_properties['build_dir'] = build_dir
-                test_suite_properties['skipped'] = []
-
-                # Enumerate through all tests and shuffle test order if requested
-                test_map_keys = sorted(TEST_MAP.keys())
-                if self.opts_shuffle_test_order:
-                    random.shuffle(test_map_keys, self.shuffle_random_func)
-                    # Update database with shuffle seed f applicable
-                    if self.db_logger:
-                        self.db_logger.reconnect();
-                        if self.db_logger.is_connected():
-                            self.db_logger.update_build_id_info(self.db_logger_build_id, _shuffle_seed=self.shuffle_random_func())
-                            self.db_logger.disconnect();
-
-                if self.db_logger:
-                    self.db_logger.reconnect();
-                    if self.db_logger.is_connected():
-                        # Update MUTs and Test Specification in database
-                        self.db_logger.update_build_id_info(self.db_logger_build_id, _muts=self.muts, _test_spec=self.test_spec)
-                        # Update Extra information in database (some options passed to test suite)
-                        self.db_logger.update_build_id_info(self.db_logger_build_id, _extra=json.dumps(self.dump_options()))
-                        self.db_logger.disconnect();
-
-                for test_id in test_map_keys:
-                    test = TEST_MAP[test_id]
-                    if self.opts_test_by_names and test_id not in self.opts_test_by_names.split(','):
-                        continue
-
-                    if test_ids and test_id not in test_ids:
-                        continue
-
-                    if self.opts_test_only_peripheral and not test.peripherals:
-                        if self.opts_verbose_skipped_tests:
-                            print self.logger.log_line(self.logger.LogType.INFO, 'Common test skipped for target %s'% (target))
-                        test_suite_properties['skipped'].append(test_id)
-                        continue
-
-                    if self.opts_test_only_common and test.peripherals:
-                        if self.opts_verbose_skipped_tests:
-                            print self.logger.log_line(self.logger.LogType.INFO, 'Peripheral test skipped for target %s'% (target))
-                        test_suite_properties['skipped'].append(test_id)
-                        continue
-
-                    if test.automated and test.is_supported(target, toolchain):
-                        if test.peripherals is None and self.opts_only_build_tests:
-                            # When users are using 'build only flag' and test do not have
-                            # specified peripherals we can allow test building by default
-                            pass
-                        elif not self.is_peripherals_available(target, test.peripherals):
-                            if self.opts_verbose_skipped_tests:
-                                if test.peripherals:
-                                    print self.logger.log_line(self.logger.LogType.INFO, 'Peripheral %s test skipped for target %s'% (",".join(test.peripherals), target))
-                                else:
-                                    print self.logger.log_line(self.logger.LogType.INFO, 'Test %s skipped for target %s'% (test_id, target))
-                            test_suite_properties['skipped'].append(test_id)
-                            continue
-
-                        build_project_options = ["analyze"] if self.opts_goanna_for_tests else None
-                        clean_project_options = True if self.opts_goanna_for_tests or clean or self.opts_clean else None
-
-                        # Detect which lib should be added to test
-                        # Some libs have to compiled like RTOS or ETH
-                        libraries = []
-                        for lib in LIBRARIES:
-                            if lib['build_dir'] in test.dependencies:
-                                libraries.append(lib['id'])
-                        # Build libs for test
-                        for lib_id in libraries:
-                            try:
-                                build_lib(lib_id,
-                                          T,
-                                          toolchain,
-                                          options=build_project_options,
-                                          verbose=self.opts_verbose,
-                                          clean=clean_mbed_libs_options,
-                                          jobs=self.opts_jobs)
-                            except ToolException:
-                                print self.logger.log_line(self.logger.LogType.ERROR, 'There were errors while building library %s'% (lib_id))
-                                return test_summary, self.shuffle_random_seed, test_summary_ext, test_suite_properties_ext
-
-                        test_suite_properties['test.libs.%s.%s.%s'% (target, toolchain, test_id)] = ', '.join(libraries)
-
-                        # TODO: move this 2 below loops to separate function
-                        INC_DIRS = []
-                        for lib_id in libraries:
-                            if 'inc_dirs_ext' in LIBRARY_MAP[lib_id] and LIBRARY_MAP[lib_id]['inc_dirs_ext']:
-                                INC_DIRS.extend(LIBRARY_MAP[lib_id]['inc_dirs_ext'])
-
-                        MACROS = []
-                        for lib_id in libraries:
-                            if 'macros' in LIBRARY_MAP[lib_id] and LIBRARY_MAP[lib_id]['macros']:
-                                MACROS.extend(LIBRARY_MAP[lib_id]['macros'])
-                        MACROS.append('TEST_SUITE_TARGET_NAME="%s"'% target)
-                        MACROS.append('TEST_SUITE_TEST_ID="%s"'% test_id)
-                        test_uuid = uuid.uuid4()
-                        MACROS.append('TEST_SUITE_UUID="%s"'% str(test_uuid))
-
-                        project_name = self.opts_firmware_global_name if self.opts_firmware_global_name else None
-                        try:
-                            path = build_project(test.source_dir,
-                                                 join(build_dir, test_id),
-                                                 T,
-                                                 toolchain,
-                                                 test.dependencies,
-                                                 options=build_project_options,
-                                                 clean=clean_project_options,
-                                                 verbose=self.opts_verbose,
-                                                 name=project_name,
-                                                 macros=MACROS,
-                                                 inc_dirs=INC_DIRS,
-                                                 jobs=self.opts_jobs)
-                        except ToolException:
-                            project_name_str = project_name if project_name is not None else test_id
-                            print self.logger.log_line(self.logger.LogType.ERROR, 'There were errors while building project %s'% (project_name_str))
-                            return test_summary, self.shuffle_random_seed, test_summary_ext, test_suite_properties_ext
-                        if self.opts_only_build_tests:
-                            # With this option we are skipping testing phase
-                            continue
-
-                        # Test duration can be increased by global value
-                        test_duration = test.duration
-                        if self.opts_extend_test_timeout is not None:
-                            test_duration += self.opts_extend_test_timeout
-
-                        # For an automated test the duration act as a timeout after
-                        # which the test gets interrupted
-                        test_spec = self.shape_test_request(target, path, test_id, test_duration)
-                        test_loops = self.get_test_loop_count(test_id)
-
-                        test_suite_properties['test.duration.%s.%s.%s'% (target, toolchain, test_id)] = test_duration
-                        test_suite_properties['test.loops.%s.%s.%s'% (target, toolchain, test_id)] = test_loops
-                        test_suite_properties['test.path.%s.%s.%s'% (target, toolchain, test_id)] = path
-
-                        # read MUTs, test specification and perform tests
-                        single_test_result, detailed_test_results = self.handle(test_spec, target, toolchain, test_loops=test_loops)
-
-                        # Append test results to global test summary
-                        if single_test_result is not None:
-                            test_summary.append(single_test_result)
-
-                        # Prepare extended test results data structure (it can be used to generate detailed test report)
-                        if toolchain not in test_summary_ext:
-                            test_summary_ext[toolchain] = {}  # test_summary_ext : toolchain
-                        if target not in test_summary_ext[toolchain]:
-                            test_summary_ext[toolchain][target] = {}    # test_summary_ext : toolchain : target
-                        if target not in test_summary_ext[toolchain][target]:
-                            test_summary_ext[toolchain][target][test_id] = detailed_test_results    # test_summary_ext : toolchain : target : test_it
-
-                test_suite_properties['skipped'] = ', '.join(test_suite_properties['skipped'])
-                test_suite_properties_ext[target][toolchain] = test_suite_properties
+            for t in execute_threads:
+                q.get() # t.join() would block some threads because we should not wait in any order for thread end
+        else:
+            # Serialized (not parallel) test execution
+            for target, toolchains in self.test_spec['targets'].iteritems():
+                if target not in self.test_suite_properties_ext:
+                    self.test_suite_properties_ext[target] = {}
+                self.execute_thread_slice(q, target, toolchains, clean, test_ids)
+                q.get()
 
         if self.db_logger:
             self.db_logger.reconnect();
@@ -494,7 +533,7 @@ class SingleTestRunner(object):
                 self.db_logger.update_build_id_info(self.db_logger_build_id, _status_fk=self.db_logger.BUILD_ID_STATUS_COMPLETED)
                 self.db_logger.disconnect();
 
-        return test_summary, self.shuffle_random_seed, test_summary_ext, test_suite_properties_ext
+        return self.test_summary, self.shuffle_random_seed, self.test_summary_ext, self.test_suite_properties_ext
 
     def generate_test_summary_by_target(self, test_summary, shuffle_seed=None):
         """ Prints well-formed summary with results (SQL table like)
@@ -625,7 +664,8 @@ class SingleTestRunner(object):
 
     def handle(self, test_spec, target_name, toolchain_name, test_loops=1):
         """ Function determines MUT's mbed disk/port and copies binary to
-            target. Test is being invoked afterwards.
+            target.
+            Test is being invoked afterwards.
         """
         data = json.loads(test_spec)
         # Get test information, image and test timeout
@@ -1571,6 +1611,12 @@ def get_default_test_options_parser():
                       dest="only_build_tests",
                       default=False,
                       help="Only build tests, skips actual test procedures (flashing etc.)")
+
+    parser.add_option('', '--parallel',
+                      dest='parallel_test_exec',
+                      default=False,
+                      action="store_true",
+                      help='Experimental, you execute test runners for connected to your host MUTs in parallel (speeds up test result collection)')
 
     parser.add_option('', '--config',
                       dest='verbose_test_configuration_only',

--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -159,6 +159,7 @@ class SingleTestRunner(object):
                  _opts_shuffle_test_order=False,
                  _opts_shuffle_test_seed=None,
                  _opts_test_by_names=None,
+                 _opts_peripheral_by_names=None,
                  _opts_test_only_peripheral=False,
                  _opts_test_only_common=False,
                  _opts_verbose_skipped_tests=False,
@@ -209,6 +210,7 @@ class SingleTestRunner(object):
         self.opts_shuffle_test_order = _opts_shuffle_test_order
         self.opts_shuffle_test_seed = _opts_shuffle_test_seed
         self.opts_test_by_names = _opts_test_by_names
+        self.opts_peripheral_by_names = _opts_peripheral_by_names
         self.opts_test_only_peripheral = _opts_test_only_peripheral
         self.opts_test_only_common = _opts_test_only_common
         self.opts_verbose_skipped_tests = _opts_verbose_skipped_tests
@@ -257,6 +259,7 @@ class SingleTestRunner(object):
                   "shuffle_test_order" : str(self.opts_shuffle_test_order),
                   "shuffle_test_seed" : str(self.opts_shuffle_test_seed),
                   "test_by_names" :  str(self.opts_test_by_names),
+                  "peripheral_by_names" : str(self.opts_peripheral_by_names),
                   "test_only_peripheral" :  str(self.opts_test_only_peripheral),
                   "test_only_common" :  str(self.opts_test_only_common),
                   "verbose" :  str(self.opts_verbose),
@@ -369,6 +372,13 @@ class SingleTestRunner(object):
                     test_suite_properties['skipped'].append(test_id)
                     continue
 
+                if self.opts_peripheral_by_names and test.peripherals and not len([i for i in test.peripherals if i in self.opts_peripheral_by_names.split(',')]):
+                    # We will skip tests not forced with -p option
+                    if self.opts_verbose_skipped_tests:
+                        print self.logger.log_line(self.logger.LogType.INFO, 'Common test skipped for target %s'% (target))
+                    test_suite_properties['skipped'].append(test_id)
+                    continue
+
                 if self.opts_test_only_common and test.peripherals:
                     if self.opts_verbose_skipped_tests:
                         print self.logger.log_line(self.logger.LogType.INFO, 'Peripheral test skipped for target %s'% (target))
@@ -379,6 +389,10 @@ class SingleTestRunner(object):
                     if test.peripherals is None and self.opts_only_build_tests:
                         # When users are using 'build only flag' and test do not have
                         # specified peripherals we can allow test building by default
+                        pass
+                    elif self.opts_peripheral_by_names and test_id not in self.opts_peripheral_by_names.split(','):
+                        # If we force peripheral with option -p we expect test
+                        # to pass even if peripheral is not in MUTs file.
                         pass
                     elif not self.is_peripherals_available(target, test.peripherals):
                         if self.opts_verbose_skipped_tests:
@@ -952,7 +966,7 @@ class SingleTestRunner(object):
         return (result, "".join(output), testcase_duration, duration)
 
     def is_peripherals_available(self, target_mcu_name, peripherals=None):
-        """ Checks if specified target should run specific peripheral test case
+        """ Checks if specified target should run specific peripheral test case defined in MUTs file
         """
         if peripherals is not None:
             peripherals = set(peripherals)
@@ -970,7 +984,7 @@ class SingleTestRunner(object):
         return False
 
     def shape_test_request(self, mcu, image_path, test_id, duration=10):
-        """ Function prepares JOSN structure describing test specification
+        """ Function prepares JSON structure describing test specification
         """
         test_spec = {
             "mcu": mcu,
@@ -1547,7 +1561,11 @@ def get_default_test_options_parser():
 
     parser.add_option('-n', '--test-by-names',
                       dest='test_by_names',
-                      help='Runs only test enumerated it this switch')
+                      help='Runs only test enumerated it this switch. Use comma to separate test case names.')
+
+    parser.add_option('-p', '--peripheral-by-names',
+                      dest='peripheral_by_names',
+                      help='Forces discovery of particular peripherals. Use comma to separate peripheral names.')
 
     copy_methods = host_tests_plugins.get_plugin_caps('CopyMethod')
     copy_methods_str = "Plugin support: " + ', '.join(copy_methods)


### PR DESCRIPTION
# Description
Added new experimental feature: thread model for function ```SingleTest::execute()``` where for each target we have separate thread.

Currently we are only building in parallel mbed SDK and libraries with dependencies.
Each unique MUT (mbed under test) is flashed separately one by one, but with this new feature we are able to flash multiple boards at the same time, run test case on hardware and get results in parallel.

Test execution time is reduced by ```n``` where ```n``` is number of MUTs (MUT: mbed under test).

## Rationale & limitations
We can experiment with usage of ```--auto``` and CI systems. Assuming that we are performing testing on ```n``` unique mbed platforms we can gain almost ```n``` folt test execution acceleration by flashing, executing and grabbing test results from each board at the same time.

Note: this extension works also with ```--auto``` feature added by non-public (yet) ```mbed-ls``` auto-detection module.

Note: Building still will take some time so we are not accelerating building process which already is accelerated by multi-core compilation feature (```-j``` switch). You can combine ```-j``` and ```--parallel``` to really messw ith your CPUs silicone ;-)

Note: We want to explore new testing possibilities with existing test suite before we enable them for mbed 3.0 test suite.

# Usage
To test in parallel with old sytle of configuration:
```
$ singletest.py singletest.py -i test_spec.json -M muts_all.json --parallel
```

To test only detected by ```mbed-ls``` boards.
```
$ singletest.py --auto --tc ARM,GCC_ARM --parallel
```
## Limitations
For now if we connect two boards of the same type, for example two Freedom K46F boards to our system test suite (```singletest.py```) will assume that we are testing only for one of the targets. Mbed-ls feeds ```singletest.py``` with information about all targets but as above only one board of the same type will be tested.
**This limitation will be removed in future versions of test suite***.

Using ```--parallel``` means that:
* separate thread will be spawned to build mbed SDK and dependencied (libraries)
	for each unique target with all declared toolchains.
	E.g:
```
		Thread(n==1):	LPC1768:	ARM, uARM, GCC_ARM
		Thread(n==2):	K64F:		ARM, GCC_ARM
		Thread(n==3):	NUCLEO_X:	uARM
		Thread(n==4):	NUCLEO_Y:	uARM
		Thread(n==5):	NUCLEO_Z:	uARM
```

	Example:
	n == 5 if 5 types of MUTs connected to host computer:
		E.g. LPC1768, K64F, NUCLEO_X, NUCLEO_Y, NUCLEO_Z.

	Thread model for n == 5
```
	Thread(1): for toolchain in LPC1768[toolchains]
	           -> build mbed SDK
				-> build libs
				 -> build project
				  -> run MUT testrunner
				  	return test results for LPC1768[toolchain]
	.
	.
	.
	Thread(4): for toolchain in NUCLEO_Z[toolchains]
	           -> build mbed SDK
				-> build libs
				 -> build project
				  -> run MUT testrunner
					return test results for NUCLEO_Z[toolchain]
```

Done:
1. Added option --parallel.
2. Decoupled execute function so it can be run in parallel with other execute functions.
3. Thread join via Queue, not Thread::Join() to avoid deadlocks or waits for particular thread to finish.
4. All builds are in parallel, but because each target and library for each toolchain have different directory we do not worry about building in parallel and compiler collisions.

Missing:
1. No sync for 'print' (TODO).
2. No sync on test result structures - not needed because we only append to them (?).

# Testing
### Test MUTs configuration
Configuration, 4 boards; three Nucleo flavors and one Freedom K64F:
```
$ mbedls
+--------------+------------+------------+-------------------------+
|platform_name |mount_point |serial_port |target_id                |
+--------------+------------+------------+-------------------------+
|K64F          |E:          |COM61       |02400203D94B0E7724B7F3CF |
|NUCLEO_F072RB |H:          |COM84       |073002006230631A5D55F517 |
|NUCLEO_F302R8 |G:          |COM34       |07050200623B61125D5EF72A |
|NUCLEO_F401RE |F:          |COM52       |07200200073E650A385BF317 |
+--------------+------------+------------+-------------------------+
```

Building stuff first so when I execute parallel tests I do not build stuff (I want to see parallel testing velocity without build time constrains).
Note: ```singletes.py``` will still check if mbed SDK and dependencies should be rebuilt but this will be also done when non-parallel test execution is invoked.
```
$ singletest.py --auto -O
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected K64F, port: COM61, mounted: E:
MBEDLS: Detected NUCLEO_F401RE, port: COM52, mounted: F:
MBEDLS: Detected NUCLEO_F302R8, port: COM34, mounted: G:
MBEDLS: Detected NUCLEO_F072RB, port: COM84, mounted: H:
Building library CMSIS (K64F, ARM)
Building library MBED (K64F, ARM)
Building project DETECT (K64F, ARM)
.
.
.
Building project ECHO (NUCLEO_F072RB, uARM)
Building project BUS_OUT (NUCLEO_F072RB, uARM)
Completed in 7.39 sec
```
```
$ singletest.py --auto --config
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected K64F, port: COM61, mounted: E:
MBEDLS: Detected NUCLEO_F401RE, port: COM52, mounted: F:
MBEDLS: Detected NUCLEO_F302R8, port: COM34, mounted: G:
MBEDLS: Detected NUCLEO_F072RB, port: COM84, mounted: H:
MUTs configuration in auto-detected:
+-------+-------------+---------------+------+-------+
| index | peripherals | mcu           | disk | port  |
+-------+-------------+---------------+------+-------+
| 1     |             | K64F          | E:   | COM61 |
| 2     |             | NUCLEO_F401RE | F:   | COM52 |
| 3     |             | NUCLEO_F302R8 | G:   | COM34 |
| 4     |             | NUCLEO_F072RB | H:   | COM84 |
+-------+-------------+---------------+------+-------+

Test specification in auto-detected:
+---------------+-----+------+
| mcu           | ARM | uARM |
+---------------+-----+------+
| K64F          | Yes | -    |
| NUCLEO_F401RE | -   | Yes  |
| NUCLEO_F302R8 | -   | Yes  |
| NUCLEO_F072RB | -   | Yes  |
+---------------+-----+------+
```
### Parallel test execution
```
$ singletest.py --auto --parallel
.
.
Result: 2 FAIL / 70 OK

Completed in 305.16 sec
```
### Non-parallel test execution
```
$ singletest.py --auto
.
.
Result: 2 FAIL / 70 OK

Completed in 695.88 sec
```
### Measurement: Parallel vs non-parallel
| Test scenario |  Board count     | Time (sec)  |
| ------------- |:---------------- | -----------:|
| Parallel      | 4 boards         |  305.16 sec |
| Non-parallel  | 4 boards         |  695.88 sec |
| Non-parallel  | 1 board (K64F)   |  304.17 sec |
| Non-parallel  | 1 board (NUCLEO) |  123.44 sec |

#### Execution in parallel (threaded model with --parallel) scheme:
Note: K64F execution is far longer that any Nucleo board, so total time of parallel execution equals to longest test execution streak. In this case it is about 305.16 sec (where 304.17 sec is K64F test execution length):
```
# +---------------+>
# | NUCLEO_F401RE |> 123.44 sec 
# +---------------+>

# +---------------+>
# | NUCLEO_F401RE |> 123.44 sec
# +---------------+>
 
# +---------------+>
# | NUCLEO_F401RE |> 123.44 sec
# +---------------+>
 
# +------------------------------+>
# |             K64F             |> 304.17 sec
# +------------------------------+>

# ------------- time axis (sec) -------------->
```
#### Non-parallel execution scheme
Non-parallel execution just takes approximately sum of times for each platform to be executed.
* Measured execution time: 695.88 sec.
* Sum of test execution times per tested board (3 * 123.44 sec + 304.17 sec) = 674.49 sec. 
  * which gives around 21.3 sec for test suite non-parallel code.
```
# +---------------+>
# | NUCLEO_F401RE |> 123.44 sec 
# +---------------+>

#                  +---------------+>
#                  | NUCLEO_F401RE |> 123.44 sec
#                  +---------------+>
 
#                                  +---------------+>
#                                  | NUCLEO_F401RE |> 123.44 sec
#                                  +---------------+>
 
#                                                  +-- ~ ------ ~ --+>
#                                                  |   ~  K64F  ~   |> 304.17 sec
#                                                  +-- ~ ------ ~ --+>

# -------------------------- time axis (sec) -------------------------->
```
