### PR TITLE
Added copying of library files.

### DIFF
--- a/workspace_tools/build_api.py
+++ b/workspace_tools/build_api.py
@@ -234,7 +234,7 @@ def build_mbed_libs(target, toolchain_name, options=None, verbose=False, clean=F
     # Target specific sources
     HAL_SRC = join(MBED_TARGETS_PATH, "hal")
     hal_implementation = toolchain.scan_resources(HAL_SRC)
-    toolchain.copy_files(hal_implementation.headers + hal_implementation.hex_files, BUILD_TARGET, HAL_SRC)
+    toolchain.copy_files(hal_implementation.headers + hal_implementation.hex_files + hal_implementation.libraries, BUILD_TARGET, HAL_SRC)
     incdirs = toolchain.scan_resources(BUILD_TARGET).inc_dirs
     objects = toolchain.compile_sources(hal_implementation, TMP_PATH, [MBED_LIBRARIES] + incdirs)
 


### PR DESCRIPTION
Our MAXWSNENV platform will include the BLE stack as a prebuilt library. This change is necessary to include the library files in the mbed build.