### PR TITLE
[HRM1017] Fix the incorrect softdevice path.

### DIFF
--- a/workspace_tools/export/gcc_arm_hrm1017.tmpl
+++ b/workspace_tools/export/gcc_arm_hrm1017.tmpl
@@ -9,7 +9,7 @@ INCLUDE_PATHS = {% for p in include_paths %}-I{{p}} {% endfor %}
 LIBRARY_PATHS = {% for p in library_paths %}-L{{p}} {% endfor %}
 LIBRARIES = {% for lib in libraries %}-l{{lib}} {% endfor %}
 LINKER_SCRIPT = {{linker_script}}
-SOFTDEVICE = mbed/TARGET_ARCH_BLE/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/s110_nrf51822_7_0_0/s110_nrf51822_7.0.0_softdevice.hex
+SOFTDEVICE = mbed/TARGET_HRM1017/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/s110_nrf51822_7_1_0/s110_nrf51822_7.1.0_softdevice.hex
 
 ###############################################################################
 AS      = $(GCC_BIN)arm-none-eabi-as


### PR DESCRIPTION
explora26@i5-GA-H77:/tmp/BLE_iBeacon$ make merge 
srec_cat mbed/TARGET_ARCH_BLE/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/s110_nrf51822_7_0_0/s110_nrf51822_7.0.0_softdevice.hex -intel BLE_iBeacon.hex -intel -o combined.hex -intel --line-length=44
srec_cat:
    mbed/TARGET_ARCH_BLE/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/s110_nrf51822_7_0_0/s110_nrf51822_7.0.0_softdevice.hex:
    open: No such file or directory
make: *** [merge] Error 1

The softdevice path is incorrect