### PR TITLE
[HAL][KSDK] Fix issue with KSDK SPI timing

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.c
@@ -91,6 +91,7 @@ void spi_frequency(spi_t *obj, int hz) {
     CLOCK_SYS_GetFreq(kBusClock, &busClock);
     uint32_t spi_address[] = SPI_BASE_ADDRS;
     DSPI_HAL_SetBaudRate(spi_address[obj->instance], kDspiCtar0, (uint32_t)hz, busClock);
+    DSPI_HAL_CalculateDelay(spi_address[obj->instance], kDspiCtar0, kDspiAfterTransfer, busClock, 500000000 / hz);  //Half clock period delay after SPI transfer
 }
 
 static inline int spi_writeable(spi_t * obj) {

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/spi_api.c
@@ -91,7 +91,7 @@ void spi_frequency(spi_t *obj, int hz) {
     CLOCK_SYS_GetFreq(kBusClock, &busClock);
     uint32_t spi_address[] = SPI_BASE_ADDRS;
     DSPI_HAL_SetBaudRate(spi_address[obj->instance], kDspiCtar0, (uint32_t)hz, busClock);
-    DSPI_HAL_CalculateDelay(spi_address[obj->instance], kDspiCtar0, kDspiAfterTransfer, busClock, 500000000 / hz);  //Half clock period delay after SPI transfer
+    DSPI_HAL_CalculateDelay(spi_address[obj->instance], kDspiCtar0, kDspiLastSckToPcs, busClock, 500000000 / hz);  //Half clock period delay after SPI transfer
 }
 
 static inline int spi_writeable(spi_t * obj) {


### PR DESCRIPTION
Depending on the format by default the Freescale SPI peripheral does not
give proper delay between SPI transfers. So code has been added which
sets half a period delay between SPI transfers.

See the following picture:
http://static.tweakers.net/ext/f/gAoTfuAGPXuMgtqbCm34UOJ9/full.png

This is related to https://github.com/mbedmicro/mbed/issues/840 (you can see the same clock issue in the pic there). This issue: https://github.com/mbedmicro/mbed/issues/968 does not seem to be solved by this, in mode 3 the MOSI line goes up stil way too soon.