### PR TITLE
Vector table must be 256 aligned

### DIFF
--- a/libraries/tests/mbed/vtor_reloc/main.cpp
+++ b/libraries/tests/mbed/vtor_reloc/main.cpp
@@ -14,7 +14,7 @@ DigitalOut out(PIN_OUT);
 DigitalOut myled(LED1);
 
 volatile int checks = 0;
-uint32_t int_table[NUM_VECTORS];
+uint32_t int_table[NUM_VECTORS] __attribute__ ((aligned(256)));
 
 #define FALLING_EDGE_COUNT 5
 


### PR DESCRIPTION
The vector table must be 256 aligned to work reliably, it must have been working by accident up to now.  This modification tested on a u-blox c027 board.  Without the change the value of `SCB->VTOR` and the location of `int_table` just before the call to `test_once()` in the second part of the test are as follows:

`SCB->VTOR 0x10000280, int_table 0x100002a0`

...and obviously the test fails.  With the change they are as follows:

`SCB->VTOR 0x10000400, int_table 0x10000400`

...and the test passes.

See issue:

https://github.com/mbedmicro/mbed/issues/993