### PR TITLE
[HAL][ARCH-MAX] SPI was fixed to minimum frequency

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/spi_api.c
@@ -214,7 +214,7 @@ void spi_format(spi_t *obj, int bits, int mode, int slave)
 
 void spi_frequency(spi_t *obj, int hz)
 {
-#if defined(TARGET_STM32F401RE) || defined(TARGET_STM32F401VC) || defined(TARGET_F407VG)
+#if defined(TARGET_STM32F401RE) || defined(TARGET_STM32F401VC) || defined(TARGET_STM32F407VG)
     // Note: The frequencies are obtained with SPI1 clock = 84 MHz (APB2 clock)
     if (hz < 600000) {
         obj->br_presc = SPI_BAUDRATEPRESCALER_256; // 330 kHz


### PR DESCRIPTION
Due to typo in the #ifdef it would completely skip the ARCH-MAX when
changing the SPI code, causing it to be stuck at lowest frequency.