### PR TITLE
Added missing functionality for disabling interrupts in SerialBase.h

### DIFF
--- a/libraries/mbed/api/SerialBase.h
+++ b/libraries/mbed/api/SerialBase.h
@@ -100,6 +100,8 @@ public:
         if((mptr != NULL) && (tptr != NULL)) {
             _irq[type].attach(tptr, mptr);
             serial_irq_set(&_serial, (SerialIrq)type, 1);
+        } else {
+            serial_irq_set(&_serial, (SerialIrq)type, 0);
         }
     }
 


### PR DESCRIPTION
Calling SerialBase::attach(NULL, IrqType type) disables interrupt for the given IrqType while calling SerialBase::attach(NULL, NULL, IrqType type) does not.

This pull request adds the same functionality to the latter call.


