### PR TITLE
[RTOS] Added stack checking methods to Thread

### DIFF
--- a/libraries/rtos/rtos/Thread.cpp
+++ b/libraries/rtos/rtos/Thread.cpp
@@ -41,6 +41,11 @@ Thread::Thread(void (*task)(void const *argument), void *argument,
             error("Error allocating the stack memory\n");
         _dynamic_stack = true;
     }
+    
+    //Fill the stack with a magic word for maximum usage checking
+    for (int i = 0; i < (stack_size / sizeof(uint32_t)); i++) {
+        _thread_def.stack_pointer[i] = 0xE25A2EA5;
+    }
 #endif
 #endif
     _tid = osThreadCreate(&_thread_def, argument);
@@ -73,6 +78,43 @@ Thread::State Thread::get_state() {
     uint8_t status;
     status = osThreadGetState(_tid);
     return ((State)status);
+#endif
+}
+
+uint32_t Thread::stack_size() {
+#ifndef __MBED_CMSIS_RTOS_CA9
+    return _thread_def.tcb.priv_stack;
+#else
+    return 0;
+#endif
+}
+
+uint32_t Thread::free_stack() {
+#ifndef __MBED_CMSIS_RTOS_CA9
+    uint32_t bottom = (uint32_t)_thread_def.tcb.stack;
+    return _thread_def.tcb.tsk_stack - bottom;
+#else
+    return 0;
+#endif
+}
+
+uint32_t Thread::used_stack() {
+#ifndef __MBED_CMSIS_RTOS_CA9
+    uint32_t top = (uint32_t)_thread_def.tcb.stack + _thread_def.tcb.priv_stack;
+    return top - _thread_def.tcb.tsk_stack;
+#else
+    return 0;
+#endif
+}
+
+uint32_t Thread::max_stack() {
+#ifndef __MBED_CMSIS_RTOS_CA9
+    uint32_t high_mark = 0;
+    while (_thread_def.tcb.stack[high_mark] == 0xE25A2EA5)
+        high_mark++;
+    return _thread_def.tcb.priv_stack - (high_mark * 4);
+#else
+    return 0;
 #endif
 }
 

--- a/libraries/rtos/rtos/Thread.h
+++ b/libraries/rtos/rtos/Thread.h
@@ -88,6 +88,26 @@ public:
       @return  the State of this Thread
     */
     State get_state();
+    
+    /** Get the total stack memory size for this Thread
+      @return  the total stack memory size in bytes
+    */
+    uint32_t stack_size();
+    
+    /** Get the currently unused stack memory for this Thread
+      @return  the currently unused stack memory in bytes
+    */
+    uint32_t free_stack();
+    
+    /** Get the currently used stack memory for this Thread
+      @return  the currently used stack memory in bytes
+    */
+    uint32_t used_stack();
+    
+    /** Get the maximum stack memory usage to date for this Thread
+      @return  the maximum stack memory usage to date in bytes
+    */
+    uint32_t max_stack();
 
     /** Wait for one or more Signal Flags to become signaled for the current RUNNING thread.
       @param   signals   wait until all specified signal flags set or 0 for any single signal flag.


### PR DESCRIPTION
Added stack checking methods to the Thread class for Cortex-M targets. The stack memory size, currently free stack memory, and currently used stack memory are calculated using the TCB. The maximum stack memory usage is determined by filling the stack with a magic word, and finding the high water mark.