### PR TITLE
Nucleo F103RB - gpio_is_connected method readdition

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_NUCLEO_F103RB/gpio_object.h
@@ -64,6 +64,10 @@ static inline int gpio_read(gpio_t *obj)
     return ((*obj->reg_in & obj->mask) ? 1 : 0);
 }
 
+static inline int gpio_is_connected(const gpio_t *obj) {
+    return obj->pin != (PinName)NC;
+}
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
This should fix busIn/Out test