### PR TITLE
[RTOS] Add workaround for internal fault

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
@@ -2066,6 +2066,10 @@ osStatus osMailPut (osMailQId queue_id, void *mail) {
   return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0);
 }
 
+#ifdef __arm__
+#pragma push
+#pragma Ospace
+#endif // __arm__
 /// Get a mail from a queue
 os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
   osEvent ret;
@@ -2080,3 +2084,6 @@ os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
 
   return ret;
 }
+#ifdef __arm__
+#pragma pop
+#endif // __arm__

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -1862,6 +1862,10 @@ osStatus osMailPut (osMailQId queue_id, void *mail) {
   return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0);
 }
 
+#ifdef __arm__
+#pragma push
+#pragma Ospace
+#endif // __arm__
 /// Get a mail from a queue
 os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
   osEvent ret;
@@ -1876,3 +1880,6 @@ os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
 
   return ret;
 }
+#ifdef __arm__
+#pragma pop
+#endif // __arm__


### PR DESCRIPTION
* Add #pragma Ospace to prevent internal fault of armcc 5.04 and 5.05
* Reported by
http://developer.mbed.org/questions/5003/Compiling-latest-github-with-ARM-DS5-fai/