### PR TITLE
Update k64f_emac.c

### DIFF
--- a/libraries/net/eth/lwip-eth/arch/TARGET_Freescale/k64f_emac.c
+++ b/libraries/net/eth/lwip-eth/arch/TARGET_Freescale/k64f_emac.c
@@ -540,7 +540,7 @@ static void packet_rx(void* pvParameters) {
     /* Wait for receive task to wakeup */
     sys_arch_sem_wait(&k64f_enet->RxReadySem, 0);
 
-    if ((bdPtr[idx].control & kEnetRxBdEmpty) == 0) {
+    while ((bdPtr[idx].control & kEnetRxBdEmpty) == 0) {
       k64f_enetif_input(k64f_enet->netif, idx);
       idx = (idx + 1) % ENET_RX_RING_LEN;
     }


### PR DESCRIPTION
process all available packets at once. Because
the interrupt handler is triggered at an interval
and multiple packets could have been received
during that interval. Fix from private fork by Liyou Zhou