### PR TITLE
[Silicon Labs] Improvements in RAM footprint of HAL.

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/gpio_api.c
@@ -42,8 +42,6 @@ void gpio_init(gpio_t *obj, PinName pin)
     CMU_ClockEnable(cmuClock_HFPER, true);
     CMU_ClockEnable(cmuClock_GPIO, true);
     obj->pin = pin;
-    obj->mask = gpio_set(pin);
-    obj->port = pin >> 4;
 }
 
 void gpio_pin_enable(gpio_t *obj, uint8_t enable)
@@ -63,7 +61,7 @@ void gpio_mode(gpio_t *obj, PinMode mode)
     //Handle pullup for input
     if(mode == InputPullUp) {
         //Set DOUT
-        GPIO->P[obj->port & 0xF].DOUTSET = 1 << (obj->pin & 0xF);
+        GPIO->P[(obj->pin >> 4) & 0xF].DOUTSET = 1 << (obj->pin & 0xF);
     }
 }
 

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/gpio_object.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/gpio_object.h
@@ -25,27 +25,25 @@ extern "C" {
 
 typedef struct {
     PinName pin;
-    uint32_t mask;
-    GPIO_Port_TypeDef port;
     PinMode mode;
-    uint32_t dir;
+    PinDirection dir;
 } gpio_t;
 
 static inline void gpio_write(gpio_t *obj, int value)
 {
     if (value) {
-        GPIO_PinOutSet(obj->port, obj->pin & 0xF); // Pin number encoded in first four bits of obj->pin
+        GPIO_PinOutSet((GPIO_Port_TypeDef)((obj->pin >> 4) & 0xF), obj->pin & 0xF); // Pin number encoded in first four bits of obj->pin
     } else {
-        GPIO_PinOutClear(obj->port, obj->pin & 0xF);
+        GPIO_PinOutClear((GPIO_Port_TypeDef)((obj->pin >> 4) & 0xF), obj->pin & 0xF);
     }
 }
 
 static inline int gpio_read(gpio_t *obj)
 {
     if (obj->dir == PIN_INPUT) {
-        return GPIO_PinInGet(obj->port, obj->pin & 0xF); // Pin number encoded in first four bits of obj->pin
+        return GPIO_PinInGet((GPIO_Port_TypeDef)((obj->pin >> 4) & 0xF), obj->pin & 0xF); // Pin number encoded in first four bits of obj->pin
     } else {
-        return GPIO_PinOutGet(obj->port, obj->pin & 0xF);
+        return GPIO_PinOutGet((GPIO_Port_TypeDef)((obj->pin >> 4) & 0xF), obj->pin & 0xF);
     }
 }
 

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/objects.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/objects.h
@@ -68,9 +68,9 @@ struct port_s {
 #if DEVICE_PWMOUT
 struct pwmout_s {
     //The period of the pulse in clock cycles
-    uint32_t period_cycles;
+    uint16_t period_cycles;
     //The width of the pulse in clock cycles
-    uint32_t width_cycles;
+    uint16_t width_cycles;
     //Channel on TIMER
     uint32_t channel;
     PinName pin;

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/pwmout_api.c
@@ -30,7 +30,6 @@
 #include "em_gpio.h"
 #include "em_timer.h"
 
-static int pwm_clockfreq;
 static int pwm_prescaler_div;
 
 uint32_t pwmout_get_channel_route(pwmout_t *obj)
@@ -109,9 +108,6 @@ void pwmout_init(pwmout_t *obj, PinName pin)
     PWM_TIMER->ROUTE &= ~_TIMER_ROUTE_LOCATION_MASK;
     PWM_TIMER->ROUTE |= PWM_ROUTE;
 
-    /*HFPER is the default clock we will use. It has a frequency of 14MHz*/
-    pwm_clockfreq = REFERENCE_FREQUENCY;
-
     /* Set default 20ms frequency and 0ms pulse width */
     pwmout_period(obj, 0.02);
 }
@@ -139,7 +135,7 @@ void pwmout_write(pwmout_t *obj, float value)
         value = 1;
     }
 
-    float pulse_period_in_s = obj->period_cycles / ((float) (pwm_clockfreq >> pwm_prescaler_div));
+    float pulse_period_in_s = obj->period_cycles / ((float) (REFERENCE_FREQUENCY >> pwm_prescaler_div));
     pwmout_pulsewidth(obj, value * pulse_period_in_s);
 }
 
@@ -155,7 +151,7 @@ void pwmout_period(pwmout_t *obj, float seconds)
     // This gives us max resolution for a given period
 
     //The value of the top register if prescaler is set to 0
-    int cycles = pwm_clockfreq * seconds;
+    int cycles = REFERENCE_FREQUENCY * seconds;
     pwm_prescaler_div = 0;
 
     //The top register is only 16 bits, so we keep dividing till we are below 0xFFFF
@@ -187,23 +183,25 @@ void pwmout_period_ms(pwmout_t *obj, int ms)
 
 void pwmout_period_us(pwmout_t *obj, int us)
 {
-    pwmout_period_ms(obj, us / 1000.0f);
+    pwmout_period(obj, us / 1000000.0f);
 }
 
 void pwmout_pulsewidth(pwmout_t *obj, float seconds)
 {
-    obj->width_cycles = (uint32_t) (((float) (pwm_clockfreq >> pwm_prescaler_div)) * seconds);
+    obj->width_cycles = (uint32_t) (((float) (REFERENCE_FREQUENCY >> pwm_prescaler_div)) * seconds);
     TIMER_CompareBufSet(PWM_TIMER, obj->channel, obj->width_cycles);
 }
 
 void pwmout_pulsewidth_ms(pwmout_t *obj, int ms)
 {
-    pwmout_pulsewidth(obj, ms / 1000.0f);
+    obj->width_cycles = (uint32_t) ((REFERENCE_FREQUENCY >> pwm_prescaler_div) * ms) / 1000;
+    TIMER_CompareBufSet(PWM_TIMER, obj->channel, obj->width_cycles);
 }
 
 void pwmout_pulsewidth_us(pwmout_t *obj, int us)
 {
-    pwmout_pulsewidth_ms(obj, us / 1000.0f);
+    obj->width_cycles = (uint32_t) ((REFERENCE_FREQUENCY >> pwm_prescaler_div) * us) / 1000000;
+    TIMER_CompareBufSet(PWM_TIMER, obj->channel, obj->width_cycles);
 }
 
 #endif


### PR DESCRIPTION
Optimized the footprint per instance of the PwmOut and GPIO objects. Should at least tens of bytes in any give program for EFM32 kits.