### PR TITLE
Changing return status of singletest.py if a build failure occurs

### DIFF
--- a/workspace_tools/singletest.py
+++ b/workspace_tools/singletest.py
@@ -235,4 +235,7 @@ if __name__ == '__main__':
                                    _opts_extend_test_timeout=opts.extend_test_timeout)
 
     # Runs test suite in CLI mode
-    singletest_in_cli_mode(single_test)
+    if (singletest_in_cli_mode(single_test)):
+        exit(0)
+    else:
+        exit(-1)

--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -1525,6 +1525,9 @@ def singletest_in_cli_mode(single_test):
         # Export build results as html report to sparate file
         write_build_report(build_report, 'tests_build/report.html', single_test.opts_report_build_file_name)
 
+    # Returns True if no build failures of the test projects or their dependencies
+    return len(single_test.build_failures) == 0
+
 class TestLogger():
     """ Super-class for logging and printing ongoing events for test suite pass
     """


### PR DESCRIPTION
Before if a build error occurred when running singletest.py, the return code would still be `0`, indicating no error. It now sets an error code of -1. Not sure if that's the right number, but at least it's nonzero :)