### PR TITLE
[RZ_A1H]Fix bugs of I2C and Update a header file of Video driver.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_RENESAS/TARGET_RZ_A1H/inc/iodefines/lvds_iodefine.h
+++ b/libraries/mbed/targets/cmsis/TARGET_RENESAS/TARGET_RZ_A1H/inc/iodefines/lvds_iodefine.h
@@ -24,7 +24,7 @@
 * File Name : lvds_iodefine.h
 * $Rev: $
 * $Date::                           $
-* Description : Definition of I/O Register (V1.00a)
+* Description : Definition of I/O Register (V1.01a)
 ******************************************************************************/
 #ifndef LVDS_IODEFINE_H
 #define LVDS_IODEFINE_H
@@ -37,7 +37,8 @@ struct st_lvds
     volatile uint8_t   dummy608[24];                           /*                  */
     volatile uint32_t  LCLKSELR;                               /*  LCLKSELR        */
     volatile uint32_t  LPLLSETR;                               /*  LPLLSETR        */
-    volatile uint32_t  LPLLMONR;                               /*  LPLLMONR        */
+    volatile uint8_t   dummy609[4];                            /*                  */
+    volatile uint32_t  LPHYACC;                                /*  LPHYACC         */
 };
 
 
@@ -48,6 +49,6 @@ struct st_lvds
 #define LVDSLVDSFCL LVDS.LVDSFCL
 #define LVDSLCLKSELR LVDS.LCLKSELR
 #define LVDSLPLLSETR LVDS.LPLLSETR
-#define LVDSLPLLMONR LVDS.LPLLMONR
+#define LVDSLPHYACC LVDS.LPHYACC
 /* <-SEC M1.10.1 */
 #endif


### PR DESCRIPTION
Hi,

We fixed bugs of I2C and update a header file of Video driver.

I2C
Bugs are as below.
- In I2C, modify the time-out of Nack is slow problem.
- In I2C, modify Write function and Read function does not work correctly with split run.

Header file
Update the header file for the Video driver support.

Regards,
Hamanaka
