### PR TITLE
[Arch Max] fix LSI clock value for Arch Max (STM32F407)

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -630,6 +630,7 @@ class ARCH_MAX(Target):
         self.extra_labels = ['STM', 'STM32F4', 'STM32F407', 'STM32F407VG']
         self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
         self.supported_form_factors = ["ARDUINO"]
+        self.macros = ['LSI_VALUE=32000']
 
     def program_cycle_s(self):
         return 2


### PR DESCRIPTION
The LSI clock of Arch Max is 32 KHz, and not sure other STM32F4xx targets have the same LSI clock or not, so define the macro to avoid using the one in [stm32f4xx_hal_conf.h](https://github.com/mbedmicro/mbed/blob/master/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/stm32f4xx_hal_conf.h#L122)