### PR TITLE
Add SysEx to USBMIDI device

### DIFF
--- a/libraries/USBDevice/USBMIDI/MIDIMessage.h
+++ b/libraries/USBDevice/USBMIDI/MIDIMessage.h
@@ -174,6 +174,16 @@ public:
         return ControlChange(123, 0, channel);
     }
 
+     /** Create a SysEx message
+     * @param data SysEx data (including 0xF0 .. 0xF7)
+     * @param len SysEx data length
+     * @returns A MIDIMessage
+     */
+    static MIDIMessage SysEx(uint8_t *data, int len) {
+        MIDIMessage msg=MIDIMessage(data,len);
+        return msg;
+    }
+
     // decode messages
 
     /** MIDI Message Types */

--- a/libraries/USBDevice/USBMIDI/USBMIDI.cpp
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.cpp
@@ -31,10 +31,10 @@ void USBMIDI::write(MIDIMessage m) {
     for(int p=1; p < m.length; p+=3) {
         uint8_t buf[4];
         // Midi message to USBMidi event packet
-        buf[0]=m.data[p] >> 4;
+        buf[0]=m.data[1] >> 4;
         // SysEx
         if(buf[0] == 0xF) {
-            if(p < m.length-1) {
+            if((m.length - p) > 3) {
                 // SysEx start or continue
                 buf[0]=0x4;
             } else {
@@ -55,8 +55,16 @@ void USBMIDI::write(MIDIMessage m) {
             }
         }
         buf[1]=m.data[p];
-        buf[2]=m.data[p+1];
-        buf[3]=m.data[p+2];
+
+        if(p+1 < m.length)
+            buf[2]=m.data[p+1];
+        else
+            buf[2]=0;
+
+        if(p+2 < m.length)
+            buf[3]=m.data[p+2];
+        else
+            buf[3]=0;
 
         USBDevice::write(EPBULK_IN, buf, 4, MAX_PACKET_SIZE_EPBULK);
     }

--- a/libraries/USBDevice/USBMIDI/USBMIDI.cpp
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.cpp
@@ -25,8 +25,41 @@ USBMIDI::USBMIDI(uint16_t vendor_id, uint16_t product_id, uint16_t product_relea
     USBDevice::connect();
 }
 
+// write plain MIDIMessage that will be converted to USBMidi event packet
 void USBMIDI::write(MIDIMessage m) {
-    USBDevice::write(EPBULK_IN, m.data, 4, MAX_PACKET_SIZE_EPBULK);
+    // first byte keeped for retro-compatibility
+    for(int p=1; p < m.length; p+=3) {
+        uint8_t buf[4];
+        // Midi message to USBMidi event packet
+        buf[0]=m.data[p] >> 4;
+        // SysEx
+        if(buf[0] == 0xF) {
+            if(p < m.length-1) {
+                // SysEx start or continue
+                buf[0]=0x4;
+            } else {
+                switch(m.length - p) {
+                    case 1:
+                        // SysEx end with one byte
+                        buf[0]=0x5;
+                        break;
+                    case 2:
+                        // SysEx end with two bytes
+                        buf[0]=0x6;
+                        break;
+                    case 3:
+                        // SysEx end with three bytes
+                        buf[0]=0x7;
+                        break;
+                }
+            }
+        }
+        buf[1]=m.data[p];
+        buf[2]=m.data[p+1];
+        buf[3]=m.data[p+2];
+
+        USBDevice::write(EPBULK_IN, buf, 4, MAX_PACKET_SIZE_EPBULK);
+    }
 }
 
 
@@ -34,24 +67,67 @@ void USBMIDI::attach(void (*fptr)(MIDIMessage)) {
     midi_evt = fptr;
 }
 
-
 bool USBMIDI::EPBULK_OUT_callback() {
     uint8_t buf[64];
     uint32_t len;
     readEP(EPBULK_OUT, buf, &len, 64);
 
     if (midi_evt != NULL) {
-        for (uint32_t i=0; i<len; i+=4) {
-            midi_evt(MIDIMessage(buf+i));
-        }
+        for (uint32_t i=0; i<len; i+=4) {   
+            uint8_t data_read;
+            data_end=true;
+            switch(buf[i]) {
+            case 0x2:
+                // Two-bytes System Common Message - undefined in USBMidi 1.0
+                data_read=2;
+                break;
+            case 0x4:
+                // SysEx start or continue
+                data_end=false;
+                data_read=3;
+                break;
+            case 0x5:
+                 // Single-byte System Common Message or SysEx end with one byte
+                data_read=1;
+                break;
+            case 0x6:
+                // SysEx end with two bytes
+                data_read=2;
+                break;
+            case 0xC:
+                // Program change
+                data_read=2;
+                break;
+            case 0xD:
+                // Channel pressure
+                data_read=2;
+                break;      
+            case 0xF:
+                // Single byte
+                data_read=1;
+                break;    
+            default:
+                // Others three-bytes messages
+                data_read=3;
+                break;      
+            } 
+        
+            for(uint8_t j=1;j<data_read+1;j++) {
+                data[cur_data]=buf[i+j];
+                cur_data++;
+            }
+        
+            if(data_end) {
+                 midi_evt(MIDIMessage(data,cur_data));
+                 cur_data=0;            
+            }
+       }
     }
 
     // We reactivate the endpoint to receive next characters
     readStart(EPBULK_OUT, MAX_PACKET_SIZE_EPBULK);
     return true;
 }
-
-
 
 // Called in ISR context
 // Set configuration. Return false if the

--- a/libraries/USBDevice/USBMIDI/USBMIDI.h
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.h
@@ -102,8 +102,11 @@ protected:
     virtual uint8_t * configurationDesc();
 
 private:
+    uint8_t data[MAX_MIDI_MESSAGE_SIZE+1];
+    uint8_t cur_data=0;
+    bool data_end = true;
+    
     void (*midi_evt)(MIDIMessage);
-
 };
 
 #endif

--- a/libraries/tests/usb/device/midi/main.cpp
+++ b/libraries/tests/usb/device/midi/main.cpp
@@ -4,7 +4,70 @@
 USBMIDI midi;
 Serial pc(USBTX, USBRX);
 
+// MIDI IN
+void transmitMessage(MIDIMessage msg) {
+ 	switch (msg.type()) {
+        case MIDIMessage::NoteOnType:
+        	wait(0.1);
+			midi.write(MIDIMessage::NoteOn(msg.key()));
+            break;
+        case MIDIMessage::NoteOffType:
+        	wait(0.1);
+			midi.write(MIDIMessage::NoteOff(msg.key()));
+            break;
+        case MIDIMessage::ProgramChangeType:
+        	wait(0.1);
+        	midi.write(MIDIMessage::ProgramChange(msg.program()));
+            break;
+        case MIDIMessage::SysExType:
+        	wait(0.1);
+        	unsigned char tmp[64];
+            for(int i=0;i<msg.length-1;i++) {
+	            tmp[i]=msg.data[i+1];
+            }
+            midi.write(MIDIMessage::SysEx(tmp,msg.length-1));
+            break;
+        default:
+            break;
+    }    
+}
+
 int main(void)
 {
+	wait(5);
+	// MIDI OUT
+
+	// set piano
+	midi.write(MIDIMessage::ProgramChange(1));
+	wait(0.1);
+
+	// play A
+	midi.write(MIDIMessage::NoteOn(21));
+	wait(0.1);
+	midi.write(MIDIMessage::NoteOff(21));
+	wait(0.1);
+
+	// GM reset
+	unsigned char gm_reset[]={0xF0,0x7E,0x7F,0x09,0x01,0xF7};
+	midi.write(MIDIMessage::SysEx(gm_reset,6));
+	wait(0.1);
+
+	// GM Master volume max
+	unsigned char gm_master_vol_max[]={0xF0,0x7F,0x7F,0x04,0x01,0x7F,0x7F,0xF7};
+	midi.write(MIDIMessage::SysEx(gm_master_vol_max,8));
+	wait(0.1);
+
+	// GS reset
+	unsigned char gs_reset[]={0xF0,0x41,0x10,0x42,0x12,0x40,0x00,0x7F,0x00,0x41,0xF7};
+	midi.write(MIDIMessage::SysEx(gs_reset,11));
+	wait(0.1);
+
+	// GS Master volume max
+	unsigned char gs_master_vol_max[]={0xF0,0x41,0x10,0x42,0x12,0x40,0x00,0x04,0x7F,0x3D,0xF7};
+	midi.write(MIDIMessage::SysEx(gs_master_vol_max,11));
+	wait(0.1);
+
+	midi.attach(transmitMessage);
+
     while(1);
 }

--- a/workspace_tools/host_tests/midi.py
+++ b/workspace_tools/host_tests/midi.py
@@ -1,0 +1,72 @@
+from __future__ import print_function
+import sys
+import re
+import time
+import mido
+from mido import Message
+
+
+def test_midi_in(port):
+	expected_messages_count=0
+	while expected_messages_count < 7:
+		for message in port.iter_pending():
+			if message.type in ('note_on', 'note_off', 'program_change', 'sysex'):
+				yield message
+				expected_messages_count+=1
+		time.sleep(0.1)
+
+def test_midi_loopback(input_port):
+	expected_messages_count=0
+	while expected_messages_count < 1:
+		for message in input_port.iter_pending():
+			print('Test MIDI OUT loopback received {}'.format(message.hex()))
+			expected_messages_count+=1
+
+def test_midi_out_loopback(output_port,input_port):
+	print("Test MIDI OUT loopback")
+	output_port.send(Message('program_change', program=1))
+	test_midi_loopback(input_port)
+
+	output_port.send(Message('note_on', note=21))
+	test_midi_loopback(input_port)
+
+	output_port.send(Message('note_off', note=21))
+	test_midi_loopback(input_port)
+
+	output_port.send(Message('sysex', data=[0x7E,0x7F,0x09,0x01]))
+	test_midi_loopback(input_port)
+
+	output_port.send(Message('sysex', data=[0x7F,0x7F,0x04,0x01,0x7F,0x7F]))
+	test_midi_loopback(input_port)
+
+	output_port.send(Message('sysex', data=[0x41,0x10,0x42,0x12,0x40,0x00,0x7F,0x00,0x41]))
+	test_midi_loopback(input_port)
+
+	output_port.send(Message('sysex', data=[0x41,0x10,0x42,0x12,0x40,0x00,0x04,0x7F,0x3D]))
+	test_midi_loopback(input_port)
+
+portname=""
+
+while portname=="":
+	print("Wait for MIDI IN plug ...")
+	for name in mido.get_input_names():
+		matchObj = re.match( r'Mbed', name)
+
+		if matchObj:
+			portname=name
+	time.sleep( 1 )
+
+try:
+	input_port = mido.open_input(portname)
+	output_port = mido.open_output(portname)
+	
+	print('Using {}'.format(input_port))
+
+	print("Test MIDI IN")
+
+	for message in test_midi_in(input_port):
+		print('Test MIDI IN received {}'.format(message.hex()))
+
+	test_midi_out_loopback(output_port,input_port)
+except KeyboardInterrupt:
+    pass


### PR DESCRIPTION
USBMIDI support was incomplete, SysEx support was missing. This PR add SysEx, with some refactoring to manage MIDI messages > 3 bytes and USB MIDI multiple packets.