### PR TITLE
Add LPC11U68 support in Sleep test case

### DIFF
--- a/libraries/tests/mbed/sleep/main.cpp
+++ b/libraries/tests/mbed/sleep/main.cpp
@@ -4,6 +4,8 @@
 InterruptIn wkp(P2_10);
 #elif defined(TARGET_K22F)
 InterruptIn wkp(D0);
+#elif defined(TARGET_LPC11U68)
+InterruptIn wkp(P0_16);
 #else
 InterruptIn wkp(p14);
 #endif
@@ -13,6 +15,9 @@ void flip() {
 }
 
 int main() {
+#if defined(TARGET_LPC11U68)
+    wkp.mode(PullUp);
+#endif
     wkp.rise(&flip);
 
     while (true) {

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -368,7 +368,7 @@ TESTS = [
         "source_dir": join(TEST_DIR, "mbed", "sleep"),
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
         "duration": 30,
-        "mcu": ["LPC1768", "LPC11U24", "LPC4088","LPC4088_DM","NRF51822"]
+        "mcu": ["LPC1768", "LPC11U24", "LPC4088","LPC4088_DM","NRF51822", "LPC11U68"]
     },
     {
         "id": "MBED_5", "description": "PWM",


### PR DESCRIPTION
- Add LPC11U68 target in MBED_4 test case
- Add wakeup pin for LPC11U68 target and set PullUp mode