### PR TITLE
allow outside access to RtcHandle

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/rtc_api.c
@@ -35,7 +35,7 @@
 
 static int rtc_inited = 0;
 
-static RTC_HandleTypeDef RtcHandle;
+RTC_HandleTypeDef RtcHandle;
 
 void rtc_init(void)
 {


### PR DESCRIPTION
Since there is not yet any abstraction API for low-power wakeup timer....
The MOTE_L152RC platform needs to application access RtcHandle in order to set RTC Alarm.

RTC Alarm wakes up CPU from deep sleep, after some time delay.