### PR TITLE
Fix bug with CAN loopback implementation on LPC11c14

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/can_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/TARGET_LPC11CXX/can_api.c
@@ -71,7 +71,7 @@ int can_mode(can_t *obj, CanMode mode) {
             break;
         case MODE_TEST_SILENT:
             LPC_CAN->CNTL |= CANCNTL_TEST;
-            LPC_CAN->TEST |= (CANCNTL_LBACK | CANTEST_SILENT);
+            LPC_CAN->TEST |= (CANTEST_LBACK | CANTEST_SILENT);
             success = 1;
             break;
         case MODE_TEST_GLOBAL:


### PR DESCRIPTION
While compiling and running the updated MBed repository code for the LPC11c14, I discovered that the can_api.c file in the \LPC11XX_11CXX\LPC11CXX target folder was not building correctly. It appears that there is a spurious "CANCNTL_LBACK" which should actually be "CANTEST_LBACK." I have modified the file to mirror the contents of the can_api.c file in the LPC15XX target folder and it appears to work now.