### PR TITLE
Updated Thread.cpp|.h to support signal clear

### DIFF
--- a/libraries/rtos/rtos/Thread.cpp
+++ b/libraries/rtos/rtos/Thread.cpp
@@ -62,6 +62,10 @@ int32_t Thread::signal_set(int32_t signals) {
     return osSignalSet(_tid, signals);
 }
 
+int32_t Thread::signal_clr(int32_t signals) {
+    return osSignalClear(_tid, signals);
+}
+
 Thread::State Thread::get_state() {
 #ifndef __MBED_CMSIS_RTOS_CA9
     return ((State)_thread_def.tcb.state);

--- a/libraries/rtos/rtos/Thread.h
+++ b/libraries/rtos/rtos/Thread.h
@@ -64,6 +64,12 @@ public:
     */
     int32_t signal_set(int32_t signals);
 
+    /** Clears the specified Signal Flags of an active thread.
+      @param   signals  specifies the signal flags of the thread that should be cleared.
+      @return  resultant signal flags of the specified thread or 0x80000000 in case of incorrect parameters.
+    */
+    int32_t signal_clr(int32_t signals);
+
     /** State of the Thread */
     enum State {
         Inactive,           /**< Not created or terminated */


### PR DESCRIPTION
Added functionality to clear consumed signal flags on thread waiting. Example of use:
```
Thread * _th;
// .....
// .....
// Waits for signal flag 1 or 2... 
for(;;){
  osEvent oe = _th->signal_wait((1 | 2), 0);
  if(oe.status == osEventSignal && (oe.value.signals & 1) != 0){
      _th->signal_clr(1);
     // add handling code for signal flag 1
  }
  if(oe.status == osEventSignal && (oe.value.signals & 2) != 0){
      _th->signal_clr(2);
     // add handling code for signal flag 2
  }

}
```