### PR TITLE
[utils.py] Making some functions more generic

### DIFF
--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -68,11 +68,13 @@ def find_cmd_abspath(cmd):
         return os.path.abspath(cmd)
     if not 'PATH' in os.environ:
         raise Exception("Can't find command path for current platform ('%s')" % sys.platform)
-    PATH=os.environ['PATH']
-    for path in PATH.split(os.pathsep):
-        abspath = '%s/%s' % (path, cmd)
-        if exists(abspath) or exists(abspath + '.exe'):
-            return abspath
+    PATH = os.environ['PATH']
+    for path in PATH.split(os.path.pathsep):
+        for filename in os.listdir(path):
+            barename = os.path.splitext(filename)[0]
+            if filename == cmd or barename == cmd:
+                return path + os.path.sep + filename
+    return None
 
 
 def mkdir(path):

--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -19,7 +19,7 @@ import inspect
 import os
 from os import listdir, remove, makedirs
 from shutil import copyfile
-from os.path import isdir, join, exists, split, relpath, splitext, pathsep, basename
+from os.path import isdir, isabs, join, exists, split, relpath, splitext, pathsep, basename
 from subprocess import Popen, PIPE, STDOUT, call
 
 
@@ -85,6 +85,8 @@ def find_cmd_abspath(cmd):
     """
     if not command_paths():
         raise Exception("Can't find command path for current platform ('%s')" % sys.platform)
+    if isabs(cmd) and exists(cmd):
+        return cmd
     for path in command_paths():
         if not exists(path):
             continue

--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -82,7 +82,7 @@ def find_cmd_abspath(cmd):
     for path in lookup_paths.split(pathsep):
         for filename in listdir(path):
             if barename(filename) == barename(cmd):
-                return path + os.path.sep + filename
+                return join(path, filename)
     return None
 
 

--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -61,7 +61,7 @@ def is_exec(path):
 
 
 def barename(filename):
-    """ Returns the part of a filename without the file extension or/and path
+    """ Returns the part of a filename without the file extension or/and path.
         
         'a/b/c.exe' => 'c'
         'c.exe'     => 'c'
@@ -69,17 +69,25 @@ def barename(filename):
     return splitext(basename(filename))[0]
 
 
+def command_paths():
+    """ Returns a list of paths found in PATH environment variable.
+    """
+    if not 'PATH' in os.environ:
+        return False
+    PATH = os.environ['PATH']
+    PATH = os.path.normpath(PATH)
+    return PATH.split(pathsep)
+
+
 def find_cmd_abspath(cmd):
     """ Returns the absolute path to a command. Notice that no checking
         is being made to see if the file is executable or not.
     """
-    if not 'PATH' in os.environ:
+    if not command_paths():
         raise Exception("Can't find command path for current platform ('%s')" % sys.platform)
-    PATH = os.environ['PATH']
-    PWD  = os.getcwd()
-    lookup_paths = PWD + pathsep + PATH
-
-    for path in lookup_paths.split(pathsep):
+    for path in command_paths():
+        if not exists(path):
+            continue
         for filename in listdir(path):
             if barename(filename) == barename(cmd):
                 return join(path, filename)


### PR DESCRIPTION
This pull request should make some functions more generic.

There was a an issue with `find_cmd_abspath` in Windows where no lookup for files with extensions was made. [This was fixed.](https://github.com/mbedmicro/mbed/pull/1114) The problem is that the fix didn't take into consideration some other issues. I list below the main such issues:

  1. Only `.exe` files are looked up on Windows (no .bat scripts for example)
  2. Returned `abspath` in `find_cmd_abspath` is missing the extension!
  3. The same path separator ('/') was used for all OSes. (bug from before)
  4. Some checking and normalization (ie. trailing `"` in PATH variable).

After the fixes, `find_cmd_abspath` should work for any platform in a generic way. I have tested both `find_cmd_abspath` and `is_valid_cmd` on Linux and Windows after the changes.