### PR TITLE
Fixed GCC_ARM toolchain issue and RTOS library support for TEENSY3_1

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/TOOLCHAIN_GCC_ARM/MK20DX256.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/TOOLCHAIN_GCC_ARM/MK20DX256.ld
@@ -42,10 +42,11 @@ SECTIONS
 {
     .isr_vector :
     {
-        __vector_table = .;
-        KEEP(*(.vector_table))
+        . = 0;
+        __isr_vector = .;
+        KEEP(*(.isr_vector))
         *(.text.Reset_Handler)
-        *(.text.System_Init)
+        *(.text.SystemInit)
          . = ALIGN(4);
     } > VECTORS
 

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/TOOLCHAIN_GCC_ARM/startup_MK20DX256.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/TOOLCHAIN_GCC_ARM/startup_MK20DX256.s
@@ -192,6 +192,13 @@ __isr_vector:
     .globl    Reset_Handler
     .type    Reset_Handler, %function
 Reset_Handler:
+/*
+ *    Call SystemInit before loading the .data section to prevent the watchdog
+ *    from resetting the board.
+ */
+    ldr    r0, =SystemInit
+    blx    r0
+
 /*     Loop to copy data from read only memory to RAM. The ranges
  *      of copy from/to are specified by following symbols evaluated in
  *      linker script.
@@ -212,8 +219,6 @@ Reset_Handler:
 
 .Lflash_to_ram_loop_end:
 
-    ldr    r0, =SystemInit
-    blx    r0
     ldr    r0, =_start
     bx    r0
     .pool

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/system_MK20DX256.c
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_K20XX/TARGET_TEENSY3_1/system_MK20DX256.c
@@ -100,6 +100,8 @@ uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
    -- SystemInit()
    ---------------------------------------------------------------------------- */
 void SystemInit (void) {
+  /* SystemInit MUST NOT use any variables from the .data section, as this section is not loaded yet! */
+
 #if (DISABLE_WDOG)
   /* Disable the WDOG module */
   /* WDOG_UNLOCK: WDOGUNLOCK=0xC520 */

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -304,6 +304,9 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif defined(TARGET_MAX32610) || defined(TARGET_MAX32600)
 #define INITIAL_SP            (0x20008000UL)
 
+#elif defined(TARGET_TEENSY3_1)
+#define INITIAL_SP            (0x20008000UL)
+
 #else
 #error "no target defined"
 

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -51,7 +51,7 @@
 #ifndef OS_TASKCNT
 #  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC4088_DM) || defined(TARGET_LPC4330) || defined(TARGET_LPC4337) || defined(TARGET_LPC1347) || defined(TARGET_K64F) || defined(TARGET_STM32F401RE)\
    || defined(TARGET_KL46Z) || defined(TARGET_KL43Z)  || defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) \
-   || defined(TARGET_STM32F411RE) || defined(TARGET_STM32F405RG) || defined(TARGET_K22F) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F401VC) || defined(TARGET_MAX32610) || defined(TARGET_MAX32600)
+   || defined(TARGET_STM32F411RE) || defined(TARGET_STM32F405RG) || defined(TARGET_K22F) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F401VC) || defined(TARGET_MAX32610) || defined(TARGET_MAX32600) || defined(TARGET_TEENSY3_1)
 #    define OS_TASKCNT         14
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_STM32F303RE) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO) || defined(TARGET_LPC1114) \
    || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
@@ -67,7 +67,7 @@
 #ifndef OS_SCHEDULERSTKSIZE
 #  if   defined(TARGET_LPC1768) || defined(TARGET_LPC2368)   || defined(TARGET_LPC4088) || defined(TARGET_LPC4088_DM) || defined(TARGET_LPC4330) || defined(TARGET_LPC4337) || defined(TARGET_LPC1347)  || defined(TARGET_K64F) || defined(TARGET_STM32F401RE)\
    || defined(TARGET_KL46Z) || defined(TARGET_KL43Z) || defined(TARGET_STM32F407) || defined(TARGET_F407VG)  || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_LPC11U68) \
-   || defined(TARGET_STM32F411RE) || defined(TARGET_STM32F405RG) || defined(TARGET_K22F) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F401VC) || defined(TARGET_MAX32610) || defined(TARGET_MAX32600)
+   || defined(TARGET_STM32F411RE) || defined(TARGET_STM32F405RG) || defined(TARGET_K22F) || defined(TARGET_STM32F429ZI) || defined(TARGET_STM32F401VC) || defined(TARGET_MAX32610) || defined(TARGET_MAX32600) || defined(TARGET_TEENSY3_1)
 #      define OS_SCHEDULERSTKSIZE    256
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) \
    || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
@@ -119,7 +119,7 @@
 #  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368)
 #    define OS_CLOCK       96000000
 
-#  elif defined(TARGET_LPC1347) || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) || defined(TARGET_STM32F303RE)
+#  elif defined(TARGET_LPC1347) || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) || defined(TARGET_STM32F303RE) || defined(TARGET_TEENSY3_1)
 #    define OS_CLOCK       72000000
 
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) || defined(TARGET_KL25Z) \

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M4/TOOLCHAIN_GCC/HAL_CM4.s
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/TARGET_M4/TOOLCHAIN_GCC/HAL_CM4.s
@@ -210,8 +210,12 @@ SVC_Handler_Veneer:
 
         CBZ     R1,SVC_Next             /* Runtask deleted? */
         TST     LR,#0x10                /* is it extended frame? */
+        #ifdef  __FPU_PRESENT
         ITTE    EQ
         VSTMDBEQ R12!,{S16-S31}         /* yes, stack also VFP hi-regs */
+        #else
+        ITE    EQ
+        #endif
         MOVEQ   R0,#0x01                /* os_tsk->stack_frame val */
         MOVNE   R0,#0x00
         STRB    R0,[R1,#TCB_STACKF]     /* os_tsk.run->stack_frame = val */
@@ -229,8 +233,12 @@ SVC_Next:
         LDMIA   R12!,{R4-R11}           /* Restore New Context */
         LDRB    R0,[R2,#TCB_STACKF]     /* Stack Frame */
         CMP     R0,#0                   /* Basic/Extended Stack Frame */
+        #ifdef  __FPU_PRESENT
         ITTE    NE
         VLDMIANE R12!,{S16-S31}         /* restore VFP hi-registers */
+        #else
+        ITE    NE
+        #endif
         MVNNE   LR,#~0xFFFFFFED         /* set EXC_RETURN value */
         MVNEQ   LR,#~0xFFFFFFFD
         MSR     PSP,R12                 /* Write PSP */
@@ -303,8 +311,12 @@ Sys_Switch:
 
         MRS     R12,PSP                 /* Read PSP */
         TST     LR,#0x10                /* is it extended frame? */
+        #ifdef  __FPU_PRESENT
         ITTE    EQ
         VSTMDBEQ R12!,{S16-S31}         /* yes, stack also VFP hi-regs */
+        #else
+        ITE    EQ
+        #endif
         MOVEQ   R0,#0x01                /* os_tsk->stack_frame val */
         MOVNE   R0,#0x00
         STRB    R0,[R1,#TCB_STACKF]     /* os_tsk.run->stack_frame = val */
@@ -321,8 +333,12 @@ Sys_Switch:
         LDMIA   R12!,{R4-R11}           /* Restore New Context */
         LDRB    R0,[R2,#TCB_STACKF]     /* Stack Frame */
         CMP     R0,#0                   /* Basic/Extended Stack Frame */
+        #ifdef  __FPU_PRESENT
         ITTE    NE
         VLDMIANE R12!,{S16-S31}         /* restore VFP hi-registers */
+        #else
+        ITE    NE
+        #endif
         MVNNE   LR,#~0xFFFFFFED         /* set EXC_RETURN value */
         MVNEQ   LR,#~0xFFFFFFFD
         MSR     PSP,R12                 /* Write PSP */


### PR DESCRIPTION
This pull request should fix the GCC_ARM toolchain issue as well as the RTOS library support for the TEENSY3_1 target (Issues #845 and #612). Both fixes have been tested in hardware and work well.

What I'm not sure about is if the settings for OS_TASKCNT and OS_SCHEDULERSTKSIZE are really the optimal values.