### PR TITLE
modify overrides flash_init/flash powerdown and PinName

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_DELTA_DFCM_NNN40/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_DELTA_DFCM_NNN40/PinNames.h
@@ -90,12 +90,12 @@ typedef enum {
     I2C_SDA0 = p22,
     I2C_SCL0 = p20,
 
-    A0  = p0,
-    A1  = p1,
-    A2  = p2,
-    A3  = p3,
-    A4  = p4,
-    A5  = p5,
+    A0  = p1,
+    A1  = p2,
+    A2  = p3,
+    A3  = p4,
+    A4  = p5,
+    A5  = p6,
 
     SWIO = p19,
     VERF0 = p0,

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_DELTA_DFCM_NNN40/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_DELTA_DFCM_NNN40/mbed_overrides.c
@@ -25,7 +25,7 @@
 #define CMD_POWER_UP (0xAB)
 #define CMD_POWER_DOWN (0xB9)
 
-void spi_flash_init(void)
+void flash_init(void)
 {   
 	NRF_GPIO->PIN_CNF[SPIM1_MOSI_PIN] = (GPIO_PIN_CNF_SENSE_Disabled << GPIO_PIN_CNF_SENSE_Pos)
 									| (GPIO_PIN_CNF_DRIVE_S0S1 << GPIO_PIN_CNF_DRIVE_Pos)
@@ -79,7 +79,7 @@ void spi_flash_init(void)
 
 }
 
-void spi_flash_powerDown(void)
+void flash_powerDown(void)
 {
     NRF_GPIO->OUTCLR 		= 	(GPIO_OUTCLR_PIN28_Clear << GPIO_OUTCLR_PIN28_Pos);
     //spi.write(CMD_POWER_DOWN);
@@ -115,9 +115,9 @@ void mbed_sdk_init()
     {// Do nothing.
     }
 	
-	spi_flash_init();
+	flash_init();
 	
 	//nrf_delay_ms(10);
-	spi_flash_powerDown();
+	flash_powerDown();
 	
 }


### PR DESCRIPTION
Hi,

update flash function name, because it is the same as WIFI_API flash function name.
And redefine analog pinout

Thanks
Marco