### PR TITLE
TimerEvent - include us ticker - fixing us_ticker_read() not available

### DIFF
--- a/libraries/mbed/api/TimerEvent.h
+++ b/libraries/mbed/api/TimerEvent.h
@@ -17,6 +17,7 @@
 #define MBED_TIMEREVENT_H
 
 #include "ticker_api.h"
+#include "us_ticker_api.h"
 
 namespace mbed {
 


### PR DESCRIPTION
Reverting latest change in the TimerEvent, which removed us ticker api header file inclusion -> was not pulled in to mbed.h,