### PR TITLE
Tools: Added support for testing of multiple targets of the same type (board type)

### DIFF
--- a/workspace_tools/host_tests/host_tests_plugins/host_test_plugins.py
+++ b/workspace_tools/host_tests/host_tests_plugins/host_test_plugins.py
@@ -106,6 +106,7 @@ class HostTestPluginBase:
         """ Runs command from command line.
         """
         result = True
+        ret = 0
         try:
             ret = call(cmd, shell=shell)
             if ret:

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
@@ -51,10 +51,11 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
             if capabilitity == 'shell':
                 if os.name == 'nt': capabilitity = 'copy'
                 elif os.name == 'posix': capabilitity = 'cp'
-            if capabilitity == 'cp' or capabilitity == 'copy' or capabilitity == 'copy':
+            if capabilitity == 'cp' or capabilitity == 'copy' or capabilitity == 'xcopy':
                 copy_method = capabilitity
                 cmd = [copy_method, image_path, destination_path]
-                result = self.run_command(cmd)
+                shell = not capabilitity == 'cp'
+                result = self.run_command(cmd, shell=shell)
         return result
 
 

--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -144,9 +144,9 @@ if __name__ == '__main__':
 
         if get_module_avail('mbed_lstools'):
             mbeds = mbed_lstools.create()
-            muts_list = mbeds.list_mbeds()
+            muts_list = mbeds.list_mbeds_ext() if hasattr(mbeds, 'list_mbeds_ext') else mbeds.list_mbeds()
             for mut in muts_list:
-                print "MBEDLS: Detected %s, port: %s, mounted: %s"% (mut['platform_name'],
+                print "MBEDLS: Detected %s, port: %s, mounted: %s"% (mut['platform_name_unique'] if 'platform_name_unique' in mut else mut['platform_name'],
                                         mut['serial_port'],
                                         mut['mount_point'])
 

--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -85,7 +85,7 @@ def get_version():
     """ Returns test script version
     """
     single_test_version_major = 1
-    single_test_version_minor = 4
+    single_test_version_minor = 5
     return (single_test_version_major, single_test_version_minor)
 
 

--- a/workspace_tools/test_exporters.py
+++ b/workspace_tools/test_exporters.py
@@ -98,12 +98,14 @@ class ReportExporter():
         """ Generates separate <DIV> sections which contains test results output.
         """
 
-        RESULT_COLORS = {'OK' : 'LimeGreen',
-                         'FAIL' : 'Orange',
-                         'ERROR' : 'LightCoral',}
+        RESULT_COLORS = {'OK': 'LimeGreen',
+                         'FAIL': 'Orange',
+                         'ERROR': 'LightCoral',
+                         'OTHER': 'LightGray',
+                        }
 
         tooltip_name = self.get_tooltip_name(test['toolchain_name'], test['target_name'], test['test_id'], test_no)
-        background_color = RESULT_COLORS[test['single_test_result'] if test['single_test_result'] in RESULT_COLORS else 'LightGray']
+        background_color = RESULT_COLORS[test['single_test_result'] if test['single_test_result'] in RESULT_COLORS else 'OTHER']
         result_div_style = "background-color: %s"% background_color
 
         result = """<div class="name" style="%s" onmouseover="show(%s)" onmouseout="hide(%s)">

--- a/workspace_tools/test_exporters.py
+++ b/workspace_tools/test_exporters.py
@@ -21,7 +21,8 @@ from workspace_tools.utils import construct_enum
 
 
 ResultExporterType = construct_enum(HTML='Html_Exporter',
-                                    JUNIT='JUnit_Exporter')
+                                    JUNIT='JUnit_Exporter',
+                                    BUILD='Build_Exporter')
 
 
 class ReportExporter():
@@ -91,10 +92,10 @@ class ReportExporter():
         """ Generate simple unique tool-tip name which can be used.
             For example as HTML <div> section id attribute.
         """
-        return "target_test_%s_%s_%s_%d"% (toolchain.lower(), target.lower(), test_id.lower(), loop_no)
+        return "target_test_%s_%s_%s_%s"% (toolchain.lower(), target.lower(), test_id.lower(), loop_no)
 
     def get_result_div_sections(self, test, test_no):
-        """ Generates separate <dvi> sections which contains test results output.
+        """ Generates separate <DIV> sections which contains test results output.
         """
 
         RESULT_COLORS = {'OK' : 'LimeGreen',
@@ -102,12 +103,14 @@ class ReportExporter():
                          'ERROR' : 'LightCoral',}
 
         tooltip_name = self.get_tooltip_name(test['toolchain_name'], test['target_name'], test['test_id'], test_no)
-        background_color = RESULT_COLORS[test['single_test_result'] if test['single_test_result'] in RESULT_COLORS else 'ERROR']
+        background_color = RESULT_COLORS[test['single_test_result'] if test['single_test_result'] in RESULT_COLORS else 'LightGray']
         result_div_style = "background-color: %s"% background_color
 
         result = """<div class="name" style="%s" onmouseover="show(%s)" onmouseout="hide(%s)">
                        <center>%s</center>
                        <div class = "tooltip" id= "%s">
+                       <b>%s</b><br />
+                       <hr />
                        <b>%s</b> in <b>%.2f sec</b><br />
                        <hr />
                        <small>
@@ -120,6 +123,7 @@ class ReportExporter():
                        tooltip_name,
                        test['single_test_result'],
                        tooltip_name,
+                       test['target_name_unique'],
                        test['test_description'],
                        test['elapsed_time'],
                        test['single_test_output'].replace('\n', '<br />'))
@@ -130,14 +134,16 @@ class ReportExporter():
             we will show it in a column to see all results.
             This function produces HTML table with corresponding results.
         """
-        result = '<table>'
-        test_ids = sorted(test_results.keys())
-        for test_no in test_ids:
-            test = test_results[test_no]
-            result += """<tr>
-                             <td valign="top">%s</td>
-                         </tr>"""% self.get_result_div_sections(test, test_no)
-        result += '</table>'
+        result = ''
+        for i, test_result in enumerate(test_results):
+            result += '<table>'
+            test_ids = sorted(test_result.keys())
+            for test_no in test_ids:
+                test = test_result[test_no]
+                result += """<tr>
+                                 <td valign="top">%s</td>
+                             </tr>"""% self.get_result_div_sections(test, "%d_%d" % (test_no, i))
+            result += '</table>'
         return result
 
     def get_all_unique_test_ids(self, test_result_ext):
@@ -158,7 +164,7 @@ class ReportExporter():
     #
 
     def exporter_html(self, test_result_ext, test_suite_properties=None):
-        """ Export test results in proprietary html format.
+        """ Export test results in proprietary HTML format.
         """
         result = """<html>
                     <head>
@@ -211,25 +217,26 @@ class ReportExporter():
                 tests = sorted(test_result_ext[toolchain][target].keys())
                 for test in tests:
                     test_results = test_result_ext[toolchain][target][test]
-                    test_ids = sorted(test_results.keys())
-                    for test_no in test_ids:
-                        test_result = test_results[test_no]
-                        name = test_result['test_description']
-                        classname = 'test.%s.%s.%s'% (target, toolchain, test_result['test_id'])
-                        elapsed_sec = test_result['elapsed_time']
-                        _stdout = test_result['single_test_output']
-                        _stderr = ''
-                        # Test case
-                        tc = TestCase(name, classname, elapsed_sec, _stdout, _stderr)
-                        # Test case extra failure / error info
-                        if test_result['single_test_result'] == 'FAIL':
-                            message = test_result['single_test_result']
-                            tc.add_failure_info(message, _stdout)
-                        elif test_result['single_test_result'] != 'OK':
-                            message = test_result['single_test_result']
-                            tc.add_error_info(message, _stdout)
+                    for test_res in test_results:
+                        test_ids = sorted(test_res.keys())
+                        for test_no in test_ids:
+                            test_result = test_res[test_no]
+                            name = test_result['test_description']
+                            classname = 'test.%s.%s.%s'% (target, toolchain, test_result['test_id'])
+                            elapsed_sec = test_result['elapsed_time']
+                            _stdout = test_result['single_test_output']
+                            _stderr = test_result['target_name_unique']
+                            # Test case
+                            tc = TestCase(name, classname, elapsed_sec, _stdout, _stderr)
+                            # Test case extra failure / error info
+                            if test_result['single_test_result'] == 'FAIL':
+                                message = test_result['single_test_result']
+                                tc.add_failure_info(message, _stdout)
+                            elif test_result['single_test_result'] != 'OK':
+                                message = test_result['single_test_result']
+                                tc.add_error_info(message, _stdout)
 
-                        test_cases.append(tc)
+                            test_cases.append(tc)
                 ts = TestSuite("test.suite.%s.%s"% (target, toolchain), test_cases, properties=test_suite_properties[target][toolchain])
                 test_suites.append(ts)
         return TestSuite.to_xml_string(test_suites)


### PR DESCRIPTION
# Description
It was impossible to run test using ```singletest.py``` on more than 1 device of the same type (e.g. two Freedom K64F boards).
Before this change test suite (```singletest.py```) would only run tests for one board per type connected skipping (ignoring) other boards. 

**Note**:
* ```mbed-ls``` was modified to generate extra unique names (human friendly format) for each connected mbed device. This name is used by ```singletest.py``` and can be used by other applications to drive automation with mbedls and mbed devices.

**Example:**
Two NUCLEO_L152RE boards connected to host computer, both with unique TargetId and assigned readable ```platform_name_unique```.
```
$ mbedls
+---------------------+----------------------------+-------------------+-------------------+----------------------------------------+
|platform_name        |platform_name_unique        |mount_point        |serial_port        |target_id                               |
+---------------------+----------------------------+-------------------+-------------------+----------------------------------------+
|K64F                 |K64F[0]                     |I:                 |COM61              |02400203D94B0E7724B7F3CF                |
|LPC1768              |LPC1768[0]                  |E:                 |COM77              |101000000000000000000002F7F18695        |
|NUCLEO_L152RE        |NUCLEO_L152RE[0]            |F:                 |COM113             |07100200656A9A955A0F0CB8                |
|NUCLEO_L152RE        |NUCLEO_L152RE[1]            |G:                 |COM114             |0710020082667D99BD03EBB4                |
+---------------------+----------------------------+-------------------+-------------------+----------------------------------------+
```
## MUTs configuration for singletest.py
You can also execute tests from configuration files: ```singletest.py -i test_spec.json -M muts_all.json```. In that case, if you want to for example run tests on multiple devices of the same type you can just specify them in MUTs file and add optional ```mcu_unique``` to distinguish test results between boards.

**Example**:
Configuring MUTs to run tests for two ```NUCLEO_L152RE``` boards:
```
...
    "13" : {"mcu" : "NUCLEO_L152RE",
            "port" : "COM114",
            "disk" : "G:\\"},

    "14" : {"mcu" : "NUCLEO_L152RE",
            "port" : "COM113",
            "disk" : "F:\\"},
...
```
or with extra ```mcu_unique``` name to differentiate tests:
```
...
    "13" : {"mcu" : "NUCLEO_L152RE",
            "mcu_unique" : "NUCLEO_L152RE[1]",
            "port" : "COM114",
            "disk" : "G:\\"},

    "131" : {"mcu" : "NUCLEO_L152RE",
            "mcu_unique" : "NUCLEO_L152RE[0]",
            "port" : "COM113",
            "disk" : "F:\\"},
...
```

test results will be respectively:
```
$ singletest.py -i test_spec.json -M muts_all.json -n DTCT_1
Building library CMSIS (NUCLEO_L152RE, uARM)
Building library MBED (NUCLEO_L152RE, uARM)
Building project DETECT (NUCLEO_L152RE, uARM)
TargetTest::NUCLEO_L152RE::uARM::DTCT_1::Simple detect test [OK] in 0.48 of 10 sec
TargetTest::NUCLEO_L152RE::uARM::DTCT_1::Simple detect test [OK] in 0.51 of 10 sec
Test summary:
+--------+---------------+-----------+---------+--------------------+--------------------+---------------+-------+
| Result | Target        | Toolchain | Test ID | Test Description   | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------------+-----------+---------+--------------------+--------------------+---------------+-------+
| OK     | NUCLEO_L152RE | uARM      | DTCT_1  | Simple detect test |        0.48        |       10      |  1/1  |
| OK     | NUCLEO_L152RE | uARM      | DTCT_1  | Simple detect test |        0.51        |       10      |  1/1  |
+--------+---------------+-----------+---------+--------------------+--------------------+---------------+-------+
Result: 2 OK

Completed in 7.80 sec

Build successes:
  * uARM::NUCLEO_L152RE
```
and
```
$ singletest.py -i test_spec.json -M muts_all.json -n DTCT_1
Building library CMSIS (NUCLEO_L152RE, uARM)
Building library MBED (NUCLEO_L152RE, uARM)
Building project DETECT (NUCLEO_L152RE, uARM)
TargetTest::NUCLEO_L152RE[0]::uARM::DTCT_1::Simple detect test [OK] in 0.49 of 10 sec
TargetTest::NUCLEO_L152RE[1]::uARM::DTCT_1::Simple detect test [OK] in 0.51 of 10 sec
Test summary:
+--------+------------------+-----------+---------+--------------------+--------------------+---------------+-------+
| Result | Target           | Toolchain | Test ID | Test Description   | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+------------------+-----------+---------+--------------------+--------------------+---------------+-------+
| OK     | NUCLEO_L152RE[0] | uARM      | DTCT_1  | Simple detect test |        0.49        |       10      |  1/1  |
| OK     | NUCLEO_L152RE[1] | uARM      | DTCT_1  | Simple detect test |        0.51        |       10      |  1/1  |
+--------+------------------+-----------+---------+--------------------+--------------------+---------------+-------+
Result: 2 OK

Completed in 7.84 sec

Build successes:
  * uARM::NUCLEO_L152RE
```

# Testing
Tested with multiple execution patterns: 
* ```singletest.py -i test_spec.json -M muts_all.json -n DTCT_1```
* ```singletest.py --auto --parallel --report-junit pr_ju.xml --report-build pr_bld.html --report-html pr_html.html```
* ```singletest.py --auto  --tc IAR```