### PR TITLE
Added to option --auto handler for -f <mcu> filter switch. 

### DIFF
--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -154,11 +154,13 @@ if __name__ == '__main__':
         use_default_toolchain = 'default' in opts.toolchains_filter.split(',') if opts.toolchains_filter is not None else True
         use_supported_toolchains = 'all' in opts.toolchains_filter.split(',') if opts.toolchains_filter is not None else False
         toolchain_filter = opts.toolchains_filter
+        platform_name_filter = opts.general_filter_regex.split(',') if opts.general_filter_regex is not None else opts.general_filter_regex
         # Test specification with information about each target and associated toolchain
         test_spec = get_autodetected_TEST_SPEC(muts_list,
                                                use_default_toolchain=use_default_toolchain,
                                                use_supported_toolchains=use_supported_toolchains,
-                                               toolchain_filter=toolchain_filter)
+                                               toolchain_filter=toolchain_filter,
+                                               platform_name_filter=platform_name_filter)
         # MUTs configuration auto-detection
         MUTs = get_autodetected_MUTS(muts_list)
     else:

--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -85,7 +85,7 @@ def get_version():
     """ Returns test script version
     """
     single_test_version_major = 1
-    single_test_version_minor = 3
+    single_test_version_minor = 4
     return (single_test_version_major, single_test_version_minor)
 
 


### PR DESCRIPTION
Description
========
Now using ```-f``` switch will filter target platforms to test when you use for example auto-detection (```--auto``` option). Use comma to pass more MCU names to ```-f``` filter.
You can't apply regular expression on names, only give full platform name!

For system connected with two boards: ```NUCLEO_L053R8``` and ```KL25Z``` we can check configuration (using switch ```--config```):
We can see both boards are detected and we will test both of them if test suite will be executed without ```-O``` or ```--config``` option.
```
$ singletest.py --auto --config
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected NUCLEO_L053R8, port: COM35, mounted: E:
MBEDLS: Detected KL25Z, port: COM89, mounted: F:
MUTs configuration in auto-detected:
+-------+-------------+---------------+------+-------+
| index | peripherals | mcu           | disk | port  |
+-------+-------------+---------------+------+-------+
| 1     |             | NUCLEO_L053R8 | E:   | COM35 |
| 2     |             | KL25Z         | F:   | COM89 |
+-------+-------------+---------------+------+-------+

Test specification in auto-detected:
+---------------+-----+------+
| mcu           | ARM | uARM |
+---------------+-----+------+
| KL25Z         | Yes | -    |
| NUCLEO_L053R8 | -   | Yes  |
+---------------+-----+------+
```

Building original configuration (no filter):
```
$ singletest.py --auto -j 8 -O
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected NUCLEO_L053R8, port: COM35, mounted: E:
MBEDLS: Detected KL25Z, port: COM89, mounted: F:
Building library CMSIS (KL25Z, ARM)
Building library MBED (KL25Z, ARM)
Building project DETECT (KL25Z, ARM)
.
.
.
Building library CMSIS (NUCLEO_L053R8, uARM)
Building library MBED (NUCLEO_L053R8, uARM)
Building project DETECT (NUCLEO_L053R8, uARM)
.
.
.
Completed in 3.68 sec
```

Filtering out other boards and checking configuration, leaving KL25Z:
```
$ singletest.py --auto -j 8 -O -f KL25Z --config
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected NUCLEO_L053R8, port: COM35, mounted: E:
MBEDLS: Detected KL25Z, port: COM89, mounted: F:
MUTs configuration in auto-detected:
+-------+-------------+-------+------+-------+
| index | peripherals | mcu   | disk | port  |
+-------+-------------+-------+------+-------+
| 2     |             | KL25Z | F:   | COM89 |
+-------+-------------+-------+------+-------+

Test specification in auto-detected:
+-------+-----+
| mcu   | ARM |
+-------+-----+
| KL25Z | Yes |
+-------+-----+
```

Building original configuration (with applied filter):
```
$ singletest.py --auto -j 8 -O -f KL25Z
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected NUCLEO_L053R8, port: COM35, mounted: E:
MBEDLS: Detected KL25Z, port: COM89, mounted: F:
Building library CMSIS (KL25Z, ARM)
Building library MBED (KL25Z, ARM)
Building project DETECT (KL25Z, ARM)
.
.
.
Completed in 1.33 sec
```