### PR TITLE
[NXP's HAL] Fix PwmOut period using SCT

### DIFF
--- a/libraries/USBDevice/USBMIDI/MIDIMessage.h
+++ b/libraries/USBDevice/USBMIDI/MIDIMessage.h
@@ -44,9 +44,9 @@
 /** A MIDI message container */
 class MIDIMessage {
 public:
-    MIDIMessage() {}
+    MIDIMessage() : length(4) {}
 
-    MIDIMessage(uint8_t *buf) {
+    MIDIMessage(uint8_t *buf) : length(4) {
         for (int i = 0; i < 4; i++)
             data[i] = buf[i];
     }
@@ -270,7 +270,7 @@ public:
     }
 
     uint8_t data[MAX_MIDI_MESSAGE_SIZE+1];
-    uint8_t length=4;
+    uint8_t length;
 };
 
 #endif

--- a/libraries/USBDevice/USBMIDI/USBMIDI.cpp
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.cpp
@@ -20,7 +20,9 @@
 #include "USBMIDI.h"
 
 
-USBMIDI::USBMIDI(uint16_t vendor_id, uint16_t product_id, uint16_t product_release): USBDevice(vendor_id, product_id, product_release) {
+USBMIDI::USBMIDI(uint16_t vendor_id, uint16_t product_id, uint16_t product_release)
+ : USBDevice(vendor_id, product_id, product_release), cur_data(0), data_end(true)
+{
     midi_evt = NULL;
     USBDevice::connect();
 }

--- a/libraries/USBDevice/USBMIDI/USBMIDI.h
+++ b/libraries/USBDevice/USBMIDI/USBMIDI.h
@@ -103,8 +103,8 @@ protected:
 
 private:
     uint8_t data[MAX_MIDI_MESSAGE_SIZE+1];
-    uint8_t cur_data=0;
-    bool data_end = true;
+    uint8_t cur_data;
+    bool data_end;
     
     void (*midi_evt)(MIDIMessage);
 };

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/pwmout_api.c
@@ -77,9 +77,8 @@ void pwmout_init(pwmout_t* obj, PinName pin) {
     pinmap_pinout(pin, PinMap_PWM);
     LPC_SCT0_Type* pwm = obj->pwm;
     
-    // Two 16-bit counters, autolimit
-    pwm->CONFIG &= ~(0x1);
-    pwm->CONFIG |= (1 << 17);
+    // Unified 32-bit counter, autolimit
+    pwm->CONFIG |= ((0x3 << 17) | 0x01);
     
     // halt and clear the counter
     pwm->CTRL |= (1 << 2) | (1 << 3);
@@ -170,8 +169,8 @@ void pwmout_period_us(pwmout_t* obj, int us) {
     uint32_t t_off = obj->pwm->MATCHREL0;
     uint32_t t_on  = obj->pwm->MATCHREL1;
     float v = (float)t_on/(float)t_off;
-    obj->pwm->MATCHREL0 = (uint64_t)us;
-    obj->pwm->MATCHREL1 = (uint64_t)((float)us * (float)v);
+    obj->pwm->MATCHREL0 = (uint32_t)us;
+    obj->pwm->MATCHREL1 = (uint32_t)((float)us * (float)v);
 }
 
 void pwmout_pulsewidth(pwmout_t* obj, float seconds) {
@@ -183,7 +182,7 @@ void pwmout_pulsewidth_ms(pwmout_t* obj, int ms) {
 }
 
 void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
-    obj->pwm->MATCHREL1 = (uint64_t)us;
+    obj->pwm->MATCHREL1 = (uint32_t)us;
 }
 
 #endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/pwmout_api.c
@@ -48,7 +48,7 @@ void pwmout_init(pwmout_t* obj, PinName pin)
     obj->pwm =  (LPC_SCT_Type*)LPC_SCT;
     obj->pwm_ch = sct_n;
 
-   LPC_SCT_Type* pwm = obj->pwm;
+    LPC_SCT_Type* pwm = obj->pwm;
 
     // Enable the SCT clock
     LPC_SYSCON->SYSAHBCLKCTRL |= (1 << 8);
@@ -81,9 +81,8 @@ void pwmout_init(pwmout_t* obj, PinName pin)
             break;
     }
 
-    // Two 16-bit counters, autolimit
-    pwm->CONFIG &= ~(0x1);
-    pwm->CONFIG |= (1 << 17);
+    // Unified 32-bit counter, autolimit
+    pwm->CONFIG |= ((0x3 << 17) | 0x01);
 
     // halt and clear the counter
     pwm->CTRL |= (1 << 2) | (1 << 3);
@@ -151,8 +150,8 @@ void pwmout_period_us(pwmout_t* obj, int us)
     uint32_t t_off = obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 0];
     uint32_t t_on  = obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 1];
     float v = (float)t_on/(float)t_off;
-    obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 0] = (uint64_t)us;
-    obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 1] = (uint64_t)((float)us * (float)v);
+    obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 0] = (uint32_t)us;
+    obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 1] = (uint32_t)((float)us * (float)v);
 }
 
 void pwmout_pulsewidth(pwmout_t* obj, float seconds)
@@ -167,7 +166,7 @@ void pwmout_pulsewidth_ms(pwmout_t* obj, int ms)
 
 void pwmout_pulsewidth_us(pwmout_t* obj, int us)
 {
-    obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 1] = (uint64_t)us;
+    obj->pwm->MATCHREL[(obj->pwm_ch * 2) + 1] = (uint32_t)us;
 }
 
 #endif


### PR DESCRIPTION
* Some targets which use SCT timer for PwmOut have a bug: PWM
signal does not come out when period is set more than 65536us. (issue #1050)
* Fix SCT counter mode from 16-bit Low to 32-bit Unified mode
* Fix wrong cast size (uint64_t) for 32-bit register
* Some TABs convert to white spaces
* Affected with LPC812, LPC824, LPC1549 and LPC11U68