### PR TITLE
workspace_tools: Use python2 in shebang

### DIFF
--- a/workspace_tools/build.py
+++ b/workspace_tools/build.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 """
 mbed SDK
 Copyright (c) 2011-2013 ARM Limited

--- a/workspace_tools/build_travis.py
+++ b/workspace_tools/build_travis.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 Travis-CI build script

--- a/workspace_tools/make.py
+++ b/workspace_tools/make.py
@@ -1,4 +1,4 @@
-#! /usr/bin/env python
+#! /usr/bin/env python2
 """
 mbed SDK
 Copyright (c) 2011-2013 ARM Limited

--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 """
 mbed SDK


### PR DESCRIPTION
The scripts are not python3 compatible so we should explicitly call
python2.  Some distributions use python3 as the default python interpreter ([ArchLinux](https://www.archlinux.org/news/python-is-now-python-3/) for example) so executing the scripts directly fails on those platforms.