### PR TITLE
Fix GCC compilation warnings.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf_delay.h
+++ b/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/nrf_delay.h
@@ -45,7 +45,7 @@ __ASM (
        " BNE loop\n\t");
 }
 #elif defined   (  __GNUC__  )
-static void __INLINE nrf_delay_us(uint32_t volatile number_of_us)
+__INLINE static void nrf_delay_us(uint32_t volatile number_of_us)
 {
     do 
     {

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -29,7 +29,7 @@
 
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
-static uint32_t acceptedSpeeds[17][2] = {{1200, UART_BAUDRATE_BAUDRATE_Baud1200},
+static int acceptedSpeeds[17][2] = {{1200, UART_BAUDRATE_BAUDRATE_Baud1200},
                                          {2400, UART_BAUDRATE_BAUDRATE_Baud2400},
                                          {4800, UART_BAUDRATE_BAUDRATE_Baud4800},
                                          {9600, UART_BAUDRATE_BAUDRATE_Baud9600},


### PR DESCRIPTION
These trivial changes silence annoying GCC warnings that are enabled under `-Wall`.

I've annotated each one individually.

I have accepted the mbed contributor agrreement - I have the same username on mbed.org.