### PR TITLE
Added tests for the WFI instruction

### DIFF
--- a/libraries/tests/mbed/wfi/main.cpp
+++ b/libraries/tests/mbed/wfi/main.cpp
@@ -1,0 +1,18 @@
+#include "mbed.h"
+#include "test_env.h"
+
+int main(void)
+{
+    MBED_HOSTTEST_TIMEOUT(15);
+    MBED_HOSTTEST_SELECT(wfi_auto);
+    MBED_HOSTTEST_DESCRIPTION(WFI correct behavior);
+    MBED_HOSTTEST_START("MBED_36");
+
+
+    int count = 0;
+
+    while(1) {
+      printf("%d\r\n", count++);
+      __WFI();
+    }
+}

--- a/workspace_tools/host_tests/__init__.py
+++ b/workspace_tools/host_tests/__init__.py
@@ -30,6 +30,7 @@ from tcpecho_server_auto import TCPEchoServerTest
 from udpecho_server_auto import UDPEchoServerTest
 from tcpecho_client_auto import TCPEchoClientTest
 from udpecho_client_auto import UDPEchoClientTest
+from wfi_auto import WFITest
 
 # Populate registry with supervising objects
 HOSTREGISTRY = HostRegistry()
@@ -46,6 +47,7 @@ HOSTREGISTRY.register_host_test("tcpecho_server_auto", TCPEchoServerTest())
 HOSTREGISTRY.register_host_test("udpecho_server_auto", UDPEchoServerTest())
 HOSTREGISTRY.register_host_test("tcpecho_client_auto", TCPEchoClientTest())
 HOSTREGISTRY.register_host_test("udpecho_client_auto", UDPEchoClientTest())
+HOSTREGISTRY.register_host_test("wfi_auto", WFITest())
 
 ###############################################################################
 # Functional interface for test supervisor registry

--- a/workspace_tools/host_tests/wfi_auto.py
+++ b/workspace_tools/host_tests/wfi_auto.py
@@ -1,0 +1,37 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import uuid
+import time
+from sys import stdout
+
+class WFITest():
+
+    def test(self, selftest):
+        result = True
+        c = selftest.mbed.serial_readline()
+        if c is None or c.strip() != "0":
+            return selftest.RESULT_IO_SERIAL
+
+        # Wait 10 seconds to allow serial prints (indicating failure)
+        selftest.mbed.set_serial_timeout(10)
+
+        # If no characters received, pass the test
+        result = not selftest.mbed.serial_readline()
+
+        return selftest.RESULT_SUCCESS if result else selftest.RESULT_FAILURE

--- a/workspace_tools/host_tests/wfi_auto.py
+++ b/workspace_tools/host_tests/wfi_auto.py
@@ -25,8 +25,12 @@ class WFITest():
     def test(self, selftest):
         result = True
         c = selftest.mbed.serial_readline()
-        if c is None or c.strip() != "0":
+
+        if c is None
             return selftest.RESULT_IO_SERIAL
+
+        if c.strip() != "0":
+            return selftest.RESULT_IO_FAIL
 
         # Wait 10 seconds to allow serial prints (indicating failure)
         selftest.mbed.set_serial_timeout(10)

--- a/workspace_tools/host_tests/wfi_auto.py
+++ b/workspace_tools/host_tests/wfi_auto.py
@@ -23,19 +23,23 @@ from sys import stdout
 class WFITest():
 
     def test(self, selftest):
-        result = True
         c = selftest.mbed.serial_readline()
 
         if c == None:
+            selftest.notify("HOST: No output detected")
             return selftest.RESULT_IO_SERIAL
 
         if c.strip() != "0":
+            selftest.notify("HOST: Unexpected output. Expected '0' but received '%s'" % c.strip())
             return selftest.RESULT_FAILURE
 
         # Wait 10 seconds to allow serial prints (indicating failure)
         selftest.mbed.set_serial_timeout(10)
 
         # If no characters received, pass the test
-        result = not selftest.mbed.serial_readline()
-
-        return selftest.RESULT_SUCCESS if result else selftest.RESULT_FAILURE
+        if not selftest.mbed.serial_readline():
+            selftest.notify("HOST: No further output detected")
+            return selftest.RESULT_SUCCESS
+        else:
+            selftest.notify("HOST: Extra output detected")
+            return selftest.RESULT_FAILURE

--- a/workspace_tools/host_tests/wfi_auto.py
+++ b/workspace_tools/host_tests/wfi_auto.py
@@ -26,7 +26,7 @@ class WFITest():
         result = True
         c = selftest.mbed.serial_readline()
 
-        if c is None
+        if c == None:
             return selftest.RESULT_IO_SERIAL
 
         if c.strip() != "0":

--- a/workspace_tools/host_tests/wfi_auto.py
+++ b/workspace_tools/host_tests/wfi_auto.py
@@ -30,7 +30,7 @@ class WFITest():
             return selftest.RESULT_IO_SERIAL
 
         if c.strip() != "0":
-            return selftest.RESULT_IO_FAIL
+            return selftest.RESULT_FAILURE
 
         # Wait 10 seconds to allow serial prints (indicating failure)
         selftest.mbed.set_serial_timeout(10)

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -66,7 +66,7 @@ Wiring:
 
   * analog_pot (AnalogIn):
       * Arduino headers: (A0, A1)
-      
+
   * SD (SPI):
       * LPC1*: (mosi=p11 , miso=p12 , sclk=p13 , cs=p14 )
       * KL25Z: (mosi=PTD2, miso=PTD3, sclk=PTD1, cs=PTD0)
@@ -579,7 +579,12 @@ TESTS = [
         "automated": True,
         "duration": 10,
     },
-
+    {
+        "id": "MBED_36", "description": "WFI correct behavior",
+        "source_dir": join(TEST_DIR, "mbed", "wfi"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True
+    },
 
     # CMSIS RTOS tests
     {


### PR DESCRIPTION
This test ensures that the WFI instruction actually waits for an interrupt. On some HAL implementations, there appears to be a ticker interrupt that fires constantly for internal timing purposes. This however triggers the WFI instruction, causing unexpected behavior.