### PR TITLE
[RTOS] fix compilation warning

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
@@ -2066,7 +2066,7 @@ osStatus osMailPut (osMailQId queue_id, void *mail) {
   return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0);
 }
 
-#ifdef __arm__
+#ifdef __CC_ARM
 #pragma push
 #pragma Ospace
 #endif // __arm__
@@ -2084,6 +2084,6 @@ os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
 
   return ret;
 }
-#ifdef __arm__
+#ifdef __CC_ARM
 #pragma pop
 #endif // __arm__

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -1862,7 +1862,7 @@ osStatus osMailPut (osMailQId queue_id, void *mail) {
   return osMessagePut(*((void **)queue_id), (uint32_t)mail, 0);
 }
 
-#ifdef __arm__
+#ifdef __CC_ARM
 #pragma push
 #pragma Ospace
 #endif // __arm__
@@ -1880,6 +1880,6 @@ os_InRegs osEvent osMailGet (osMailQId queue_id, uint32_t millisec) {
 
   return ret;
 }
-#ifdef __arm__
+#ifdef __CC_ARM
 #pragma pop
 #endif // __arm__


### PR DESCRIPTION
pragma push/pop/Ospace are only supported by ARM compiler. Change
predefined marco from __arm__ to __CC_ARM. Warning messages are
shown as below.

[Warning] rt_CMSIS.c@1867: 1866:0: warning: ignoring #pragma push
[-Wunknown-pragmas] ignoring #pragma Ospace  [-Wunknown-pragmas]
[Warning] rt_CMSIS.c@1884: 1866:0: warning: ignoring #pragma push
[-Wunknown-pragmas] ignoring #pragma pop  [-Wunknown-pragmas]

Change-Id: Ife657b710d694449b30dc4b3150cd49c883fc080
Signed-off-by: Jun-Ru Chang <jrjang@gmail.com>