### PR TITLE
Add GCC_CR to LPC824, fixes LPCXpresso exporter

### DIFF
--- a/workspace_tools/build_release.py
+++ b/workspace_tools/build_release.py
@@ -33,7 +33,7 @@ OFFICIAL_MBED_LIBRARY_BUILD = (
     ('ARCH_PRO',     ('ARM', 'GCC_ARM', 'GCC_CR', 'GCC_CS', 'IAR')),
     ('LPC2368',      ('ARM', 'GCC_ARM')),
     ('LPC812',       ('uARM','IAR')),
-    ('LPC824',       ('uARM', 'IAR')),
+    ('LPC824',       ('uARM', 'IAR', 'GCC_CR')),
     ('SSCI824',      ('uARM',)),
     ('LPC1347',      ('ARM','IAR')),
     ('LPC4088',      ('ARM', 'GCC_ARM', 'GCC_CR', 'IAR')),


### PR DESCRIPTION
There is currently an issue when trying to export a program for the LPC824 using the LPCXpresso toolchain. The toolchain relies on GCC_CR, so this is being added to the build release list.