### PR TITLE
Copy missing files to be able to compile export_test projects

### DIFF
--- a/workspace_tools/export_test.py
+++ b/workspace_tools/export_test.py
@@ -37,7 +37,7 @@ def setup_test_user_prj():
         print 'Test user project already generated...'
         return
 
-    setup_user_prj(USER_PRJ, join(TEST_DIR, "rtos", "mbed", "basic"), [join(LIB_DIR, "rtos")])
+    setup_user_prj(USER_PRJ, join(TEST_DIR, "rtos", "mbed", "basic"), [join(LIB_DIR, "rtos"), join(LIB_DIR, "tests", "mbed", "env")])
 
     # FAKE BUILD URL
     open(join(USER_SRC, "mbed.bld"), 'w').write("http://mbed.org/users/mbed_official/code/mbed/builds/976df7c37ad5\n")


### PR DESCRIPTION
The file test_env.h is missing, so the projects created with workspace_tools/export_test.py do not compiler, e.g. gcc_arm for LPC1768.