### PR TITLE
Fixes for premature error checking

### DIFF
--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -110,17 +110,24 @@ def check_required_modules(required_modules, verbose=True):
         @return returns True if all modules are installed already
     """
     import imp
-    all_modules_found = True
     not_installed_modules = []
     for module_name in required_modules:
         try:
             imp.find_module(module_name)
         except ImportError as e:
-            all_modules_found = False
-            not_installed_modules.append(module_name)
-            if verbose:
-                print "Error: %s"% e
+            # We also test against a rare case: module is an egg file
+            try:
+                __import__(module_name)
+            except ImportError as e:
+                not_installed_modules.append(module_name)
+                if verbose:
+                    print "Error: %s" % e
+
     if verbose:
-        if not all_modules_found:
+        if not_installed_modules:
             print "Warning: Module(s) %s not installed. Please install required module(s) before using this script."% (', '.join(not_installed_modules))
-    return all_modules_found
+
+    if not_installed_modules:
+        return False
+    else:
+        return True

--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -65,7 +65,7 @@ def find_cmd_abspath(cmd):
         None is returned if no absolute path was found.
     """
     if exists(cmd):
-        return '%s/%s' % (os.getcwd(), cmd)
+        return os.path.abspath(cmd)
     if not 'PATH' in os.environ:
         raise Exception("Can't find command path for current platform ('%s')" % sys.platform)
     PATH=os.environ['PATH']
@@ -109,7 +109,7 @@ def get_caller_name(steps=2):
 
 
 def error(msg):
-    print msg
+    print("ERROR: %s" % msg)
     sys.exit(1)
 
 

--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -31,12 +31,16 @@ def cmd(l, check=True, verbose=False, shell=False, cwd=None):
 
 
 def run_cmd(command, wd=None, redirect=False):
+    if not exists(command[0]):
+        error('run_cmd(): %s path does not exist' % command[0])
     p = Popen(command, stdout=PIPE, stderr=STDOUT if redirect else PIPE, cwd=wd)
     _stdout, _stderr = p.communicate()
     return _stdout, _stderr, p.returncode
 
 
 def run_cmd_ext(command):
+    if not exists(command[0]):
+        error('run_cmd_ext(): %s path does not exist' % command[0])
     p = Popen(command, stdout=PIPE, stderr=PIPE)
     _stdout, _stderr = p.communicate()
     return _stdout, _stderr, p.returncode


### PR DESCRIPTION
Some issues fixed:

  1. Added command validation before running a command. The validation assures that the command resolves to an executable file. Descriptive feedback is printed on error.
  2. Falsely giving errors for modules that have not been extracted from their .egg. These modules can be imported but false errors were given that they are not installed on the system.

Feedback example:
````
manos@box:~/tmp/mbed/workspace_tools$ python -B build.py -m LPC1768 -t uARM
..
ERROR: run_cmd: Command 'C:/Program Files/ARM/armcc_4.1_791/bin/armcc' can't be found
````