### PR TITLE
Added macros to alias the endpoint callback functions to support configurability

### DIFF
--- a/libraries/USBDevice/USBAudio/USBAudio.cpp
+++ b/libraries/USBDevice/USBAudio/USBAudio.cpp
@@ -119,7 +119,7 @@ float USBAudio::getVolume() {
 }
 
 
-bool USBAudio::EP3_OUT_callback() {
+bool USBAudio::EPISO_OUT_callback() {
     uint32_t size = 0;
     interruptOUT = true;
     if (buf_stream_in != NULL) {
@@ -132,7 +132,7 @@ bool USBAudio::EP3_OUT_callback() {
 }
 
 
-bool USBAudio::EP3_IN_callback() {
+bool USBAudio::EPISO_IN_callback() {
     interruptIN = true;
     writeIN = true;
     return true;

--- a/libraries/USBDevice/USBAudio/USBAudio.h
+++ b/libraries/USBDevice/USBAudio/USBAudio.h
@@ -216,12 +216,12 @@ protected:
     /*
     * Callback called when a packet is received
     */
-    virtual bool EP3_OUT_callback();
+    virtual bool EPISO_OUT_callback();
 
     /*
     * Callback called when a packet has been sent
     */
-    virtual bool EP3_IN_callback();
+    virtual bool EPISO_IN_callback();
 
 private:
 

--- a/libraries/USBDevice/USBDevice/USBEndpoints_KL25Z.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints_KL25Z.h
@@ -81,12 +81,18 @@
 /* Bulk endpoints */
 #define EPBULK_OUT  (EP2OUT)
 #define EPBULK_IN   (EP2IN)
+#define EPBULK_OUT_callback   EP2_OUT_callback
+#define EPBULK_IN_callback    EP2_IN_callback
 /* Interrupt endpoints */
 #define EPINT_OUT   (EP1OUT)
 #define EPINT_IN    (EP1IN)
+#define EPINT_OUT_callback    EP1_OUT_callback
+#define EPINT_IN_callback     EP1_IN_callback
 /* Isochronous endpoints */
 #define EPISO_OUT   (EP3OUT)
 #define EPISO_IN    (EP3IN)
+#define EPISO_OUT_callback    EP3_OUT_callback
+#define EPISO_IN_callback     EP3_IN_callback
 
 #define MAX_PACKET_SIZE_EPBULK  (MAX_PACKET_SIZE_EP2)
 #define MAX_PACKET_SIZE_EPINT   (MAX_PACKET_SIZE_EP1)

--- a/libraries/USBDevice/USBDevice/USBEndpoints_LPC11U.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints_LPC11U.h
@@ -53,12 +53,18 @@
 /* Bulk endpoint */
 #define EPBULK_OUT  (EP2OUT)
 #define EPBULK_IN   (EP2IN)
+#define EPBULK_OUT_callback   EP2_OUT_callback
+#define EPBULK_IN_callback    EP2_IN_callback
 /* Interrupt endpoint */
 #define EPINT_OUT   (EP1OUT)
 #define EPINT_IN    (EP1IN)
+#define EPINT_OUT_callback    EP1_OUT_callback
+#define EPINT_IN_callback     EP1_IN_callback
 /* Isochronous endpoint */
 #define EPISO_OUT   (EP3OUT)
 #define EPISO_IN    (EP3IN)
+#define EPISO_OUT_callback    EP3_OUT_callback
+#define EPISO_IN_callback     EP3_IN_callback
 
 #define MAX_PACKET_SIZE_EPBULK  (MAX_PACKET_SIZE_EP2)
 #define MAX_PACKET_SIZE_EPINT   (MAX_PACKET_SIZE_EP1)

--- a/libraries/USBDevice/USBDevice/USBEndpoints_LPC17_LPC23.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints_LPC17_LPC23.h
@@ -81,12 +81,18 @@
 /* Bulk endpoints */
 #define EPBULK_OUT  (EP2OUT)
 #define EPBULK_IN   (EP2IN)
+#define EPBULK_OUT_callback   EP2_OUT_callback
+#define EPBULK_IN_callback    EP2_IN_callback
 /* Interrupt endpoints */
 #define EPINT_OUT   (EP1OUT)
 #define EPINT_IN    (EP1IN)
+#define EPINT_OUT_callback    EP1_OUT_callback
+#define EPINT_IN_callback     EP1_IN_callback
 /* Isochronous endpoints */
 #define EPISO_OUT   (EP3OUT)
 #define EPISO_IN    (EP3IN)
+#define EPISO_OUT_callback    EP3_OUT_callback
+#define EPISO_IN_callback     EP3_IN_callback
 
 #define MAX_PACKET_SIZE_EPBULK  (MAX_PACKET_SIZE_EP2)
 #define MAX_PACKET_SIZE_EPINT   (MAX_PACKET_SIZE_EP1)

--- a/libraries/USBDevice/USBDevice/USBEndpoints_RZ_A1H.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints_RZ_A1H.h
@@ -65,12 +65,18 @@
 /* Bulk endpoints */
 #define EPBULK_OUT  (EP2OUT)
 #define EPBULK_IN   (EP2IN)
+#define EPBULK_OUT_callback   EP2_OUT_callback
+#define EPBULK_IN_callback    EP2_IN_callback
 /* Interrupt endpoints */
 #define EPINT_OUT   (EP1OUT)
 #define EPINT_IN    (EP1IN)
+#define EPINT_OUT_callback    EP1_OUT_callback
+#define EPINT_IN_callback     EP1_IN_callback
 /* Isochronous endpoints */
 #define EPISO_OUT   (EP3OUT)
 #define EPISO_IN    (EP3IN)
+#define EPISO_OUT_callback    EP3_OUT_callback
+#define EPISO_IN_callback     EP3_IN_callback
 
 #define MAX_PACKET_SIZE_EPBULK  (MAX_PACKET_SIZE_EP2)
 #define MAX_PACKET_SIZE_EPINT   (MAX_PACKET_SIZE_EP1)

--- a/libraries/USBDevice/USBDevice/USBEndpoints_STM32F4.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints_STM32F4.h
@@ -49,12 +49,18 @@
 /* Bulk endpoint */
 #define EPBULK_OUT  (EP2OUT)
 #define EPBULK_IN   (EP2IN)
+#define EPBULK_OUT_callback   EP2_OUT_callback
+#define EPBULK_IN_callback    EP2_IN_callback
 /* Interrupt endpoint */
 #define EPINT_OUT   (EP1OUT)
 #define EPINT_IN    (EP1IN)
+#define EPINT_OUT_callback    EP1_OUT_callback
+#define EPINT_IN_callback     EP1_IN_callback
 /* Isochronous endpoint */
 #define EPISO_OUT   (EP3OUT)
 #define EPISO_IN    (EP3IN)
+#define EPISO_OUT_callback    EP3_OUT_callback
+#define EPISO_IN_callback     EP3_IN_callback
 
 #define MAX_PACKET_SIZE_EPBULK  (MAX_PACKET_SIZE_EP2)
 #define MAX_PACKET_SIZE_EPINT   (MAX_PACKET_SIZE_EP1)

--- a/libraries/USBDevice/USBHID/USBKeyboard.cpp
+++ b/libraries/USBDevice/USBHID/USBKeyboard.cpp
@@ -420,7 +420,7 @@ uint8_t * USBKeyboard::reportDesc() {
 }
 
 
-bool USBKeyboard::EP1_OUT_callback() {
+bool USBKeyboard::EPINT_OUT_callback() {
     uint32_t bytesRead = 0;
     uint8_t led[65];
     USBDevice::readEP(EPINT_OUT, led, &bytesRead, MAX_HID_REPORT_SIZE);

--- a/libraries/USBDevice/USBHID/USBKeyboard.h
+++ b/libraries/USBDevice/USBHID/USBKeyboard.h
@@ -150,7 +150,7 @@ public:
     *
     * @returns if handle by subclass, return true
     */
-    virtual bool EP1_OUT_callback();
+    virtual bool EPINT_OUT_callback();
 
     /**
     * Read status of lock keys. Useful to switch-on/off leds according to key pressed. Only the first three bits of the result is important:

--- a/libraries/USBDevice/USBHID/USBMouseKeyboard.cpp
+++ b/libraries/USBDevice/USBHID/USBMouseKeyboard.cpp
@@ -548,7 +548,7 @@ uint8_t * USBMouseKeyboard::reportDesc() {
     return NULL;
 }
 
-bool USBMouseKeyboard::EP1_OUT_callback() {
+bool USBMouseKeyboard::EPINT_OUT_callback() {
     uint32_t bytesRead = 0;
     uint8_t led[65];
     USBDevice::readEP(EPINT_OUT, led, &bytesRead, MAX_HID_REPORT_SIZE);

--- a/libraries/USBDevice/USBHID/USBMouseKeyboard.h
+++ b/libraries/USBDevice/USBHID/USBMouseKeyboard.h
@@ -202,7 +202,7 @@ class USBMouseKeyboard: public USBHID, public Stream
         *
         * @returns if handle by subclass, return true
         */
-        virtual bool EP1_OUT_callback();
+        virtual bool EPINT_OUT_callback();
 
 
     private:

--- a/libraries/USBDevice/USBMIDI/USBMIDI.cpp
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.cpp
@@ -35,7 +35,7 @@ void USBMIDI::attach(void (*fptr)(MIDIMessage)) {
 }
 
 
-bool USBMIDI::EP2_OUT_callback() {
+bool USBMIDI::EPBULK_OUT_callback() {
     uint8_t buf[64];
     uint32_t len;
     readEP(EPBULK_OUT, buf, &len, 64);

--- a/libraries/USBDevice/USBMIDI/USBMIDI.h
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.h
@@ -78,7 +78,7 @@ public:
 
 
 protected:
-    virtual bool EP2_OUT_callback();
+    virtual bool EPBULK_OUT_callback();
     virtual bool USBCallback_setConfiguration(uint8_t configuration);
     /*
     * Get string product descriptor

--- a/libraries/USBDevice/USBMSD/USBMSD.cpp
+++ b/libraries/USBDevice/USBMSD/USBMSD.cpp
@@ -147,7 +147,7 @@ void USBMSD::reset() {
 
 
 // Called in ISR context called when a data is received
-bool USBMSD::EP2_OUT_callback() {
+bool USBMSD::EPBULK_OUT_callback() {
     uint32_t size = 0;
     uint8_t buf[MAX_PACKET_SIZE_EPBULK];
     readEP(EPBULK_OUT, buf, &size, MAX_PACKET_SIZE_EPBULK);
@@ -184,7 +184,7 @@ bool USBMSD::EP2_OUT_callback() {
 }
 
 // Called in ISR context when a data has been transferred
-bool USBMSD::EP2_IN_callback() {
+bool USBMSD::EPBULK_IN_callback() {
     switch (stage) {
 
             // the device has to send data to the host

--- a/libraries/USBDevice/USBMSD/USBMSD.h
+++ b/libraries/USBDevice/USBMSD/USBMSD.h
@@ -158,12 +158,12 @@ protected:
     /*
     * Callback called when a packet is received
     */
-    virtual bool EP2_OUT_callback();
+    virtual bool EPBULK_OUT_callback();
 
     /*
     * Callback called when a packet has been sent
     */
-    virtual bool EP2_IN_callback();
+    virtual bool EPBULK_IN_callback();
 
     /*
     * Set configuration of device. Add endpoints

--- a/libraries/USBDevice/USBSerial/USBSerial.cpp
+++ b/libraries/USBDevice/USBSerial/USBSerial.cpp
@@ -46,7 +46,7 @@ bool USBSerial::writeBlock(uint8_t * buf, uint16_t size) {
 
 
 
-bool USBSerial::EP2_OUT_callback() {
+bool USBSerial::EPBULK_OUT_callback() {
     uint8_t c[65];
     uint32_t size = 0;
 

--- a/libraries/USBDevice/USBSerial/USBSerial.h
+++ b/libraries/USBDevice/USBSerial/USBSerial.h
@@ -145,7 +145,7 @@ public:
     }
 
 protected:
-    virtual bool EP2_OUT_callback();
+    virtual bool EPBULK_OUT_callback();
     virtual void lineCodingChanged(int baud, int bits, int parity, int stop){
         if (settingsChangedCallback) {
             settingsChangedCallback(baud, bits, parity, stop);


### PR DESCRIPTION
Macros exist in each of the USBEndpoints_<target>.h files for assigning default endpoints for bulk, interrupt and isochronous functions. These macros are used by the various device classes. The callback functions in the classes, however, are hard coded to specific endpoint numbers. I have added additional macros to alias the callback functions to ensure that they match the assigned endpoints for a given target.

All currently supported USBDevice targets have used the same endpoint assignments, so no problem has arisen. We are currently working on adding a new target in which the endpoint assignments will be different from the other targets and encountered this issue.