### PR TITLE
Implement some CAN modes for the LPC1549/LPC11Cxx/LPC1768

### DIFF
--- a/libraries/mbed/hal/can_api.h
+++ b/libraries/mbed/hal/can_api.h
@@ -45,8 +45,8 @@ typedef enum {
     MODE_RESET,
     MODE_NORMAL,
     MODE_SILENT,
-    MODE_TEST_GLOBAL,
     MODE_TEST_LOCAL,
+    MODE_TEST_GLOBAL,
     MODE_TEST_SILENT
 } CanMode;
 

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/can_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/can_api.c
@@ -45,7 +45,42 @@ static inline void can_enable(can_t *obj) {
 }
 
 int can_mode(can_t *obj, CanMode mode) {
-    return 0; // not implemented
+    int success = 0;
+    switch (mode) {
+        case MODE_RESET:
+            LPC_CAN->CNTL &=~CANCNTL_TEST;
+            can_disable(obj);
+            success = 1;
+            break;
+        case MODE_NORMAL:
+            LPC_CAN->CNTL &=~CANCNTL_TEST;
+            can_enable(obj);
+            success = 1;
+            break;
+        case MODE_SILENT:
+            LPC_CAN->CNTL |= CANCNTL_TEST;
+            LPC_CAN->TEST |= CANTEST_SILENT;
+            LPC_CAN->TEST &=~CANTEST_LBACK;
+            success = 1;
+            break;
+        case MODE_TEST_LOCAL:
+            LPC_CAN->CNTL |= CANCNTL_TEST;
+            LPC_CAN->TEST &=~CANTEST_SILENT;
+            LPC_CAN->TEST |= CANTEST_LBACK;
+            success = 1;
+            break;
+        case MODE_TEST_SILENT:
+            LPC_CAN->CNTL |= CANCNTL_TEST;
+            LPC_CAN->TEST |= (CANCNTL_LBACK | CANTEST_SILENT);
+            success = 1;
+            break;
+        case MODE_TEST_GLOBAL:
+        default:
+            success = 0;
+            break;
+    }
+    
+    return success;
 }
 
 int can_filter(can_t *obj, uint32_t id, uint32_t mask, CANFormat format, int32_t handle) {

--- a/libraries/tests/mbed/can_loopback/main.cpp
+++ b/libraries/tests/mbed/can_loopback/main.cpp
@@ -1,0 +1,50 @@
+#include "mbed.h"
+#include "test_env.h"
+
+#if defined(TARGET_LPC1549)
+CAN can1(D9, D8);
+#elif defined(TARGET_LPC1768) || defined(TARGET_LPC4088)
+CAN can1(p9, p10);
+#endif
+
+#define TEST_ITERATIONS     127
+
+int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(dev_null);
+    MBED_HOSTTEST_DESCRIPTION(CAN Loopback);
+    MBED_HOSTTEST_START("MBED_A27");
+
+    can1.mode(CAN::Reset);
+
+    if (!can1.mode(CAN::LocalTest)) {
+        printf("Mode change failed\n");
+    }
+
+    char success_count = 0;
+    for (char i=0; i < TEST_ITERATIONS; i++) {
+        unsigned int id = 1337;
+        CANMessage tx_msg(id, &i, sizeof(i));
+        bool sent = false;
+        if (can1.write(tx_msg)) {
+            printf("Sent %u: %d\n", id, i);
+            sent = true;
+        }
+        wait_ms(50);
+
+        bool read = false;
+        CANMessage rx_msg;
+        if (can1.read(rx_msg)) {
+            printf("Read %u: %d\n", rx_msg.id, rx_msg.data[0]);
+            read = (rx_msg.id == id) && (rx_msg.data[0] == i);
+        }
+
+        bool success = sent && read;
+
+        if (success) {
+            success_count++;
+        }
+    }
+
+    MBED_HOSTTEST_RESULT(success_count == TEST_ITERATIONS);
+}

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -80,7 +80,12 @@ Wiring:
   * i2c_eeprom:
       * LPC1*: (SDA=p28 , SCL=p27)
       * KL25Z: (SDA=PTE0, SCL=PTE1)
-      
+
+  * can_transceiver:
+     * LPC1768: (RX=p9,   TX=p10)
+     * LPC1549: (RX=D9,   TX=D8)
+     * LPC4088: (RX=p9,   TX=p10)
+
 """
 TESTS = [
     # Automated MBED tests
@@ -269,6 +274,15 @@ TESTS = [
         "peripherals": ["analog_pot"],
         "automated": True,
         "duration": 10,
+    },
+    {
+        "id": "MBED_A27", "description": "CAN loopback test",
+        "source_dir": join(TEST_DIR, "mbed", "can_loopback"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True,
+        "duration": 20,
+        "peripherals": ["can_transceiver"],
+        "mcu": ["LPC1549", "LPC1768"],
     },
     {
         "id": "MBED_BLINKY", "description": "Blinky",


### PR DESCRIPTION
I've partially implemented the can_mode HAL functions for the LPC1549/LPC11Cxx and LPC1768 platforms.

On the LPC1549/LPC11Cxx which use the C_CAN controller, I've implemented everything except for GlobalTest mode. On the LPC1768, I implemented everything except for GlobalTest mode and SilentTest mode. Based on my preliminary testing, I'm not sure if it's possible to do SilentTest mode, but it's not entirely obvious what is required of SilentTest mode. Is there official API documentation describing what the behavior is expected for each mode?

As LocalTest mode is substantially new, I've added an automated test case, MBED_A27, which does a simple loopback test that verifies it sees the messages it sends out. It only requires that a CAN transceiver is wired up to the controller with appropriate termination resistors.

I've tested the code against the LPC1549Xpresso and mbed-LPC1768 using GCC_ARM to build the tests.