### PR TITLE
SPI - transfer() unification

### DIFF
--- a/libraries/mbed/api/I2C.h
+++ b/libraries/mbed/api/I2C.h
@@ -141,9 +141,9 @@ public:
      *
      * @param address   8/10 bit I2c slave address
      * @param tx_buffer The TX buffer with data to be transfered
-     * @param tx_length The length of TX buffer
+     * @param tx_length The length of TX buffer in bytes
      * @param rx_buffer The RX buffer which is used for received data
-     * @param rx_length The length of RX buffer
+     * @param rx_length The length of RX buffer in bytes
      * @param event     The logical OR of events to modify
      * @param callback  The event callback function
      * @param repeated Repeated start, true - do not send stop at end

--- a/libraries/mbed/api/SPI.h
+++ b/libraries/mbed/api/SPI.h
@@ -120,7 +120,7 @@ public:
      *                  received data are ignored
      * @param rx_length The length of RX buffer in bytes
      * @param callback  The event callback function
-     * @param event     The logical OR of events to modify
+     * @param event     The logical OR of events to modify. Look at spi hal header file for SPI events.
      * @return Zero if the transfer has started, or -1 if SPI peripheral is busy
      */
     template<typename Type>

--- a/libraries/mbed/api/SPI.h
+++ b/libraries/mbed/api/SPI.h
@@ -115,48 +115,21 @@ public:
      *
      * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
      *                  the default SPI value is sent
-     * @param tx_length The length of TX buffer
+     * @param tx_length The length of TX buffer in bytes
      * @param rx_buffer The RX buffer which is used for received data. If NULL is passed,
      *                  received data are ignored
-     * @param rx_length The length of RX buffer
+     * @param rx_length The length of RX buffer in bytes
      * @param callback  The event callback function
      * @param event     The logical OR of events to modify
      * @return Zero if the transfer has started, or -1 if SPI peripheral is busy
      */
-    virtual int transfer(const uint8_t *tx_buffer, int tx_length, uint8_t *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE) {
-        return transfer(tx_buffer, tx_length, rx_buffer, rx_length, 8, callback, event);
-    }
-
-    /** Start non-blocking SPI transfer using 16bit buffers.
-     *
-     * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
-     *                  the default SPI value is sent
-     * @param tx_length The length of TX buffer
-     * @param rx_buffer The RX buffer which is used for received data. If NULL is passed,
-     *                  received data are ignored
-     * @param rx_length The length of RX buffer
-     * @param callback  The event callback function
-     * @param event     The logical OR of events to modify
-     * @return Zero if the transfer has started, or -1 if SPI peripheral is busy
-     */
-    virtual int transfer(const uint16_t *tx_buffer, int tx_length, uint16_t *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE) {
-        return transfer(tx_buffer, tx_length, rx_buffer, rx_length, 16, callback, event);
-    }
-
-    /** Start non-blocking SPI transfer using 32bit buffers.
-     *
-     * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
-     *                  the default SPI value is sent
-     * @param tx_length The length of TX buffer
-     * @param rx_buffer The RX buffer which is used for received data. If NULL is passed,
-     *                  received data are ignored
-     * @param rx_length The length of RX buffer
-     * @param callback  The event callback function
-     * @param event     The logical OR of events to modify
-     * @return Zero if the transfer has started, or -1 if SPI peripheral is busy
-     */
-    virtual int transfer(const uint32_t *tx_buffer, int tx_length, uint32_t *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE)  {
-        return transfer((void *)tx_buffer, tx_length, (void *)rx_buffer, rx_length, 32, callback, event);
+    template<typename Type>
+    int transfer(const Type *tx_buffer, int tx_length, Type *rx_buffer, int rx_length, const event_callback_t& callback, int event = SPI_EVENT_COMPLETE) {
+        if (spi_active(&_spi)) {
+            return queue_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
+        }
+        start_transfer(tx_buffer, tx_length, rx_buffer, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
+        return 0;
     }
 
     /** Abort the on-going SPI transfer, and continue with transfer's in the queue if any.
@@ -188,10 +161,10 @@ protected:
      *
      * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
      *                  the default SPI value is sent
-     * @param tx_length The length of TX buffer
+     * @param tx_length The length of TX buffer in bytes
      * @param rx_buffer The RX buffer which is used for received data. If NULL is passed,
      *                  received data are ignored
-     * @param rx_length The length of RX buffer
+     * @param rx_length The length of RX buffer in bytes
      * @param bit_width The buffers element width
      * @param callback  The event callback function
      * @param event     The logical OR of events to modify
@@ -203,10 +176,10 @@ protected:
      *
      * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
      *                  the default SPI value is sent
-     * @param tx_length The length of TX buffer
+     * @param tx_length The length of TX buffer in bytes
      * @param rx_buffer The RX buffer which is used for received data. If NULL is passed,
      *                  received data are ignored
-     * @param rx_length The length of RX buffer
+     * @param rx_length The length of RX buffer in bytes
      * @param bit_width The buffers element width
      * @param callback  The event callback function
      * @param event     The logical OR of events to modify
@@ -218,10 +191,10 @@ protected:
      *
      * @param tx_buffer The TX buffer with data to be transfered. If NULL is passed,
      *                  the default SPI value is sent
-     * @param tx_length The length of TX buffer
+     * @param tx_length The length of TX buffer in bytes
      * @param rx_buffer The RX buffer which is used for received data. If NULL is passed,
      *                  received data are ignored
-     * @param rx_length The length of RX buffer
+     * @param rx_length The length of RX buffer in bytes
      * @param bit_width The buffers element width
      * @param callback  The event callback function
      * @param event     The logical OR of events to modify

--- a/libraries/mbed/api/SPI.h
+++ b/libraries/mbed/api/SPI.h
@@ -128,7 +128,7 @@ public:
         if (spi_active(&_spi)) {
             return queue_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
         }
-        start_transfer(tx_buffer, tx_length, rx_buffer, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
+        start_transfer(tx_buffer, tx_length, rx_buffer, rx_length, sizeof(Type)*8, callback, event);
         return 0;
     }
 

--- a/libraries/mbed/api/SerialBase.h
+++ b/libraries/mbed/api/SerialBase.h
@@ -131,7 +131,7 @@ public:
     /** Begin asynchronous write using 8bit buffer. The completition invokes registered TX event callback
      *
      *  @param buffer   The buffer where received data will be stored
-     *  @param length   The buffer length
+     *  @param length   The buffer length in bytes
      *  @param callback The event callback function
      *  @param event    The logical OR of TX events
      */
@@ -140,7 +140,7 @@ public:
     /** Begin asynchronous write using 16bit buffer. The completition invokes registered TX event callback
      *
      *  @param buffer   The buffer where received data will be stored
-     *  @param length   The buffer length
+     *  @param length   The buffer length in bytes
      *  @param callback The event callback function
      *  @param event    The logical OR of TX events
      */
@@ -153,7 +153,7 @@ public:
     /** Begin asynchronous reading using 8bit buffer. The completition invokes registred RX event callback.
      *
      *  @param buffer     The buffer where received data will be stored
-     *  @param length     The buffer length
+     *  @param length     The buffer length in bytes
      *  @param callback   The event callback function
      *  @param event      The logical OR of RX events
      *  @param char_match The matching character
@@ -163,7 +163,7 @@ public:
     /** Begin asynchronous reading using 16bit buffer. The completition invokes registred RX event callback.
      *
      *  @param buffer     The buffer where received data will be stored
-     *  @param length     The buffer length
+     *  @param length     The buffer length in bytes
      *  @param callback   The event callback function
      *  @param event      The logical OR of RX events
      *  @param char_match The matching character

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -948,11 +948,6 @@ void spi_master_transfer(spi_t *obj, const void *tx, size_t tx_length, void *rx,
     spi_enable_event(obj, SPI_EVENT_ALL, false);
     spi_enable_event(obj, event, true);
 
-    /* Be tricky on how we handle increased bit widths in the buffer... Handling on byte-basis */
-    // div 8 = shift right 3
-    tx_length = tx_length * (bit_width >> 3);
-    rx_length = rx_length * (bit_width >> 3);
-
     // Set the sleep mode
     blockSleepMode(SPI_LEAST_ACTIVE_SLEEPMODE);
 

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -404,9 +404,6 @@ void spi_buffer_set(spi_t *obj, const void *tx, uint32_t tx_length, void *rx, ui
     uint32_t i;
     uint16_t *tx_ptr = (uint16_t *) tx;
 
-    tx_length *= (bit_width >> 3);
-    rx_length *= (bit_width >> 3);
-
     obj->tx_buff.buffer = (void *)tx;
     obj->rx_buff.buffer = rx;
     obj->tx_buff.length = tx_length;


### PR DESCRIPTION
@Sissors revieW!

- fixing also usage of spi buffers length in the EFM32 HAL