### PR TITLE
HW SSEL Support for SPI API

### DIFF
--- a/libraries/mbed/api/SPI.h
+++ b/libraries/mbed/api/SPI.h
@@ -37,10 +37,21 @@ namespace mbed {
  *
  * #include "mbed.h"
  *
+ * // hardware ssel (where applicable)
+ * //SPI device(p5, p6, p7, p8); // mosi, miso, sclk, ssel
+ *
+ * // software ssel
  * SPI device(p5, p6, p7); // mosi, miso, sclk
+ * DigitalOut cs(p8); // ssel
  *
  * int main() {
+ *     // hardware ssel (where applicable)
+ *     //int response = device.write(0xFF);
+ *
+ *     // software ssel
+ *     cs = 0;
  *     int response = device.write(0xFF);
+ *     cs = 1;
  * }
  * @endcode
  */
@@ -50,16 +61,14 @@ public:
 
     /** Create a SPI master connected to the specified pins
      *
-     * Pin Options:
-     *  (5, 6, 7) or (11, 12, 13)
-     *
      *  mosi or miso can be specfied as NC if not used
      *
      *  @param mosi SPI Master Out, Slave In pin
      *  @param miso SPI Master In, Slave Out pin
      *  @param sclk SPI Clock pin
+     *  @param ssel SPI chip select pin
      */
-    SPI(PinName mosi, PinName miso, PinName sclk, PinName _unused=NC);
+    SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel=NC);
 
     /** Configure the data transmission format
      *

--- a/libraries/mbed/api/SPISlave.h
+++ b/libraries/mbed/api/SPISlave.h
@@ -54,16 +54,12 @@ public:
 
     /** Create a SPI slave connected to the specified pins
      *
-     * Pin Options:
-     *  (5, 6, 7i, 8) or (11, 12, 13, 14)
-     *
      *  mosi or miso can be specfied as NC if not used
      *
      *  @param mosi SPI Master Out, Slave In pin
      *  @param miso SPI Master In, Slave Out pin
      *  @param sclk SPI Clock pin
      *  @param ssel SPI chip select pin
-     *  @param name (optional) A string to identify the object
      */
     SPISlave(PinName mosi, PinName miso, PinName sclk, PinName ssel);
 

--- a/libraries/mbed/common/SPI.cpp
+++ b/libraries/mbed/common/SPI.cpp
@@ -19,12 +19,12 @@
 
 namespace mbed {
 
-SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName _unused) :
+SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
         _spi(),
         _bits(8),
         _mode(0),
         _hz(1000000) {
-    spi_init(&_spi, mosi, miso, sclk, NC);
+    spi_init(&_spi, mosi, miso, sclk, ssel);
     spi_format(&_spi, _bits, _mode, 0);
     spi_frequency(&_spi, _hz);
 }

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20XX/spi_api.c
@@ -41,14 +41,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->MCR &= ~(SPI_MCR_MDIS_MASK | SPI_MCR_HALT_MASK);
     //obj->spi->MCR |= SPI_MCR_DIS_RXF_MASK | SPI_MCR_DIS_TXF_MASK;
 
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
     // not halt in the debug mode
     obj->spi->SR |= SPI_SR_EOQF_MASK;
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL05Z/spi_api.c
@@ -60,14 +60,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
           break;
     }
 
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
     // enable SPI
     obj->spi->C1 |= SPI_C1_SPE_MASK;
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL25Z/spi_api.c
@@ -40,14 +40,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_1: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 23; break;
     }
 
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
     // enable SPI
     obj->spi->C1 |= SPI_C1_SPE_MASK;
 

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL43Z/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL43Z/spi_api.c
@@ -81,14 +81,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_1: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 23; break;
     }
 
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
     // enable SPI
     obj->spi->C1 |= SPI_C1_SPE_MASK;
     obj->spi->C2 &= ~SPI_C2_SPIMODE_MASK; //8bit

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/spi_api.c
@@ -98,14 +98,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_1: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 23; break;
     }
 
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
     // enable SPI
     obj->spi->C1 |= SPI_C1_SPE_MASK;
     obj->spi->C2 &= ~SPI_C2_SPIMODE_MASK; //8bit

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.c
@@ -43,14 +43,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     uint32_t spi_address[] = SPI_BASE_ADDRS;
     DSPI_HAL_Init(spi_address[obj->instance]);
     DSPI_HAL_Disable(spi_address[obj->instance]);
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
     DSPI_HAL_SetDelay(spi_address[obj->instance], kDspiCtar0, 0, 0, kDspiPcsToSck);
-    spi_frequency(obj, 1000000);
 
     DSPI_HAL_Enable(spi_address[obj->instance]);
     DSPI_HAL_StartTransfer(spi_address[obj->instance]);

--- a/libraries/mbed/targets/hal/TARGET_Maxim/TARGET_MAX32610/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Maxim/TARGET_MAX32610/spi_api.c
@@ -88,10 +88,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->gen_ctrl = (MXC_F_SPI_GEN_CTRL_SPI_MSTR_EN |
                           MXC_F_SPI_GEN_CTRL_TX_FIFO_EN |
                           MXC_F_SPI_GEN_CTRL_RX_FIFO_EN );
-
-    // Give instance the default settings
-    spi_format(obj, DEFAULT_CHAR, DEFAULT_MODE, 0);
-    spi_frequency(obj, DEFAULT_FREQ);
 }
 
 //******************************************************************************

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/spi_api.c
@@ -85,17 +85,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             break;
     }
     
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
-    
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/spi_api.c
@@ -50,17 +50,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             break;
     }
     
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
-    
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/spi_api.c
@@ -87,17 +87,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             break;
     }
     
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
-    
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC13XX/spi_api.c
@@ -79,17 +79,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             break;
     }
     
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
-    
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/spi_api.c
@@ -158,17 +158,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     LPC_SYSCON->SYSAHBCLKCTRL1 |=  (0x1 << (obj->spi_n + 9));
     LPC_SYSCON->PRESETCTRL1    |=  (0x1 << (obj->spi_n + 9));
     LPC_SYSCON->PRESETCTRL1    &= ~(0x1 << (obj->spi_n + 9));
-
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
-    // enable the spi channel
-    spi_enable(obj);
 }
 
 void spi_free(spi_t *obj)

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/spi_api.c
@@ -72,17 +72,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_0: LPC_SC->PCONP |= 1 << 21; break;
         case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
     }
-    
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
 
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC23XX/spi_api.c
@@ -73,17 +73,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_1: LPC_SC->PCONP |= 1 << 10; break;
     }
     
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
-    
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/spi_api.c
@@ -93,17 +93,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_2: LPC_SC->PCONP |= 1 << 20; break;
     }
     
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
-    
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/spi_api.c
@@ -73,17 +73,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_2: LPC_SC->PCONP |= 1 << 20; break;
     }
 
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
-    // enable the ssp channel
-    ssp_enable(obj);
-
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/spi_api.c
@@ -91,17 +91,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
         case SPI_0: LPC_CGU->BASE_CLK[CLK_BASE_SSP0] = (1 << 11) | (CLKIN_MAINPLL << 24); break;
         case SPI_1: LPC_CGU->BASE_CLK[CLK_BASE_SSP1] = (1 << 11) | (CLKIN_MAINPLL << 24); break;
     }
-
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
     
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/spi_api.c
@@ -100,17 +100,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             LPC_SYSCON->PRESETCTRL |= (0x1<<1);
             break;
     }
-    
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
 }
 
 void spi_free(spi_t *obj) {}

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/spi_api.c
@@ -103,17 +103,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     LPC_SYSCON->PRESETCTRL    &= ~(1 << obj->spi_n);
     LPC_SYSCON->PRESETCTRL    |=  (1 << obj->spi_n);
 
-    // set default format and frequency
-    if (ssel == (PinName)NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
     obj->spi->DLY = 2;             // 2 SPI clock times pre-delay
-
-    // enable the ssp channel
-    spi_enable(obj);
 }
 
 void spi_free(spi_t *obj)

--- a/libraries/mbed/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_RENESAS/TARGET_RZ_A1H/spi_api.c
@@ -96,14 +96,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->spi->SPBFCR = 0xf0;  // and set trigger count: read 1, write 1
     obj->spi->SPBFCR = 0x30;  // and reset buffer
 
-    // set default format and frequency
-    if ((int)ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
     pinmap_pinout(miso, PinMap_SPI_MISO);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F0/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F0/spi_api.c
@@ -100,13 +100,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->pin_sclk = sclk;
     obj->pin_ssel = ssel;
 
-    if (ssel == NC) { // SW NSS Master mode
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -162,13 +160,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else {
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F0/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F0/spi_api.c
@@ -102,9 +102,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/spi_api.c
@@ -100,13 +100,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->pin_sclk = sclk;
     obj->pin_ssel = ssel;
 
-    if (ssel == NC) { // SW NSS Master mode
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -162,13 +160,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else {
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/spi_api.c
@@ -102,9 +102,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3/spi_api.c
@@ -117,9 +117,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3/spi_api.c
@@ -115,13 +115,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->pin_sclk = sclk;
     obj->pin_ssel = ssel;
 
-    if (ssel == NC) { // SW NSS Master mode
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -189,13 +187,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else {
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/spi_api.c
@@ -123,13 +123,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->cpha = SPI_CPHA_1Edge;
     obj->br_presc = SPI_BaudRatePrescaler_256;
 
-    if (ssel == NC) { // Master
-        obj->mode = SPI_Mode_Master;
-        obj->nss = SPI_NSS_Soft;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_Mode_Slave;
-        obj->nss = SPI_NSS_Soft;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -167,13 +165,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_Mode_Master;
-        obj->nss = SPI_NSS_Soft;
-    } else {
-        obj->mode = SPI_Mode_Slave;
-        obj->nss = SPI_NSS_Hard;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3XX/spi_api.c
@@ -125,9 +125,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
@@ -117,13 +117,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->pin_sclk = sclk;
     obj->pin_ssel = ssel;
 
-    if (ssel == NC) { // SW NSS Master mode
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -201,13 +199,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else {
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
@@ -119,9 +119,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/spi_api.c
@@ -92,18 +92,6 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
             RCC->APB1ENR |= RCC_APB1ENR_SPI3EN;
             break;
     }
-    
-
-    // set default format and frequency
-    if (ssel == NC) {
-        spi_format(obj, 8, 0, 0);  // 8 bits, mode 0, master
-    } else {
-        spi_format(obj, 8, 0, 1);  // 8 bits, mode 0, slave
-    }
-    spi_frequency(obj, 1000000);
-    
-    // enable the ssp channel
-    ssp_enable(obj);
 
     // pin out the spi pins
     pinmap_pinout(mosi, PinMap_SPI_MOSI);
@@ -132,6 +120,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave) {
                      ((polarity) ? 1 : 0) << 1 |
                      ((slave) ? 0: 1) << 2 |
                      ((bits == 16) ? 1 : 0) << 11;
+
+    if (slave) {
+        // Use software slave management
+        obj->spi->CR1 |= SPI_CR1_SSM | SPI_CR1_SSI;
+    }
 
     if (obj->spi->SR & SPI_SR_MODF) {
         obj->spi->CR1 = obj->spi->CR1;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4XX/spi_api.c
@@ -99,8 +99,7 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     pinmap_pinout(sclk, PinMap_SPI_SCLK);
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
+    } else {
         // Use software slave management
         obj->spi->CR1 |= SPI_CR1_SSM | SPI_CR1_SSI;
     }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/spi_api.c
@@ -100,13 +100,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->pin_sclk = sclk;
     obj->pin_ssel = ssel;
 
-    if (ssel == NC) { // SW NSS Master mode
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -162,13 +160,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else {
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/spi_api.c
@@ -102,9 +102,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/spi_api.c
@@ -103,13 +103,11 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
     obj->pin_sclk = sclk;
     obj->pin_ssel = ssel;
 
-    if (ssel == NC) { // SW NSS Master mode
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else { // Slave
+    if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    }
+    else {
+         obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);
@@ -171,13 +169,11 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
             break;
     }
 
-    if (slave == 0) {
-        obj->mode = SPI_MODE_MASTER;
-        obj->nss = SPI_NSS_SOFT;
-    } else {
-        obj->mode = SPI_MODE_SLAVE;
-        obj->nss = SPI_NSS_HARD_INPUT;
+    if (obj->nss != SPI_NSS_SOFT) {
+        obj->nss = (slave) ? SPI_NSS_HARD_INPUT : SPI_NSS_HARD_OUTPUT;
     }
+
+    obj->mode = (slave) ? SPI_MODE_SLAVE : SPI_MODE_MASTER;
 
     init_spi(obj);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/spi_api.c
@@ -105,9 +105,8 @@ void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel
 
     if (ssel != NC) {
         pinmap_pinout(ssel, PinMap_SPI_SSEL);
-    }
-    else {
-         obj->nss = SPI_NSS_SOFT;
+    } else {
+        obj->nss = SPI_NSS_SOFT;
     }
 
     init_spi(obj);


### PR DESCRIPTION
There was a lot of duplicate code and unclear use of the spi_init ssel parameter. This looked like 30 copy  & pastes of the logic from the LPC1768 implementation. ssel in spi_init is now clearly (coded, still not documented) to be hw based SS rather than master slave determination. This behavior was derived from the constructor implementation since HAL documentation doesn't exist.

Update SPI API documentation for hardware driven SS. Modify all target spi_api.c implementations. spi_init ssel parameter was used incorrectly to determine master/slave mode rather than enable hardware driven SS (seems to be due to legacy copy paste). Remove duplicate copy paste code of initialization in spi_init that is done by constructor (SPI and SPISlave)