### PR TITLE
Added timeouts (delays) on serial port and mounting point

### DIFF
--- a/workspace_tools/host_tests/host_tests_plugins/host_test_plugins.py
+++ b/workspace_tools/host_tests/host_tests_plugins/host_test_plugins.py
@@ -15,6 +15,9 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
+from os import access, F_OK
+from sys import stdout
+from time import sleep
 from subprocess import call
 
 
@@ -57,6 +60,34 @@ class HostTestPluginBase:
         """
         print "Plugin error: %s::%s: %s"% (self.name, self.type, text)
         return False
+
+    def print_plugin_info(self, text, NL=True):
+        """ Function prints notification in console and exits always with True
+        """
+        if NL:
+            print "Plugin info: %s::%s: %s"% (self.name, self.type, text)
+        else:
+            print "Plugin info: %s::%s: %s"% (self.name, self.type, text),
+        return True
+
+    def print_plugin_char(self, char):
+        """ Function prints char on stdout
+        """
+        stdout.write(char)
+        stdout.flush()
+        return True
+
+    def check_mount_point_ready(self, destination_disk, init_delay=0.2, loop_delay=0.25):
+        """ Checks if destination_disk is ready and can be accessed by e.g. copy commands
+            @init_delay - Initial delay time before first access check
+            @loop_delay - pooling delay for access check
+        """
+        if not access(destination_disk, F_OK):
+            self.print_plugin_info("Waiting for mount point '%s' to be ready..."% destination_disk, NL=False)
+            sleep(init_delay)
+            while not access(destination_disk, F_OK):
+                sleep(loop_delay)
+                self.print_plugin_char('.')
 
     def check_parameters(self, capabilitity, *args, **kwargs):
         """ This function should be ran each time we call execute()

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
@@ -59,6 +59,8 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
             if capabilitity == 'default':
                 image_path = kwargs['image_path']
                 destination_disk = kwargs['destination_disk']
+                # Wait for mount point to be ready
+                self.check_mount_point_ready(destination_disk)  # Blocking
                 result = self.generic_mbed_copy(image_path, destination_disk)
         return result
 

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
@@ -42,6 +42,8 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
         if self.check_parameters(capabilitity, *args, **kwargs) is True:
             image_path = kwargs['image_path']
             destination_disk = kwargs['destination_disk']
+            # Wait for mount point to be ready
+            self.check_mount_point_ready(destination_disk)  # Blocking
             # Prepare correct command line parameter values
             image_base_name = basename(image_path)
             destination_path = join(destination_disk, image_base_name)


### PR DESCRIPTION
# Description
* Added timeouts (delays) on serial port and mounting point accesses in host_test and copy plugins to prevent serial/disk I/O errors when device remounts USB iface of interface chip.
* Also some Freedom boards (KL25Z, KL46Z) can cause re-mounting issues when (experimental) parallel test execution is turn on option ```--parallel```.
This implementation hopefully solves both problems.
# Rationale
There was a problem with U-BLOX interface chip which is re-mounting and causing serial / mount point I/O when test suite is executed.
See here: http://developer.mbed.org/questions/6743/singletestpy-need-wait-between-end-of-co

Fix is adding pooling for serial port and mount point so we are only flashing and reading from serial when both are available (when accessing).

# Usage:
```
$ singletest.py -i test_spec.json -M muts_all.json  --global-loops 3 -W
```
or (only when mbed-ls is installed)
```
$ singletest.py --auto --global-loops 3 -W
```
Note: Flags ```--global-loops 3 -W``` added to repeat failing tests up to 3 times.

Results:
```
Test summary:
+---------+------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result  | Target     | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+---------+------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK      | UBLOX_C027 | ARM       | DTCT_1      | Simple detect test                    |        0.58        |       10      |  1/1  |
| OK      | UBLOX_C027 | ARM       | EXAMPLE_1   | /dev/null                             |        3.5         |       20      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_10     | Hello World                           |        0.4         |       5       |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_11     | Ticker Int                            |       11.41        |       15      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_12     | C++                                   |        1.43        |       10      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_16     | RTC                                   |        4.62        |       20      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_2      | stdio                                 |        0.84        |       20      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_23     | Ticker Int us                         |       11.42        |       15      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_24     | Timeout Int us                        |       11.45        |       15      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_25     | Time us                               |       11.61        |       15      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_26     | Integer constant division             |        1.43        |       20      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_34     | Ticker Two callbacks                  |       11.43        |       15      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_A1     | Basic                                 |        1.41        |       20      |  1/1  |
| OK      | UBLOX_C027 | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.48        |       20      |  1/1  |
| TIMEOUT | UBLOX_C027 | ARM       | MBED_A9     | Serial Echo at 115200                 |       40.41        |       20      |  0/3  |
| OK      | UBLOX_C027 | ARM       | MBED_BUSOUT | BusOut                                |        2.36        |       15      |  1/1  |
+---------+------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 15 OK / 1 TIMEOUT

Completed in 283.15 sec
```
## (Experimental) Parallel tests for KL25Z and KL46Z fix:
This pull request should also fix parallel execution for few Freedom Boards (its interface chip also behaves in such a way it remounts USB devices after target reset / flashing).
Note: indeed this pull request fixes this issue, at least in configuration I've set up.
```
$ singletest.py --auto --parallel --global-loops 3 -W
```
```
MBEDLS: Detecting connected mbed-enabled devices...
MBEDLS: Detected KL46Z, port: COM40, mounted: E:
MBEDLS: Detected KL25Z, port: COM89, mounted: F:
Building library CMSIS (KL25Z, ARM)Building library CMSIS (KL46Z, ARM)


Building library MBED (KL46Z, ARM)
Building library MBED (KL25Z, ARM)
Building project DETECT (KL25Z, ARM)
Building project DETECT (KL46Z, ARM)
TargetTest::KL25Z::ARM::DTCT_1::Simple detect test [OK] in 0.51 of 10 sec
Building project DEV_NULL (KL25Z, ARM)
TargetTest::KL46Z::ARM::DTCT_1::Simple detect test [OK] in 0.48 of 10 sec
Building project DEV_NULL (KL46Z, ARM)
TargetTest::KL25Z::ARM::EXAMPLE_1::/dev/null [OK] in 3.50 of 20 sec
Building project I2C_MMA8451Q (KL25Z, ARM)
TargetTest::KL46Z::ARM::EXAMPLE_1::/dev/null [OK] in 3.52 of 20 sec
Building project I2C_MMA8451Q (KL46Z, ARM)
TargetTest::KL25Z::ARM::KL25Z_5::MMA8451Q accelerometer [OK] in 12.54 of 15 sec
Building project HELLO (KL25Z, ARM)
TargetTest::KL46Z::ARM::KL25Z_5::MMA8451Q accelerometer [FAIL] in 12.54 of 15 sec
TargetTest::KL25Z::ARM::MBED_10::Hello World [OK] in 0.39 of 5 sec
Building project TICKER (KL25Z, ARM)
TargetTest::KL46Z::ARM::KL25Z_5::MMA8451Q accelerometer [FAIL] in 12.55 of 15 sec
TargetTest::KL25Z::ARM::MBED_11::Ticker Int [OK] in 11.38 of 15 sec
Building project CPP (KL25Z, ARM)
TargetTest::KL25Z::ARM::MBED_12::C++ [OK] in 1.39 of 10 sec
Building project RTC (KL25Z, ARM)
TargetTest::KL46Z::ARM::KL25Z_5::MMA8451Q accelerometer [FAIL] in 12.55 of 15 sec
Building project HELLO (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_16::RTC [OK] in 4.59 of 20 sec
Building project STDIO (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_10::Hello World [OK] in 0.39 of 5 sec
Building project TICKER (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_2::stdio [OK] in 0.74 of 20 sec
Building project TICKER_2 (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_11::Ticker Int [OK] in 11.36 of 15 sec
Building project CPP (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_23::Ticker Int us [OK] in 11.36 of 15 sec
Building project TIMEOUT (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_12::C++ [OK] in 1.36 of 10 sec
Building project RTC (KL46Z, ARM)
TargetTest::KL46Z::ARM::MBED_16::RTC [OK] in 4.58 of 20 sec
Building project STDIO (KL46Z, ARM)
TargetTest::KL46Z::ARM::MBED_2::stdio [OK] in 0.79 of 20 sec
Building project TICKER_2 (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_24::Timeout Int us [FAIL] in 14.62 of 15 sec
TargetTest::KL46Z::ARM::MBED_23::Ticker Int us [OK] in 11.39 of 15 sec
Building project TIMEOUT (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_24::Timeout Int us [OK] in 11.59 of 15 sec
Building project TIME_US (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_24::Timeout Int us [OK] in 11.59 of 15 sec
Building project TIME_US (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_25::Time us [OK] in 11.38 of 15 sec
Building project DIV (KL25Z, ARM)
TargetTest::KL25Z::ARM::MBED_26::Integer constant division [OK] in 1.40 of 20 sec
Building project TICKER_3 (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_25::Time us [OK] in 11.39 of 15 sec
Building project DIV (KL46Z, ARM)
TargetTest::KL46Z::ARM::MBED_26::Integer constant division [OK] in 1.40 of 20 sec
Building project TICKER_3 (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_34::Ticker Two callbacks [OK] in 11.36 of 15 sec
Building project BASIC (KL25Z, ARM)
TargetTest::KL25Z::ARM::MBED_A1::Basic [OK] in 1.36 of 20 sec
Building project CALL_BEFORE_MAIN (KL25Z, ARM)
TargetTest::KL25Z::ARM::MBED_A21::Call function before main (mbed_main) [OK] in 1.44 of 20 sec
Building project ECHO (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_34::Ticker Two callbacks [OK] in 11.36 of 15 sec
Building project BASIC (KL46Z, ARM)
TargetTest::KL46Z::ARM::MBED_A1::Basic [OK] in 1.35 of 20 sec
Building project CALL_BEFORE_MAIN (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_A9::Serial Echo at 115200 [OK] in 6.34 of 20 sec
Building project BUS_OUT (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_A21::Call function before main (mbed_main) [OK] in 1.45 of 20 sec
Building project ECHO (KL46Z, ARM)
TargetTest::KL25Z::ARM::MBED_BUSOUT::BusOut [OK] in 2.30 of 15 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project BASIC (KL25Z, ARM)
TargetTest::KL46Z::ARM::MBED_A9::Serial Echo at 115200 [OK] in 6.34 of 20 sec
Building project BUS_OUT (KL46Z, ARM)
TargetTest::KL46Z::ARM::MBED_BUSOUT::BusOut [OK] in 2.32 of 15 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project BASIC (KL46Z, ARM)
TargetTest::KL25Z::ARM::RTOS_1::Basic thread [OK] in 11.37 of 15 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project MUTEX (KL25Z, ARM)
TargetTest::KL46Z::ARM::RTOS_1::Basic thread [OK] in 11.39 of 15 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project MUTEX (KL46Z, ARM)
TargetTest::KL25Z::ARM::RTOS_2::Mutex resource lock [OK] in 11.56 of 20 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project SEMAPHORE (KL25Z, ARM)
TargetTest::KL25Z::ARM::RTOS_3::Semaphore resource lock [OK] in 8.49 of 20 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project SIGNALS (KL25Z, ARM)
TargetTest::KL46Z::ARM::RTOS_2::Mutex resource lock [OK] in 11.49 of 20 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project SEMAPHORE (KL46Z, ARM)
TargetTest::KL25Z::ARM::RTOS_4::Signals messaging [OK] in 6.44 of 20 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project QUEUE (KL25Z, ARM)
TargetTest::KL46Z::ARM::RTOS_3::Semaphore resource lock [OK] in 8.49 of 20 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project SIGNALS (KL46Z, ARM)
TargetTest::KL25Z::ARM::RTOS_5::Queue messaging [OK] in 2.41 of 20 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project MAIL (KL25Z, ARM)
TargetTest::KL46Z::ARM::RTOS_4::Signals messaging [OK] in 6.45 of 20 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project QUEUE (KL46Z, ARM)
TargetTest::KL25Z::ARM::RTOS_6::Mail messaging [OK] in 2.41 of 20 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project TIMER (KL25Z, ARM)
TargetTest::KL46Z::ARM::RTOS_5::Queue messaging [OK] in 2.41 of 20 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project MAIL (KL46Z, ARM)
TargetTest::KL46Z::ARM::RTOS_6::Mail messaging [OK] in 2.40 of 20 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project TIMER (KL46Z, ARM)
TargetTest::KL25Z::ARM::RTOS_7::Timer [OK] in 11.37 of 15 sec
Building library RTX (KL25Z, ARM)
Building library RTOS (KL25Z, ARM)
Building project ISR (KL25Z, ARM)
TargetTest::KL25Z::ARM::RTOS_8::ISR (Queue) [OK] in 6.45 of 20 sec
TargetTest::KL46Z::ARM::RTOS_7::Timer [OK] in 11.37 of 15 sec
Building library RTX (KL46Z, ARM)
Building library RTOS (KL46Z, ARM)
Building project ISR (KL46Z, ARM)
TargetTest::KL46Z::ARM::RTOS_8::ISR (Queue) [OK] in 6.45 of 20 sec
Test summary:
+--------+--------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result | Target | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+--------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK     | KL25Z  | ARM       | DTCT_1      | Simple detect test                    |        0.51        |       10      |  1/1  |
| OK     | KL46Z  | ARM       | DTCT_1      | Simple detect test                    |        0.48        |       10      |  1/1  |
| OK     | KL25Z  | ARM       | EXAMPLE_1   | /dev/null                             |        3.5         |       20      |  1/1  |
| OK     | KL46Z  | ARM       | EXAMPLE_1   | /dev/null                             |        3.52        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | KL25Z_5     | MMA8451Q accelerometer                |       12.54        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_10     | Hello World                           |        0.39        |       5       |  1/1  |
| OK     | KL25Z  | ARM       | MBED_11     | Ticker Int                            |       11.38        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_12     | C++                                   |        1.39        |       10      |  1/1  |
| FAIL   | KL46Z  | ARM       | KL25Z_5     | MMA8451Q accelerometer                |       12.55        |       15      |  0/3  |
| OK     | KL25Z  | ARM       | MBED_16     | RTC                                   |        4.59        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_10     | Hello World                           |        0.39        |       5       |  1/1  |
| OK     | KL25Z  | ARM       | MBED_2      | stdio                                 |        0.74        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_11     | Ticker Int                            |       11.36        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_23     | Ticker Int us                         |       11.36        |       15      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_12     | C++                                   |        1.36        |       10      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_16     | RTC                                   |        4.58        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_2      | stdio                                 |        0.79        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_23     | Ticker Int us                         |       11.39        |       15      |  1/1  |
| FAIL   | KL25Z  | ARM       | MBED_24     | Timeout Int us                        |       11.59        |       15      |  1/2  |
| OK     | KL46Z  | ARM       | MBED_24     | Timeout Int us                        |       11.59        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_25     | Time us                               |       11.38        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_26     | Integer constant division             |        1.4         |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_25     | Time us                               |       11.39        |       15      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_26     | Integer constant division             |        1.4         |       20      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_34     | Ticker Two callbacks                  |       11.36        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_A1     | Basic                                 |        1.36        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.44        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_34     | Ticker Two callbacks                  |       11.36        |       15      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_A1     | Basic                                 |        1.35        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_A9     | Serial Echo at 115200                 |        6.34        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.45        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | MBED_BUSOUT | BusOut                                |        2.3         |       15      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_A9     | Serial Echo at 115200                 |        6.34        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | MBED_BUSOUT | BusOut                                |        2.32        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_1      | Basic thread                          |       11.37        |       15      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_1      | Basic thread                          |       11.39        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_2      | Mutex resource lock                   |       11.56        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_3      | Semaphore resource lock               |        8.49        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_2      | Mutex resource lock                   |       11.49        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_4      | Signals messaging                     |        6.44        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_3      | Semaphore resource lock               |        8.49        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_5      | Queue messaging                       |        2.41        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_4      | Signals messaging                     |        6.45        |       20      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_6      | Mail messaging                        |        2.41        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_5      | Queue messaging                       |        2.41        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_6      | Mail messaging                        |        2.4         |       20      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_7      | Timer                                 |       11.37        |       15      |  1/1  |
| OK     | KL25Z  | ARM       | RTOS_8      | ISR (Queue)                           |        6.45        |       20      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_7      | Timer                                 |       11.37        |       15      |  1/1  |
| OK     | KL46Z  | ARM       | RTOS_8      | ISR (Queue)                           |        6.45        |       20      |  1/1  |
+--------+--------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 2 FAIL / 48 OK

Completed in 342.10 sec
```