### PR TITLE
Replaced SPI pin definitions for K64F in SD tests

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,8 @@ You can for example read more in our ```docs``` section in [mbedmicro/mbed/doc](
 # How to contribute
 We really appreciate your contributions! We are Open Source project and we need your help. We want to keep it as easy as possible to contribute changes that get things working in your environment. There are a few guidelines that we need contributors to follow so that we can have a chance of keeping on top of things.
 
+Before a pull request will be merged, the [mbed Contributor Agreement](http://developer.mbed.org/contributor_agreement/) must be signed.
+
 You can pick up existing [mbed GitHub Issue](https://github.com/mbedmicro/mbed/issues) and solve it or implement new feature you find important, attractive or just necessary. We will review your proposal via pull request mechanism, give you comments and merge your changes if we decide your contribution satisfy criteria such as quality.
 
 # Enhancements vs Bugs

--- a/libraries/tests/mbed/sd/main.cpp
+++ b/libraries/tests/mbed/sd/main.cpp
@@ -9,7 +9,7 @@ SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F)
-SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
+SDFileSystem sd(PTE3, PTE1, PTE2, PTE4, "sd");
 
 #elif defined(TARGET_K22F)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");

--- a/libraries/tests/mbed/sd_perf_fatfs/main.cpp
+++ b/libraries/tests/mbed/sd_perf_fatfs/main.cpp
@@ -11,7 +11,7 @@ SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F)
-SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
+SDFileSystem sd(PTE3, PTE1, PTE2, PTE4, "sd");
 
 #elif defined(TARGET_K22F)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");

--- a/libraries/tests/mbed/sd_perf_fhandle/main.cpp
+++ b/libraries/tests/mbed/sd_perf_fhandle/main.cpp
@@ -11,7 +11,7 @@ SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F)
-SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
+SDFileSystem sd(PTE3, PTE1, PTE2, PTE4, "sd");
 
 #elif defined(TARGET_K22F)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");

--- a/libraries/tests/mbed/sd_perf_stdio/main.cpp
+++ b/libraries/tests/mbed/sd_perf_stdio/main.cpp
@@ -11,7 +11,7 @@ SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");
 
 #elif defined(TARGET_K64F)
-SDFileSystem sd(PTD2, PTD3, PTD1, PTD0, "sd");
+SDFileSystem sd(PTE3, PTE1, PTE2, PTE4, "sd");
 
 #elif defined(TARGET_K22F)
 SDFileSystem sd(PTD6, PTD7, PTD5, PTD4, "sd");


### PR DESCRIPTION
The old pin definitions were all for Port D pins, which are incorrect. These improper pin mappings caused all tests to fail.

Pin definitions were replaced with the definitions as stated here -
http://developer.mbed.org/media/uploads/sam_grove/xk64f_sensors.jpg.pagespeed.ic.RCpM8talCK.webp

Tests now pass on the K64F Sch Rev D1