### PR TITLE
Added tests that ensure correct handling of setting Serial pins to NC

### DIFF
--- a/libraries/tests/mbed/serial_nc_rx/main.cpp
+++ b/libraries/tests/mbed/serial_nc_rx/main.cpp
@@ -1,0 +1,34 @@
+#include "mbed.h"
+#include "test_env.h"
+
+int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(serial_nc_rx_auto);
+    MBED_HOSTTEST_DESCRIPTION(Serial NC RX);
+    MBED_HOSTTEST_START("MBED_37");
+
+    Serial *pc = new Serial(NC, USBRX);
+
+    char c = pc->getc();
+
+    delete pc;
+
+    // This should be true
+    if (c == 'E') {
+      Serial *pc = new Serial(USBTX, NC);
+
+      pc->printf("RX OK - Expected\r\n");
+
+      c = pc->getc();
+
+      // This should be false/not get here
+      if (c == 'U') {
+        pc->printf("RX OK - Unexpected\r\n");
+      }
+
+      delete pc;
+    }
+
+    while (1) {
+    }
+}

--- a/libraries/tests/mbed/serial_nc_tx/main.cpp
+++ b/libraries/tests/mbed/serial_nc_tx/main.cpp
@@ -1,0 +1,30 @@
+#include "mbed.h"
+#include "test_env.h"
+
+int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(serial_nc_tx_auto);
+    MBED_HOSTTEST_DESCRIPTION(Serial NC TX);
+    MBED_HOSTTEST_START("MBED_38");
+
+    // Wait until we receive start signal from host test
+    Serial *pc = new Serial(USBTX, USBRX);
+    char c = pc->getc();
+    delete pc;
+
+    // If signal is correct, start the test
+    if (c == 'S') {
+      Serial *pc = new Serial(USBTX, NC);
+      pc->printf("TX OK - Expected\r\n");
+      delete pc;
+
+      pc = new Serial(NC, USBRX);
+      pc->printf("TX OK - Unexpected\r\n");
+      delete pc;
+    }
+
+
+
+    while (1) {
+    }
+}

--- a/workspace_tools/host_tests/__init__.py
+++ b/workspace_tools/host_tests/__init__.py
@@ -31,6 +31,8 @@ from udpecho_server_auto import UDPEchoServerTest
 from tcpecho_client_auto import TCPEchoClientTest
 from udpecho_client_auto import UDPEchoClientTest
 from wfi_auto import WFITest
+from serial_nc_rx_auto import SerialNCRXTest
+from serial_nc_tx_auto import SerialNCTXTest
 
 # Populate registry with supervising objects
 HOSTREGISTRY = HostRegistry()
@@ -48,6 +50,8 @@ HOSTREGISTRY.register_host_test("udpecho_server_auto", UDPEchoServerTest())
 HOSTREGISTRY.register_host_test("tcpecho_client_auto", TCPEchoClientTest())
 HOSTREGISTRY.register_host_test("udpecho_client_auto", UDPEchoClientTest())
 HOSTREGISTRY.register_host_test("wfi_auto", WFITest())
+HOSTREGISTRY.register_host_test("serial_nc_rx_auto", SerialNCRXTest())
+HOSTREGISTRY.register_host_test("serial_nc_tx_auto", SerialNCTXTest())
 
 ###############################################################################
 # Functional interface for test supervisor registry

--- a/workspace_tools/host_tests/serial_nc_rx_auto.py
+++ b/workspace_tools/host_tests/serial_nc_rx_auto.py
@@ -31,10 +31,9 @@ class SerialNCRXTest():
 
         out_str = selftest.mbed.serial_readline()
 
-        if out_str == None:
+        if not out_str:
             selftest.notify("HOST: No output detected")
             return selftest.RESULT_IO_SERIAL
-
 
         out_str_stripped = out_str.strip(strip_chars)
 
@@ -51,7 +50,7 @@ class SerialNCRXTest():
         out_str = selftest.mbed.serial_readline()
 
         # If no characters received, pass the test
-        if out_str == "" or out_str == None:
+        if not out_str:
             selftest.notify("HOST: No further output detected")
             return selftest.RESULT_SUCCESS
         else:

--- a/workspace_tools/host_tests/serial_nc_rx_auto.py
+++ b/workspace_tools/host_tests/serial_nc_rx_auto.py
@@ -1,0 +1,65 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import uuid
+import time
+import string
+from sys import stdout
+
+class SerialNCRXTest():
+
+    def test(self, selftest):
+        selftest.mbed.flush();
+        selftest.mbed.serial_write("E");
+
+        strip_chars = string.whitespace + "\0"
+
+        out_str = selftest.mbed.serial_readline()
+
+        if out_str == None:
+            selftest.notify("HOST: No output detected")
+            return selftest.RESULT_IO_SERIAL
+
+
+        out_str_stripped = out_str.strip(strip_chars)
+
+        if out_str_stripped != "RX OK - Expected":
+            selftest.notify("HOST: Unexpected output. Expected 'RX OK - Expected' but received '%s'" % out_str_stripped)
+            return selftest.RESULT_FAILURE
+
+        # Wait 0.5 seconds to ensure mbed is listening
+        time.sleep(0.5)
+
+        # Send character, mbed shouldn't receive
+        selftest.mbed.serial_write("U");
+
+        out_str = selftest.mbed.serial_readline()
+
+        # If no characters received, pass the test
+        if out_str == "" or out_str == None:
+            selftest.notify("HOST: No further output detected")
+            return selftest.RESULT_SUCCESS
+        else:
+            out_str_stripped = out_str.strip(strip_chars)
+
+            if out_str_stripped == "RX OK - Unexpected":
+                selftest.notify("HOST: Unexpected output returned indicating RX still functioning")
+            else:
+                selftest.notify("HOST: Extraneous output '%s' detected indicating unknown error" % out_str_stripped)
+
+            return selftest.RESULT_FAILURE

--- a/workspace_tools/host_tests/serial_nc_tx_auto.py
+++ b/workspace_tools/host_tests/serial_nc_tx_auto.py
@@ -1,0 +1,59 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import uuid
+import time
+import string
+from sys import stdout
+
+class SerialNCTXTest():
+
+    def test(self, selftest):
+        selftest.mbed.flush();
+        selftest.mbed.serial_write("S");
+        
+        strip_chars = string.whitespace + "\0"
+
+        out_str = selftest.mbed.serial_readline()
+        selftest.notify("HOST: " + out_str)
+
+        if out_str == None:
+            selftest.notify("HOST: No output detected")
+            return selftest.RESULT_IO_SERIAL
+
+        out_str_stripped = out_str.strip(strip_chars)
+
+        if out_str_stripped != "TX OK - Expected":
+            selftest.notify("HOST: Unexpected output. Expected 'TX OK - Expected' but received '%s'" % out_str_stripped)
+            return selftest.RESULT_FAILURE
+
+        out_str = selftest.mbed.serial_readline()
+
+        # If no characters received, pass the test
+        if out_str == "" or out_str == None:
+            selftest.notify("HOST: No further output detected")
+            return selftest.RESULT_SUCCESS
+        else:
+            out_str_stripped = out_str.strip(strip_chars)
+
+            if out_str_stripped == "TX OK - Unexpected":
+                selftest.notify("HOST: Unexpected output returned indicating TX still functioning")
+            else:
+                selftest.notify("HOST: Extraneous output '%s' detected indicating unknown error" % out_str_stripped)
+
+            return selftest.RESULT_FAILURE

--- a/workspace_tools/host_tests/serial_nc_tx_auto.py
+++ b/workspace_tools/host_tests/serial_nc_tx_auto.py
@@ -26,13 +26,13 @@ class SerialNCTXTest():
     def test(self, selftest):
         selftest.mbed.flush();
         selftest.mbed.serial_write("S");
-        
+
         strip_chars = string.whitespace + "\0"
 
         out_str = selftest.mbed.serial_readline()
         selftest.notify("HOST: " + out_str)
 
-        if out_str == None:
+        if not out_str:
             selftest.notify("HOST: No output detected")
             return selftest.RESULT_IO_SERIAL
 
@@ -45,7 +45,7 @@ class SerialNCTXTest():
         out_str = selftest.mbed.serial_readline()
 
         # If no characters received, pass the test
-        if out_str == "" or out_str == None:
+        if not out_str:
             selftest.notify("HOST: No further output detected")
             return selftest.RESULT_SUCCESS
         else:

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -585,6 +585,18 @@ TESTS = [
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
         "automated": True
     },
+    {
+        "id": "MBED_37", "description": "Serial NC RX",
+        "source_dir": join(TEST_DIR, "mbed", "serial_nc_rx"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True
+    },
+    {
+        "id": "MBED_38", "description": "Serial NC TX",
+        "source_dir": join(TEST_DIR, "mbed", "serial_nc_tx"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True
+    },
 
     # CMSIS RTOS tests
     {


### PR DESCRIPTION
These tests ensure that an mbed platform correctly handles having Serial pins set to NC. It tests to ensure that the target can only transmit or only receive (respectively for serial_nc_tx and serial_nc_rx).