### PR TITLE
Added KL26 Target

### DIFF
--- a/libraries/USBDevice/USBDevice/USBEndpoints.h
+++ b/libraries/USBDevice/USBDevice/USBEndpoints.h
@@ -41,7 +41,7 @@ typedef enum {
 #include "USBEndpoints_LPC17_LPC23.h"
 #elif defined(TARGET_LPC11UXX) || defined(TARGET_LPC1347) || defined (TARGET_LPC11U6X) || defined (TARGET_LPC1549)
 #include "USBEndpoints_LPC11U.h"
-#elif defined(TARGET_KL25Z) | defined(TARGET_KL43Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | defined(TARGET_K64F) | defined(TARGET_K22F) | defined(TARGET_TEENSY3_1)
+#elif defined(TARGET_KL25Z) | defined(TARGET_KL26Z) | defined(TARGET_KL43Z) | defined(TARGET_KL46Z) | defined(TARGET_K20D50M) | defined(TARGET_K64F) | defined(TARGET_K22F) | defined(TARGET_TEENSY3_1)
 #include "USBEndpoints_KL25Z.h"
 #elif defined (TARGET_STM32F4)
 #include "USBEndpoints_STM32F4.h"

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/MKL26Z4.h
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/MKL26Z4.h
@@ -1,0 +1,4454 @@
+/*
+** ###################################################################
+**     Processors:          MKL26Z128VFM4
+**                          MKL26Z64VFM4
+**                          MKL26Z32VM4
+**                          MKL26Z128VFT4
+**                          MKL26Z64VFT4
+**                          MKL26Z32VFT4
+**                          MKL26Z256VLH4
+**                          MKL26Z128VLH4
+**                          MKL26Z64VLH4
+**                          MKL26Z32VLH4
+**                          MKL26Z256VLK4
+**                          MKL26Z256VLL4
+**                          MKL26Z128VLL4
+**                          MKL26Z256VMC4
+**                          MKL26Z128VMC4
+**
+**     Compilers:           ARM Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manual:    KL46P121M48SF4RM, Rev.1 Draft A, Aug 2012
+**     Version:             rev. 1.0, 2012-12-12
+**
+**     Abstract:
+**         CMSIS Peripheral Access Layer for MKL26Z4
+**
+**     Copyright: 1997 - 2012 Freescale, Inc. All Rights Reserved.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2012-12-12)
+**         Initial version.
+**
+** ###################################################################
+*/
+
+/**
+ * @file MKL26Z4.h
+ * @version 1.0
+ * @date 2012-12-12
+ * @brief CMSIS Peripheral Access Layer for MKL26Z4
+ *
+ * CMSIS Peripheral Access Layer for MKL26Z4
+ */
+
+#if !defined(MKL26Z4_H_)
+#define MKL26Z4_H_                               /**< Symbol preventing repeated inclusion */
+
+/** Memory map major version (memory maps with equal major version number are
+ * compatible) */
+#define MCU_MEM_MAP_VERSION 0x0100u
+/** Memory map minor version */
+#define MCU_MEM_MAP_VERSION_MINOR 0x0000u
+
+
+/* ----------------------------------------------------------------------------
+   -- Interrupt vector numbers
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup Interrupt_vector_numbers Interrupt vector numbers
+ * @{
+ */
+
+/** Interrupt Number Definitions */
+typedef enum IRQn {
+  /* Core interrupts */
+  NonMaskableInt_IRQn          = -14,              /**< Non Maskable Interrupt */
+  HardFault_IRQn               = -13,              /**< Cortex-M0 SV Hard Fault Interrupt */
+  SVCall_IRQn                  = -5,               /**< Cortex-M0 SV Call Interrupt */
+  PendSV_IRQn                  = -2,               /**< Cortex-M0 Pend SV Interrupt */
+  SysTick_IRQn                 = -1,               /**< Cortex-M0 System Tick Interrupt */
+
+  /* Device specific interrupts */
+  DMA0_IRQn                    = 0,                /**< DMA channel 0 transfer complete/error interrupt */
+  DMA1_IRQn                    = 1,                /**< DMA channel 1 transfer complete/error interrupt */
+  DMA2_IRQn                    = 2,                /**< DMA channel 2 transfer complete/error interrupt */
+  DMA3_IRQn                    = 3,                /**< DMA channel 3 transfer complete/error interrupt */
+  Reserved20_IRQn              = 4,                /**< Reserved interrupt 20 */
+  FTFA_IRQn                    = 5,                /**< FTFA command complete/read collision interrupt */
+  LVD_LVW_IRQn                 = 6,                /**< Low Voltage Detect, Low Voltage Warning */
+  LLW_IRQn                     = 7,                /**< Low Leakage Wakeup */
+  I2C0_IRQn                    = 8,                /**< I2C0 interrupt */
+  I2C1_IRQn                    = 9,                /**< I2C0 interrupt 25 */
+  SPI0_IRQn                    = 10,               /**< SPI0 interrupt */
+  SPI1_IRQn                    = 11,               /**< SPI1 interrupt */
+  UART0_IRQn                   = 12,               /**< UART0 status/error interrupt */
+  UART1_IRQn                   = 13,               /**< UART1 status/error interrupt */
+  UART2_IRQn                   = 14,               /**< UART2 status/error interrupt */
+  ADC0_IRQn                    = 15,               /**< ADC0 interrupt */
+  CMP0_IRQn                    = 16,               /**< CMP0 interrupt */
+  TPM0_IRQn                    = 17,               /**< TPM0 fault, overflow and channels interrupt */
+  TPM1_IRQn                    = 18,               /**< TPM1 fault, overflow and channels interrupt */
+  TPM2_IRQn                    = 19,               /**< TPM2 fault, overflow and channels interrupt */
+  RTC_IRQn                     = 20,               /**< RTC interrupt */
+  RTC_Seconds_IRQn             = 21,               /**< RTC seconds interrupt */
+  PIT_IRQn                     = 22,               /**< PIT timer interrupt */
+  I2S0_IRQn                    = 23,               /**< I2S0 transmit interrupt */
+  USB0_IRQn                    = 24,               /**< USB0 interrupt */
+  DAC0_IRQn                    = 25,               /**< DAC0 interrupt */
+  TSI0_IRQn                    = 26,               /**< TSI0 interrupt */
+  MCG_IRQn                     = 27,               /**< MCG interrupt */
+  LPTimer_IRQn                 = 28,               /**< LPTimer interrupt */
+  Reserved45_IRQn              = 29,               /**< Reserved interrupt 45 */
+  PORTA_IRQn                   = 30,               /**< Port A interrupt */
+  PORTD_IRQn                   = 31                /**< Port D interrupt */
+} IRQn_Type;
+
+/**
+ * @}
+ */ /* end of group Interrupt_vector_numbers */
+
+
+/* ----------------------------------------------------------------------------
+   -- Cortex M0 Core Configuration
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup Cortex_Core_Configuration Cortex M0 Core Configuration
+ * @{
+ */
+
+#define __CM0PLUS_REV                  0x0000    /**< Core revision r0p0 */
+#define __MPU_PRESENT                  0         /**< Defines if an MPU is present or not */
+#define __VTOR_PRESENT                 1         /**< Defines if an MPU is present or not */
+#define __NVIC_PRIO_BITS               2         /**< Number of priority bits implemented in the NVIC */
+#define __Vendor_SysTickConfig         0         /**< Vendor specific implementation of SysTickConfig is defined */
+
+#include "core_cm0plus.h"              /* Core Peripheral Access Layer */
+#include "system_MKL26Z4.h"            /* Device specific configuration file */
+
+/**
+ * @}
+ */ /* end of group Cortex_Core_Configuration */
+
+
+/* ----------------------------------------------------------------------------
+   -- Device Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup Peripheral_access_layer Device Peripheral Access Layer
+ * @{
+ */
+
+
+/*
+** Start of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma push
+  #pragma anon_unions
+#elif defined(__CWCC__)
+  #pragma push
+  #pragma cpp_extensions on
+#elif defined(__GNUC__)
+  /* anonymous unions are enabled by default */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=extended
+#else
+  #error Not supported compiler type
+#endif
+
+/* ----------------------------------------------------------------------------
+   -- ADC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup ADC_Peripheral_Access_Layer ADC Peripheral Access Layer
+ * @{
+ */
+
+/** ADC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC1[2];                            /**< ADC Status and Control Registers 1, array offset: 0x0, array step: 0x4 */
+  __IO uint32_t CFG1;                              /**< ADC Configuration Register 1, offset: 0x8 */
+  __IO uint32_t CFG2;                              /**< ADC Configuration Register 2, offset: 0xC */
+  __I  uint32_t R[2];                              /**< ADC Data Result Register, array offset: 0x10, array step: 0x4 */
+  __IO uint32_t CV1;                               /**< Compare Value Registers, offset: 0x18 */
+  __IO uint32_t CV2;                               /**< Compare Value Registers, offset: 0x1C */
+  __IO uint32_t SC2;                               /**< Status and Control Register 2, offset: 0x20 */
+  __IO uint32_t SC3;                               /**< Status and Control Register 3, offset: 0x24 */
+  __IO uint32_t OFS;                               /**< ADC Offset Correction Register, offset: 0x28 */
+  __IO uint32_t PG;                                /**< ADC Plus-Side Gain Register, offset: 0x2C */
+  __IO uint32_t MG;                                /**< ADC Minus-Side Gain Register, offset: 0x30 */
+  __IO uint32_t CLPD;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x34 */
+  __IO uint32_t CLPS;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x38 */
+  __IO uint32_t CLP4;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x3C */
+  __IO uint32_t CLP3;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x40 */
+  __IO uint32_t CLP2;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x44 */
+  __IO uint32_t CLP1;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x48 */
+  __IO uint32_t CLP0;                              /**< ADC Plus-Side General Calibration Value Register, offset: 0x4C */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t CLMD;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x54 */
+  __IO uint32_t CLMS;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x58 */
+  __IO uint32_t CLM4;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x5C */
+  __IO uint32_t CLM3;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x60 */
+  __IO uint32_t CLM2;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x64 */
+  __IO uint32_t CLM1;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x68 */
+  __IO uint32_t CLM0;                              /**< ADC Minus-Side General Calibration Value Register, offset: 0x6C */
+} ADC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- ADC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup ADC_Register_Masks ADC Register Masks
+ * @{
+ */
+
+/* SC1 Bit Fields */
+#define ADC_SC1_ADCH_MASK                        0x1Fu
+#define ADC_SC1_ADCH_SHIFT                       0
+#define ADC_SC1_ADCH(x)                          (((uint32_t)(((uint32_t)(x))<<ADC_SC1_ADCH_SHIFT))&ADC_SC1_ADCH_MASK)
+#define ADC_SC1_DIFF_MASK                        0x20u
+#define ADC_SC1_DIFF_SHIFT                       5
+#define ADC_SC1_AIEN_MASK                        0x40u
+#define ADC_SC1_AIEN_SHIFT                       6
+#define ADC_SC1_COCO_MASK                        0x80u
+#define ADC_SC1_COCO_SHIFT                       7
+/* CFG1 Bit Fields */
+#define ADC_CFG1_ADICLK_MASK                     0x3u
+#define ADC_CFG1_ADICLK_SHIFT                    0
+#define ADC_CFG1_ADICLK(x)                       (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_ADICLK_SHIFT))&ADC_CFG1_ADICLK_MASK)
+#define ADC_CFG1_MODE_MASK                       0xCu
+#define ADC_CFG1_MODE_SHIFT                      2
+#define ADC_CFG1_MODE(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_MODE_SHIFT))&ADC_CFG1_MODE_MASK)
+#define ADC_CFG1_ADLSMP_MASK                     0x10u
+#define ADC_CFG1_ADLSMP_SHIFT                    4
+#define ADC_CFG1_ADIV_MASK                       0x60u
+#define ADC_CFG1_ADIV_SHIFT                      5
+#define ADC_CFG1_ADIV(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CFG1_ADIV_SHIFT))&ADC_CFG1_ADIV_MASK)
+#define ADC_CFG1_ADLPC_MASK                      0x80u
+#define ADC_CFG1_ADLPC_SHIFT                     7
+/* CFG2 Bit Fields */
+#define ADC_CFG2_ADLSTS_MASK                     0x3u
+#define ADC_CFG2_ADLSTS_SHIFT                    0
+#define ADC_CFG2_ADLSTS(x)                       (((uint32_t)(((uint32_t)(x))<<ADC_CFG2_ADLSTS_SHIFT))&ADC_CFG2_ADLSTS_MASK)
+#define ADC_CFG2_ADHSC_MASK                      0x4u
+#define ADC_CFG2_ADHSC_SHIFT                     2
+#define ADC_CFG2_ADACKEN_MASK                    0x8u
+#define ADC_CFG2_ADACKEN_SHIFT                   3
+#define ADC_CFG2_MUXSEL_MASK                     0x10u
+#define ADC_CFG2_MUXSEL_SHIFT                    4
+/* R Bit Fields */
+#define ADC_R_D_MASK                             0xFFFFu
+#define ADC_R_D_SHIFT                            0
+#define ADC_R_D(x)                               (((uint32_t)(((uint32_t)(x))<<ADC_R_D_SHIFT))&ADC_R_D_MASK)
+/* CV1 Bit Fields */
+#define ADC_CV1_CV_MASK                          0xFFFFu
+#define ADC_CV1_CV_SHIFT                         0
+#define ADC_CV1_CV(x)                            (((uint32_t)(((uint32_t)(x))<<ADC_CV1_CV_SHIFT))&ADC_CV1_CV_MASK)
+/* CV2 Bit Fields */
+#define ADC_CV2_CV_MASK                          0xFFFFu
+#define ADC_CV2_CV_SHIFT                         0
+#define ADC_CV2_CV(x)                            (((uint32_t)(((uint32_t)(x))<<ADC_CV2_CV_SHIFT))&ADC_CV2_CV_MASK)
+/* SC2 Bit Fields */
+#define ADC_SC2_REFSEL_MASK                      0x3u
+#define ADC_SC2_REFSEL_SHIFT                     0
+#define ADC_SC2_REFSEL(x)                        (((uint32_t)(((uint32_t)(x))<<ADC_SC2_REFSEL_SHIFT))&ADC_SC2_REFSEL_MASK)
+#define ADC_SC2_DMAEN_MASK                       0x4u
+#define ADC_SC2_DMAEN_SHIFT                      2
+#define ADC_SC2_ACREN_MASK                       0x8u
+#define ADC_SC2_ACREN_SHIFT                      3
+#define ADC_SC2_ACFGT_MASK                       0x10u
+#define ADC_SC2_ACFGT_SHIFT                      4
+#define ADC_SC2_ACFE_MASK                        0x20u
+#define ADC_SC2_ACFE_SHIFT                       5
+#define ADC_SC2_ADTRG_MASK                       0x40u
+#define ADC_SC2_ADTRG_SHIFT                      6
+#define ADC_SC2_ADACT_MASK                       0x80u
+#define ADC_SC2_ADACT_SHIFT                      7
+/* SC3 Bit Fields */
+#define ADC_SC3_AVGS_MASK                        0x3u
+#define ADC_SC3_AVGS_SHIFT                       0
+#define ADC_SC3_AVGS(x)                          (((uint32_t)(((uint32_t)(x))<<ADC_SC3_AVGS_SHIFT))&ADC_SC3_AVGS_MASK)
+#define ADC_SC3_AVGE_MASK                        0x4u
+#define ADC_SC3_AVGE_SHIFT                       2
+#define ADC_SC3_ADCO_MASK                        0x8u
+#define ADC_SC3_ADCO_SHIFT                       3
+#define ADC_SC3_CALF_MASK                        0x40u
+#define ADC_SC3_CALF_SHIFT                       6
+#define ADC_SC3_CAL_MASK                         0x80u
+#define ADC_SC3_CAL_SHIFT                        7
+/* OFS Bit Fields */
+#define ADC_OFS_OFS_MASK                         0xFFFFu
+#define ADC_OFS_OFS_SHIFT                        0
+#define ADC_OFS_OFS(x)                           (((uint32_t)(((uint32_t)(x))<<ADC_OFS_OFS_SHIFT))&ADC_OFS_OFS_MASK)
+/* PG Bit Fields */
+#define ADC_PG_PG_MASK                           0xFFFFu
+#define ADC_PG_PG_SHIFT                          0
+#define ADC_PG_PG(x)                             (((uint32_t)(((uint32_t)(x))<<ADC_PG_PG_SHIFT))&ADC_PG_PG_MASK)
+/* MG Bit Fields */
+#define ADC_MG_MG_MASK                           0xFFFFu
+#define ADC_MG_MG_SHIFT                          0
+#define ADC_MG_MG(x)                             (((uint32_t)(((uint32_t)(x))<<ADC_MG_MG_SHIFT))&ADC_MG_MG_MASK)
+/* CLPD Bit Fields */
+#define ADC_CLPD_CLPD_MASK                       0x3Fu
+#define ADC_CLPD_CLPD_SHIFT                      0
+#define ADC_CLPD_CLPD(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLPD_CLPD_SHIFT))&ADC_CLPD_CLPD_MASK)
+/* CLPS Bit Fields */
+#define ADC_CLPS_CLPS_MASK                       0x3Fu
+#define ADC_CLPS_CLPS_SHIFT                      0
+#define ADC_CLPS_CLPS(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLPS_CLPS_SHIFT))&ADC_CLPS_CLPS_MASK)
+/* CLP4 Bit Fields */
+#define ADC_CLP4_CLP4_MASK                       0x3FFu
+#define ADC_CLP4_CLP4_SHIFT                      0
+#define ADC_CLP4_CLP4(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP4_CLP4_SHIFT))&ADC_CLP4_CLP4_MASK)
+/* CLP3 Bit Fields */
+#define ADC_CLP3_CLP3_MASK                       0x1FFu
+#define ADC_CLP3_CLP3_SHIFT                      0
+#define ADC_CLP3_CLP3(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP3_CLP3_SHIFT))&ADC_CLP3_CLP3_MASK)
+/* CLP2 Bit Fields */
+#define ADC_CLP2_CLP2_MASK                       0xFFu
+#define ADC_CLP2_CLP2_SHIFT                      0
+#define ADC_CLP2_CLP2(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP2_CLP2_SHIFT))&ADC_CLP2_CLP2_MASK)
+/* CLP1 Bit Fields */
+#define ADC_CLP1_CLP1_MASK                       0x7Fu
+#define ADC_CLP1_CLP1_SHIFT                      0
+#define ADC_CLP1_CLP1(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP1_CLP1_SHIFT))&ADC_CLP1_CLP1_MASK)
+/* CLP0 Bit Fields */
+#define ADC_CLP0_CLP0_MASK                       0x3Fu
+#define ADC_CLP0_CLP0_SHIFT                      0
+#define ADC_CLP0_CLP0(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLP0_CLP0_SHIFT))&ADC_CLP0_CLP0_MASK)
+/* CLMD Bit Fields */
+#define ADC_CLMD_CLMD_MASK                       0x3Fu
+#define ADC_CLMD_CLMD_SHIFT                      0
+#define ADC_CLMD_CLMD(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLMD_CLMD_SHIFT))&ADC_CLMD_CLMD_MASK)
+/* CLMS Bit Fields */
+#define ADC_CLMS_CLMS_MASK                       0x3Fu
+#define ADC_CLMS_CLMS_SHIFT                      0
+#define ADC_CLMS_CLMS(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLMS_CLMS_SHIFT))&ADC_CLMS_CLMS_MASK)
+/* CLM4 Bit Fields */
+#define ADC_CLM4_CLM4_MASK                       0x3FFu
+#define ADC_CLM4_CLM4_SHIFT                      0
+#define ADC_CLM4_CLM4(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM4_CLM4_SHIFT))&ADC_CLM4_CLM4_MASK)
+/* CLM3 Bit Fields */
+#define ADC_CLM3_CLM3_MASK                       0x1FFu
+#define ADC_CLM3_CLM3_SHIFT                      0
+#define ADC_CLM3_CLM3(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM3_CLM3_SHIFT))&ADC_CLM3_CLM3_MASK)
+/* CLM2 Bit Fields */
+#define ADC_CLM2_CLM2_MASK                       0xFFu
+#define ADC_CLM2_CLM2_SHIFT                      0
+#define ADC_CLM2_CLM2(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM2_CLM2_SHIFT))&ADC_CLM2_CLM2_MASK)
+/* CLM1 Bit Fields */
+#define ADC_CLM1_CLM1_MASK                       0x7Fu
+#define ADC_CLM1_CLM1_SHIFT                      0
+#define ADC_CLM1_CLM1(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM1_CLM1_SHIFT))&ADC_CLM1_CLM1_MASK)
+/* CLM0 Bit Fields */
+#define ADC_CLM0_CLM0_MASK                       0x3Fu
+#define ADC_CLM0_CLM0_SHIFT                      0
+#define ADC_CLM0_CLM0(x)                         (((uint32_t)(((uint32_t)(x))<<ADC_CLM0_CLM0_SHIFT))&ADC_CLM0_CLM0_MASK)
+
+/**
+ * @}
+ */ /* end of group ADC_Register_Masks */
+
+
+/* ADC - Peripheral instance base addresses */
+/** Peripheral ADC0 base address */
+#define ADC0_BASE                                (0x4003B000u)
+/** Peripheral ADC0 base pointer */
+#define ADC0                                     ((ADC_Type *)ADC0_BASE)
+/** Array initializer of ADC peripheral base pointers */
+#define ADC_BASES                                { ADC0 }
+
+/**
+ * @}
+ */ /* end of group ADC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- CMP Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup CMP_Peripheral_Access_Layer CMP Peripheral Access Layer
+ * @{
+ */
+
+/** CMP - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR0;                                /**< CMP Control Register 0, offset: 0x0 */
+  __IO uint8_t CR1;                                /**< CMP Control Register 1, offset: 0x1 */
+  __IO uint8_t FPR;                                /**< CMP Filter Period Register, offset: 0x2 */
+  __IO uint8_t SCR;                                /**< CMP Status and Control Register, offset: 0x3 */
+  __IO uint8_t DACCR;                              /**< DAC Control Register, offset: 0x4 */
+  __IO uint8_t MUXCR;                              /**< MUX Control Register, offset: 0x5 */
+} CMP_Type;
+
+/* ----------------------------------------------------------------------------
+   -- CMP Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup CMP_Register_Masks CMP Register Masks
+ * @{
+ */
+
+/* CR0 Bit Fields */
+#define CMP_CR0_HYSTCTR_MASK                     0x3u
+#define CMP_CR0_HYSTCTR_SHIFT                    0
+#define CMP_CR0_HYSTCTR(x)                       (((uint8_t)(((uint8_t)(x))<<CMP_CR0_HYSTCTR_SHIFT))&CMP_CR0_HYSTCTR_MASK)
+#define CMP_CR0_FILTER_CNT_MASK                  0x70u
+#define CMP_CR0_FILTER_CNT_SHIFT                 4
+#define CMP_CR0_FILTER_CNT(x)                    (((uint8_t)(((uint8_t)(x))<<CMP_CR0_FILTER_CNT_SHIFT))&CMP_CR0_FILTER_CNT_MASK)
+/* CR1 Bit Fields */
+#define CMP_CR1_EN_MASK                          0x1u
+#define CMP_CR1_EN_SHIFT                         0
+#define CMP_CR1_OPE_MASK                         0x2u
+#define CMP_CR1_OPE_SHIFT                        1
+#define CMP_CR1_COS_MASK                         0x4u
+#define CMP_CR1_COS_SHIFT                        2
+#define CMP_CR1_INV_MASK                         0x8u
+#define CMP_CR1_INV_SHIFT                        3
+#define CMP_CR1_PMODE_MASK                       0x10u
+#define CMP_CR1_PMODE_SHIFT                      4
+#define CMP_CR1_TRIGM_MASK                       0x20u
+#define CMP_CR1_TRIGM_SHIFT                      5
+#define CMP_CR1_WE_MASK                          0x40u
+#define CMP_CR1_WE_SHIFT                         6
+#define CMP_CR1_SE_MASK                          0x80u
+#define CMP_CR1_SE_SHIFT                         7
+/* FPR Bit Fields */
+#define CMP_FPR_FILT_PER_MASK                    0xFFu
+#define CMP_FPR_FILT_PER_SHIFT                   0
+#define CMP_FPR_FILT_PER(x)                      (((uint8_t)(((uint8_t)(x))<<CMP_FPR_FILT_PER_SHIFT))&CMP_FPR_FILT_PER_MASK)
+/* SCR Bit Fields */
+#define CMP_SCR_COUT_MASK                        0x1u
+#define CMP_SCR_COUT_SHIFT                       0
+#define CMP_SCR_CFF_MASK                         0x2u
+#define CMP_SCR_CFF_SHIFT                        1
+#define CMP_SCR_CFR_MASK                         0x4u
+#define CMP_SCR_CFR_SHIFT                        2
+#define CMP_SCR_IEF_MASK                         0x8u
+#define CMP_SCR_IEF_SHIFT                        3
+#define CMP_SCR_IER_MASK                         0x10u
+#define CMP_SCR_IER_SHIFT                        4
+#define CMP_SCR_DMAEN_MASK                       0x40u
+#define CMP_SCR_DMAEN_SHIFT                      6
+/* DACCR Bit Fields */
+#define CMP_DACCR_VOSEL_MASK                     0x3Fu
+#define CMP_DACCR_VOSEL_SHIFT                    0
+#define CMP_DACCR_VOSEL(x)                       (((uint8_t)(((uint8_t)(x))<<CMP_DACCR_VOSEL_SHIFT))&CMP_DACCR_VOSEL_MASK)
+#define CMP_DACCR_VRSEL_MASK                     0x40u
+#define CMP_DACCR_VRSEL_SHIFT                    6
+#define CMP_DACCR_DACEN_MASK                     0x80u
+#define CMP_DACCR_DACEN_SHIFT                    7
+/* MUXCR Bit Fields */
+#define CMP_MUXCR_MSEL_MASK                      0x7u
+#define CMP_MUXCR_MSEL_SHIFT                     0
+#define CMP_MUXCR_MSEL(x)                        (((uint8_t)(((uint8_t)(x))<<CMP_MUXCR_MSEL_SHIFT))&CMP_MUXCR_MSEL_MASK)
+#define CMP_MUXCR_PSEL_MASK                      0x38u
+#define CMP_MUXCR_PSEL_SHIFT                     3
+#define CMP_MUXCR_PSEL(x)                        (((uint8_t)(((uint8_t)(x))<<CMP_MUXCR_PSEL_SHIFT))&CMP_MUXCR_PSEL_MASK)
+#define CMP_MUXCR_PSTM_MASK                      0x80u
+#define CMP_MUXCR_PSTM_SHIFT                     7
+
+/**
+ * @}
+ */ /* end of group CMP_Register_Masks */
+
+
+/* CMP - Peripheral instance base addresses */
+/** Peripheral CMP0 base address */
+#define CMP0_BASE                                (0x40073000u)
+/** Peripheral CMP0 base pointer */
+#define CMP0                                     ((CMP_Type *)CMP0_BASE)
+/** Array initializer of CMP peripheral base pointers */
+#define CMP_BASES                                { CMP0 }
+
+/**
+ * @}
+ */ /* end of group CMP_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DAC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup DAC_Peripheral_Access_Layer DAC Peripheral Access Layer
+ * @{
+ */
+
+/** DAC - Register Layout Typedef */
+typedef struct {
+  struct {                                         /* offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATL;                               /**< DAC Data Low Register, array offset: 0x0, array step: 0x2 */
+    __IO uint8_t DATH;                               /**< DAC Data High Register, array offset: 0x1, array step: 0x2 */
+  } DAT[2];
+       uint8_t RESERVED_0[28];
+  __IO uint8_t SR;                                 /**< DAC Status Register, offset: 0x20 */
+  __IO uint8_t C0;                                 /**< DAC Control Register, offset: 0x21 */
+  __IO uint8_t C1;                                 /**< DAC Control Register 1, offset: 0x22 */
+  __IO uint8_t C2;                                 /**< DAC Control Register 2, offset: 0x23 */
+} DAC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- DAC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup DAC_Register_Masks DAC Register Masks
+ * @{
+ */
+
+/* DATL Bit Fields */
+#define DAC_DATL_DATA0_MASK                      0xFFu
+#define DAC_DATL_DATA0_SHIFT                     0
+#define DAC_DATL_DATA0(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_DATL_DATA0_SHIFT))&DAC_DATL_DATA0_MASK)
+/* DATH Bit Fields */
+#define DAC_DATH_DATA1_MASK                      0xFu
+#define DAC_DATH_DATA1_SHIFT                     0
+#define DAC_DATH_DATA1(x)                        (((uint8_t)(((uint8_t)(x))<<DAC_DATH_DATA1_SHIFT))&DAC_DATH_DATA1_MASK)
+/* SR Bit Fields */
+#define DAC_SR_DACBFRPBF_MASK                    0x1u
+#define DAC_SR_DACBFRPBF_SHIFT                   0
+#define DAC_SR_DACBFRPTF_MASK                    0x2u
+#define DAC_SR_DACBFRPTF_SHIFT                   1
+/* C0 Bit Fields */
+#define DAC_C0_DACBBIEN_MASK                     0x1u
+#define DAC_C0_DACBBIEN_SHIFT                    0
+#define DAC_C0_DACBTIEN_MASK                     0x2u
+#define DAC_C0_DACBTIEN_SHIFT                    1
+#define DAC_C0_LPEN_MASK                         0x8u
+#define DAC_C0_LPEN_SHIFT                        3
+#define DAC_C0_DACSWTRG_MASK                     0x10u
+#define DAC_C0_DACSWTRG_SHIFT                    4
+#define DAC_C0_DACTRGSEL_MASK                    0x20u
+#define DAC_C0_DACTRGSEL_SHIFT                   5
+#define DAC_C0_DACRFS_MASK                       0x40u
+#define DAC_C0_DACRFS_SHIFT                      6
+#define DAC_C0_DACEN_MASK                        0x80u
+#define DAC_C0_DACEN_SHIFT                       7
+/* C1 Bit Fields */
+#define DAC_C1_DACBFEN_MASK                      0x1u
+#define DAC_C1_DACBFEN_SHIFT                     0
+#define DAC_C1_DACBFMD_MASK                      0x4u
+#define DAC_C1_DACBFMD_SHIFT                     2
+#define DAC_C1_DMAEN_MASK                        0x80u
+#define DAC_C1_DMAEN_SHIFT                       7
+/* C2 Bit Fields */
+#define DAC_C2_DACBFUP_MASK                      0x1u
+#define DAC_C2_DACBFUP_SHIFT                     0
+#define DAC_C2_DACBFRP_MASK                      0x10u
+#define DAC_C2_DACBFRP_SHIFT                     4
+
+/**
+ * @}
+ */ /* end of group DAC_Register_Masks */
+
+
+/* DAC - Peripheral instance base addresses */
+/** Peripheral DAC0 base address */
+#define DAC0_BASE                                (0x4003F000u)
+/** Peripheral DAC0 base pointer */
+#define DAC0                                     ((DAC_Type *)DAC0_BASE)
+/** Array initializer of DAC peripheral base pointers */
+#define DAC_BASES                                { DAC0 }
+
+/**
+ * @}
+ */ /* end of group DAC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup DMA_Peripheral_Access_Layer DMA Peripheral Access Layer
+ * @{
+ */
+
+/** DMA - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[256];
+  struct {                                         /* offset: 0x100, array step: 0x10 */
+    __IO uint32_t SAR;                               /**< Source Address Register, array offset: 0x100, array step: 0x10 */
+    __IO uint32_t DAR;                               /**< Destination Address Register, array offset: 0x104, array step: 0x10 */
+    union {                                          /* offset: 0x108, array step: 0x10 */
+      __IO uint32_t DSR_BCR;                           /**< DMA Status Register / Byte Count Register, array offset: 0x108, array step: 0x10 */
+      struct {                                         /* offset: 0x108, array step: 0x10 */
+             uint8_t RESERVED_0[3];
+        __IO uint8_t DSR;                                /**< DMA_DSR0 register...DMA_DSR3 register., array offset: 0x10B, array step: 0x10 */
+      } DMA_DSR_ACCESS8BIT;
+    };
+    __IO uint32_t DCR;                               /**< DMA Control Register, array offset: 0x10C, array step: 0x10 */
+  } DMA[4];
+} DMA_Type;
+
+/* ----------------------------------------------------------------------------
+   -- DMA Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup DMA_Register_Masks DMA Register Masks
+ * @{
+ */
+
+/* SAR Bit Fields */
+#define DMA_SAR_SAR_MASK                         0xFFFFFFFFu
+#define DMA_SAR_SAR_SHIFT                        0
+#define DMA_SAR_SAR(x)                           (((uint32_t)(((uint32_t)(x))<<DMA_SAR_SAR_SHIFT))&DMA_SAR_SAR_MASK)
+/* DAR Bit Fields */
+#define DMA_DAR_DAR_MASK                         0xFFFFFFFFu
+#define DMA_DAR_DAR_SHIFT                        0
+#define DMA_DAR_DAR(x)                           (((uint32_t)(((uint32_t)(x))<<DMA_DAR_DAR_SHIFT))&DMA_DAR_DAR_MASK)
+/* DSR_BCR Bit Fields */
+#define DMA_DSR_BCR_BCR_MASK                     0xFFFFFFu
+#define DMA_DSR_BCR_BCR_SHIFT                    0
+#define DMA_DSR_BCR_BCR(x)                       (((uint32_t)(((uint32_t)(x))<<DMA_DSR_BCR_BCR_SHIFT))&DMA_DSR_BCR_BCR_MASK)
+#define DMA_DSR_BCR_DONE_MASK                    0x1000000u
+#define DMA_DSR_BCR_DONE_SHIFT                   24
+#define DMA_DSR_BCR_BSY_MASK                     0x2000000u
+#define DMA_DSR_BCR_BSY_SHIFT                    25
+#define DMA_DSR_BCR_REQ_MASK                     0x4000000u
+#define DMA_DSR_BCR_REQ_SHIFT                    26
+#define DMA_DSR_BCR_BED_MASK                     0x10000000u
+#define DMA_DSR_BCR_BED_SHIFT                    28
+#define DMA_DSR_BCR_BES_MASK                     0x20000000u
+#define DMA_DSR_BCR_BES_SHIFT                    29
+#define DMA_DSR_BCR_CE_MASK                      0x40000000u
+#define DMA_DSR_BCR_CE_SHIFT                     30
+/* DCR Bit Fields */
+#define DMA_DCR_LCH2_MASK                        0x3u
+#define DMA_DCR_LCH2_SHIFT                       0
+#define DMA_DCR_LCH2(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_LCH2_SHIFT))&DMA_DCR_LCH2_MASK)
+#define DMA_DCR_LCH1_MASK                        0xCu
+#define DMA_DCR_LCH1_SHIFT                       2
+#define DMA_DCR_LCH1(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_LCH1_SHIFT))&DMA_DCR_LCH1_MASK)
+#define DMA_DCR_LINKCC_MASK                      0x30u
+#define DMA_DCR_LINKCC_SHIFT                     4
+#define DMA_DCR_LINKCC(x)                        (((uint32_t)(((uint32_t)(x))<<DMA_DCR_LINKCC_SHIFT))&DMA_DCR_LINKCC_MASK)
+#define DMA_DCR_D_REQ_MASK                       0x80u
+#define DMA_DCR_D_REQ_SHIFT                      7
+#define DMA_DCR_DMOD_MASK                        0xF00u
+#define DMA_DCR_DMOD_SHIFT                       8
+#define DMA_DCR_DMOD(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_DMOD_SHIFT))&DMA_DCR_DMOD_MASK)
+#define DMA_DCR_SMOD_MASK                        0xF000u
+#define DMA_DCR_SMOD_SHIFT                       12
+#define DMA_DCR_SMOD(x)                          (((uint32_t)(((uint32_t)(x))<<DMA_DCR_SMOD_SHIFT))&DMA_DCR_SMOD_MASK)
+#define DMA_DCR_START_MASK                       0x10000u
+#define DMA_DCR_START_SHIFT                      16
+#define DMA_DCR_DSIZE_MASK                       0x60000u
+#define DMA_DCR_DSIZE_SHIFT                      17
+#define DMA_DCR_DSIZE(x)                         (((uint32_t)(((uint32_t)(x))<<DMA_DCR_DSIZE_SHIFT))&DMA_DCR_DSIZE_MASK)
+#define DMA_DCR_DINC_MASK                        0x80000u
+#define DMA_DCR_DINC_SHIFT                       19
+#define DMA_DCR_SSIZE_MASK                       0x300000u
+#define DMA_DCR_SSIZE_SHIFT                      20
+#define DMA_DCR_SSIZE(x)                         (((uint32_t)(((uint32_t)(x))<<DMA_DCR_SSIZE_SHIFT))&DMA_DCR_SSIZE_MASK)
+#define DMA_DCR_SINC_MASK                        0x400000u
+#define DMA_DCR_SINC_SHIFT                       22
+#define DMA_DCR_EADREQ_MASK                      0x800000u
+#define DMA_DCR_EADREQ_SHIFT                     23
+#define DMA_DCR_AA_MASK                          0x10000000u
+#define DMA_DCR_AA_SHIFT                         28
+#define DMA_DCR_CS_MASK                          0x20000000u
+#define DMA_DCR_CS_SHIFT                         29
+#define DMA_DCR_ERQ_MASK                         0x40000000u
+#define DMA_DCR_ERQ_SHIFT                        30
+#define DMA_DCR_EINT_MASK                        0x80000000u
+#define DMA_DCR_EINT_SHIFT                       31
+
+/**
+ * @}
+ */ /* end of group DMA_Register_Masks */
+
+
+/* DMA - Peripheral instance base addresses */
+/** Peripheral DMA base address */
+#define DMA_BASE                                 (0x40008000u)
+/** Peripheral DMA base pointer */
+#define DMA0                                     ((DMA_Type *)DMA_BASE)
+/** Array initializer of DMA peripheral base pointers */
+#define DMA_BASES                                { DMA0 }
+
+/**
+ * @}
+ */ /* end of group DMA_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup DMAMUX_Peripheral_Access_Layer DMAMUX Peripheral Access Layer
+ * @{
+ */
+
+/** DMAMUX - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CHCFG[4];                           /**< Channel Configuration register, array offset: 0x0, array step: 0x1 */
+} DMAMUX_Type;
+
+/* ----------------------------------------------------------------------------
+   -- DMAMUX Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup DMAMUX_Register_Masks DMAMUX Register Masks
+ * @{
+ */
+
+/* CHCFG Bit Fields */
+#define DMAMUX_CHCFG_SOURCE_MASK                 0x3Fu
+#define DMAMUX_CHCFG_SOURCE_SHIFT                0
+#define DMAMUX_CHCFG_SOURCE(x)                   (((uint8_t)(((uint8_t)(x))<<DMAMUX_CHCFG_SOURCE_SHIFT))&DMAMUX_CHCFG_SOURCE_MASK)
+#define DMAMUX_CHCFG_TRIG_MASK                   0x40u
+#define DMAMUX_CHCFG_TRIG_SHIFT                  6
+#define DMAMUX_CHCFG_ENBL_MASK                   0x80u
+#define DMAMUX_CHCFG_ENBL_SHIFT                  7
+
+/**
+ * @}
+ */ /* end of group DMAMUX_Register_Masks */
+
+
+/* DMAMUX - Peripheral instance base addresses */
+/** Peripheral DMAMUX0 base address */
+#define DMAMUX0_BASE                             (0x40021000u)
+/** Peripheral DMAMUX0 base pointer */
+#define DMAMUX0                                  ((DMAMUX_Type *)DMAMUX0_BASE)
+/** Array initializer of DMAMUX peripheral base pointers */
+#define DMAMUX_BASES                             { DMAMUX0 }
+
+/**
+ * @}
+ */ /* end of group DMAMUX_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FGPIO Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup FGPIO_Peripheral_Access_Layer FGPIO Peripheral Access Layer
+ * @{
+ */
+
+/** FGPIO - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PDOR;                              /**< Port Data Output Register, offset: 0x0 */
+  __O  uint32_t PSOR;                              /**< Port Set Output Register, offset: 0x4 */
+  __O  uint32_t PCOR;                              /**< Port Clear Output Register, offset: 0x8 */
+  __O  uint32_t PTOR;                              /**< Port Toggle Output Register, offset: 0xC */
+  __I  uint32_t PDIR;                              /**< Port Data Input Register, offset: 0x10 */
+  __IO uint32_t PDDR;                              /**< Port Data Direction Register, offset: 0x14 */
+} FGPIO_Type;
+
+/* ----------------------------------------------------------------------------
+   -- FGPIO Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup FGPIO_Register_Masks FGPIO Register Masks
+ * @{
+ */
+
+/* PDOR Bit Fields */
+#define FGPIO_PDOR_PDO_MASK                      0xFFFFFFFFu
+#define FGPIO_PDOR_PDO_SHIFT                     0
+#define FGPIO_PDOR_PDO(x)                        (((uint32_t)(((uint32_t)(x))<<FGPIO_PDOR_PDO_SHIFT))&FGPIO_PDOR_PDO_MASK)
+/* PSOR Bit Fields */
+#define FGPIO_PSOR_PTSO_MASK                     0xFFFFFFFFu
+#define FGPIO_PSOR_PTSO_SHIFT                    0
+#define FGPIO_PSOR_PTSO(x)                       (((uint32_t)(((uint32_t)(x))<<FGPIO_PSOR_PTSO_SHIFT))&FGPIO_PSOR_PTSO_MASK)
+/* PCOR Bit Fields */
+#define FGPIO_PCOR_PTCO_MASK                     0xFFFFFFFFu
+#define FGPIO_PCOR_PTCO_SHIFT                    0
+#define FGPIO_PCOR_PTCO(x)                       (((uint32_t)(((uint32_t)(x))<<FGPIO_PCOR_PTCO_SHIFT))&FGPIO_PCOR_PTCO_MASK)
+/* PTOR Bit Fields */
+#define FGPIO_PTOR_PTTO_MASK                     0xFFFFFFFFu
+#define FGPIO_PTOR_PTTO_SHIFT                    0
+#define FGPIO_PTOR_PTTO(x)                       (((uint32_t)(((uint32_t)(x))<<FGPIO_PTOR_PTTO_SHIFT))&FGPIO_PTOR_PTTO_MASK)
+/* PDIR Bit Fields */
+#define FGPIO_PDIR_PDI_MASK                      0xFFFFFFFFu
+#define FGPIO_PDIR_PDI_SHIFT                     0
+#define FGPIO_PDIR_PDI(x)                        (((uint32_t)(((uint32_t)(x))<<FGPIO_PDIR_PDI_SHIFT))&FGPIO_PDIR_PDI_MASK)
+/* PDDR Bit Fields */
+#define FGPIO_PDDR_PDD_MASK                      0xFFFFFFFFu
+#define FGPIO_PDDR_PDD_SHIFT                     0
+#define FGPIO_PDDR_PDD(x)                        (((uint32_t)(((uint32_t)(x))<<FGPIO_PDDR_PDD_SHIFT))&FGPIO_PDDR_PDD_MASK)
+
+/**
+ * @}
+ */ /* end of group FGPIO_Register_Masks */
+
+
+/* FGPIO - Peripheral instance base addresses */
+/** Peripheral FPTA base address */
+#define FPTA_BASE                                (0xF80FF000u)
+/** Peripheral FPTA base pointer */
+#define FPTA                                     ((FGPIO_Type *)FPTA_BASE)
+/** Peripheral FPTB base address */
+#define FPTB_BASE                                (0xF80FF040u)
+/** Peripheral FPTB base pointer */
+#define FPTB                                     ((FGPIO_Type *)FPTB_BASE)
+/** Peripheral FPTC base address */
+#define FPTC_BASE                                (0xF80FF080u)
+/** Peripheral FPTC base pointer */
+#define FPTC                                     ((FGPIO_Type *)FPTC_BASE)
+/** Peripheral FPTD base address */
+#define FPTD_BASE                                (0xF80FF0C0u)
+/** Peripheral FPTD base pointer */
+#define FPTD                                     ((FGPIO_Type *)FPTD_BASE)
+/** Peripheral FPTE base address */
+#define FPTE_BASE                                (0xF80FF100u)
+/** Peripheral FPTE base pointer */
+#define FPTE                                     ((FGPIO_Type *)FPTE_BASE)
+/** Array initializer of FGPIO peripheral base pointers */
+#define FGPIO_BASES                              { FPTA, FPTB, FPTC, FPTD, FPTE }
+
+/**
+ * @}
+ */ /* end of group FGPIO_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- FTFA Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup FTFA_Peripheral_Access_Layer FTFA Peripheral Access Layer
+ * @{
+ */
+
+/** FTFA - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t FSTAT;                              /**< Flash Status Register, offset: 0x0 */
+  __IO uint8_t FCNFG;                              /**< Flash Configuration Register, offset: 0x1 */
+  __I  uint8_t FSEC;                               /**< Flash Security Register, offset: 0x2 */
+  __I  uint8_t FOPT;                               /**< Flash Option Register, offset: 0x3 */
+  __IO uint8_t FCCOB3;                             /**< Flash Common Command Object Registers, offset: 0x4 */
+  __IO uint8_t FCCOB2;                             /**< Flash Common Command Object Registers, offset: 0x5 */
+  __IO uint8_t FCCOB1;                             /**< Flash Common Command Object Registers, offset: 0x6 */
+  __IO uint8_t FCCOB0;                             /**< Flash Common Command Object Registers, offset: 0x7 */
+  __IO uint8_t FCCOB7;                             /**< Flash Common Command Object Registers, offset: 0x8 */
+  __IO uint8_t FCCOB6;                             /**< Flash Common Command Object Registers, offset: 0x9 */
+  __IO uint8_t FCCOB5;                             /**< Flash Common Command Object Registers, offset: 0xA */
+  __IO uint8_t FCCOB4;                             /**< Flash Common Command Object Registers, offset: 0xB */
+  __IO uint8_t FCCOBB;                             /**< Flash Common Command Object Registers, offset: 0xC */
+  __IO uint8_t FCCOBA;                             /**< Flash Common Command Object Registers, offset: 0xD */
+  __IO uint8_t FCCOB9;                             /**< Flash Common Command Object Registers, offset: 0xE */
+  __IO uint8_t FCCOB8;                             /**< Flash Common Command Object Registers, offset: 0xF */
+  __IO uint8_t FPROT3;                             /**< Program Flash Protection Registers, offset: 0x10 */
+  __IO uint8_t FPROT2;                             /**< Program Flash Protection Registers, offset: 0x11 */
+  __IO uint8_t FPROT1;                             /**< Program Flash Protection Registers, offset: 0x12 */
+  __IO uint8_t FPROT0;                             /**< Program Flash Protection Registers, offset: 0x13 */
+} FTFA_Type;
+
+/* ----------------------------------------------------------------------------
+   -- FTFA Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup FTFA_Register_Masks FTFA Register Masks
+ * @{
+ */
+
+/* FSTAT Bit Fields */
+#define FTFA_FSTAT_MGSTAT0_MASK                  0x1u
+#define FTFA_FSTAT_MGSTAT0_SHIFT                 0
+#define FTFA_FSTAT_FPVIOL_MASK                   0x10u
+#define FTFA_FSTAT_FPVIOL_SHIFT                  4
+#define FTFA_FSTAT_ACCERR_MASK                   0x20u
+#define FTFA_FSTAT_ACCERR_SHIFT                  5
+#define FTFA_FSTAT_RDCOLERR_MASK                 0x40u
+#define FTFA_FSTAT_RDCOLERR_SHIFT                6
+#define FTFA_FSTAT_CCIF_MASK                     0x80u
+#define FTFA_FSTAT_CCIF_SHIFT                    7
+/* FCNFG Bit Fields */
+#define FTFA_FCNFG_ERSSUSP_MASK                  0x10u
+#define FTFA_FCNFG_ERSSUSP_SHIFT                 4
+#define FTFA_FCNFG_ERSAREQ_MASK                  0x20u
+#define FTFA_FCNFG_ERSAREQ_SHIFT                 5
+#define FTFA_FCNFG_RDCOLLIE_MASK                 0x40u
+#define FTFA_FCNFG_RDCOLLIE_SHIFT                6
+#define FTFA_FCNFG_CCIE_MASK                     0x80u
+#define FTFA_FCNFG_CCIE_SHIFT                    7
+/* FSEC Bit Fields */
+#define FTFA_FSEC_SEC_MASK                       0x3u
+#define FTFA_FSEC_SEC_SHIFT                      0
+#define FTFA_FSEC_SEC(x)                         (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_SEC_SHIFT))&FTFA_FSEC_SEC_MASK)
+#define FTFA_FSEC_FSLACC_MASK                    0xCu
+#define FTFA_FSEC_FSLACC_SHIFT                   2
+#define FTFA_FSEC_FSLACC(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_FSLACC_SHIFT))&FTFA_FSEC_FSLACC_MASK)
+#define FTFA_FSEC_MEEN_MASK                      0x30u
+#define FTFA_FSEC_MEEN_SHIFT                     4
+#define FTFA_FSEC_MEEN(x)                        (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_MEEN_SHIFT))&FTFA_FSEC_MEEN_MASK)
+#define FTFA_FSEC_KEYEN_MASK                     0xC0u
+#define FTFA_FSEC_KEYEN_SHIFT                    6
+#define FTFA_FSEC_KEYEN(x)                       (((uint8_t)(((uint8_t)(x))<<FTFA_FSEC_KEYEN_SHIFT))&FTFA_FSEC_KEYEN_MASK)
+/* FOPT Bit Fields */
+#define FTFA_FOPT_OPT_MASK                       0xFFu
+#define FTFA_FOPT_OPT_SHIFT                      0
+#define FTFA_FOPT_OPT(x)                         (((uint8_t)(((uint8_t)(x))<<FTFA_FOPT_OPT_SHIFT))&FTFA_FOPT_OPT_MASK)
+/* FCCOB3 Bit Fields */
+#define FTFA_FCCOB3_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB3_CCOBn_SHIFT                  0
+#define FTFA_FCCOB3_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB3_CCOBn_SHIFT))&FTFA_FCCOB3_CCOBn_MASK)
+/* FCCOB2 Bit Fields */
+#define FTFA_FCCOB2_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB2_CCOBn_SHIFT                  0
+#define FTFA_FCCOB2_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB2_CCOBn_SHIFT))&FTFA_FCCOB2_CCOBn_MASK)
+/* FCCOB1 Bit Fields */
+#define FTFA_FCCOB1_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB1_CCOBn_SHIFT                  0
+#define FTFA_FCCOB1_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB1_CCOBn_SHIFT))&FTFA_FCCOB1_CCOBn_MASK)
+/* FCCOB0 Bit Fields */
+#define FTFA_FCCOB0_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB0_CCOBn_SHIFT                  0
+#define FTFA_FCCOB0_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB0_CCOBn_SHIFT))&FTFA_FCCOB0_CCOBn_MASK)
+/* FCCOB7 Bit Fields */
+#define FTFA_FCCOB7_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB7_CCOBn_SHIFT                  0
+#define FTFA_FCCOB7_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB7_CCOBn_SHIFT))&FTFA_FCCOB7_CCOBn_MASK)
+/* FCCOB6 Bit Fields */
+#define FTFA_FCCOB6_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB6_CCOBn_SHIFT                  0
+#define FTFA_FCCOB6_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB6_CCOBn_SHIFT))&FTFA_FCCOB6_CCOBn_MASK)
+/* FCCOB5 Bit Fields */
+#define FTFA_FCCOB5_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB5_CCOBn_SHIFT                  0
+#define FTFA_FCCOB5_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB5_CCOBn_SHIFT))&FTFA_FCCOB5_CCOBn_MASK)
+/* FCCOB4 Bit Fields */
+#define FTFA_FCCOB4_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB4_CCOBn_SHIFT                  0
+#define FTFA_FCCOB4_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB4_CCOBn_SHIFT))&FTFA_FCCOB4_CCOBn_MASK)
+/* FCCOBB Bit Fields */
+#define FTFA_FCCOBB_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOBB_CCOBn_SHIFT                  0
+#define FTFA_FCCOBB_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOBB_CCOBn_SHIFT))&FTFA_FCCOBB_CCOBn_MASK)
+/* FCCOBA Bit Fields */
+#define FTFA_FCCOBA_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOBA_CCOBn_SHIFT                  0
+#define FTFA_FCCOBA_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOBA_CCOBn_SHIFT))&FTFA_FCCOBA_CCOBn_MASK)
+/* FCCOB9 Bit Fields */
+#define FTFA_FCCOB9_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB9_CCOBn_SHIFT                  0
+#define FTFA_FCCOB9_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB9_CCOBn_SHIFT))&FTFA_FCCOB9_CCOBn_MASK)
+/* FCCOB8 Bit Fields */
+#define FTFA_FCCOB8_CCOBn_MASK                   0xFFu
+#define FTFA_FCCOB8_CCOBn_SHIFT                  0
+#define FTFA_FCCOB8_CCOBn(x)                     (((uint8_t)(((uint8_t)(x))<<FTFA_FCCOB8_CCOBn_SHIFT))&FTFA_FCCOB8_CCOBn_MASK)
+/* FPROT3 Bit Fields */
+#define FTFA_FPROT3_PROT_MASK                    0xFFu
+#define FTFA_FPROT3_PROT_SHIFT                   0
+#define FTFA_FPROT3_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT3_PROT_SHIFT))&FTFA_FPROT3_PROT_MASK)
+/* FPROT2 Bit Fields */
+#define FTFA_FPROT2_PROT_MASK                    0xFFu
+#define FTFA_FPROT2_PROT_SHIFT                   0
+#define FTFA_FPROT2_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT2_PROT_SHIFT))&FTFA_FPROT2_PROT_MASK)
+/* FPROT1 Bit Fields */
+#define FTFA_FPROT1_PROT_MASK                    0xFFu
+#define FTFA_FPROT1_PROT_SHIFT                   0
+#define FTFA_FPROT1_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT1_PROT_SHIFT))&FTFA_FPROT1_PROT_MASK)
+/* FPROT0 Bit Fields */
+#define FTFA_FPROT0_PROT_MASK                    0xFFu
+#define FTFA_FPROT0_PROT_SHIFT                   0
+#define FTFA_FPROT0_PROT(x)                      (((uint8_t)(((uint8_t)(x))<<FTFA_FPROT0_PROT_SHIFT))&FTFA_FPROT0_PROT_MASK)
+
+/**
+ * @}
+ */ /* end of group FTFA_Register_Masks */
+
+
+/* FTFA - Peripheral instance base addresses */
+/** Peripheral FTFA base address */
+#define FTFA_BASE                                (0x40020000u)
+/** Peripheral FTFA base pointer */
+#define FTFA                                     ((FTFA_Type *)FTFA_BASE)
+/** Array initializer of FTFA peripheral base pointers */
+#define FTFA_BASES                               { FTFA }
+
+/**
+ * @}
+ */ /* end of group FTFA_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup GPIO_Peripheral_Access_Layer GPIO Peripheral Access Layer
+ * @{
+ */
+
+/** GPIO - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PDOR;                              /**< Port Data Output Register, offset: 0x0 */
+  __O  uint32_t PSOR;                              /**< Port Set Output Register, offset: 0x4 */
+  __O  uint32_t PCOR;                              /**< Port Clear Output Register, offset: 0x8 */
+  __O  uint32_t PTOR;                              /**< Port Toggle Output Register, offset: 0xC */
+  __I  uint32_t PDIR;                              /**< Port Data Input Register, offset: 0x10 */
+  __IO uint32_t PDDR;                              /**< Port Data Direction Register, offset: 0x14 */
+} GPIO_Type;
+
+/* ----------------------------------------------------------------------------
+   -- GPIO Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup GPIO_Register_Masks GPIO Register Masks
+ * @{
+ */
+
+/* PDOR Bit Fields */
+#define GPIO_PDOR_PDO_MASK                       0xFFFFFFFFu
+#define GPIO_PDOR_PDO_SHIFT                      0
+#define GPIO_PDOR_PDO(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDOR_PDO_SHIFT))&GPIO_PDOR_PDO_MASK)
+/* PSOR Bit Fields */
+#define GPIO_PSOR_PTSO_MASK                      0xFFFFFFFFu
+#define GPIO_PSOR_PTSO_SHIFT                     0
+#define GPIO_PSOR_PTSO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PSOR_PTSO_SHIFT))&GPIO_PSOR_PTSO_MASK)
+/* PCOR Bit Fields */
+#define GPIO_PCOR_PTCO_MASK                      0xFFFFFFFFu
+#define GPIO_PCOR_PTCO_SHIFT                     0
+#define GPIO_PCOR_PTCO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PCOR_PTCO_SHIFT))&GPIO_PCOR_PTCO_MASK)
+/* PTOR Bit Fields */
+#define GPIO_PTOR_PTTO_MASK                      0xFFFFFFFFu
+#define GPIO_PTOR_PTTO_SHIFT                     0
+#define GPIO_PTOR_PTTO(x)                        (((uint32_t)(((uint32_t)(x))<<GPIO_PTOR_PTTO_SHIFT))&GPIO_PTOR_PTTO_MASK)
+/* PDIR Bit Fields */
+#define GPIO_PDIR_PDI_MASK                       0xFFFFFFFFu
+#define GPIO_PDIR_PDI_SHIFT                      0
+#define GPIO_PDIR_PDI(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDIR_PDI_SHIFT))&GPIO_PDIR_PDI_MASK)
+/* PDDR Bit Fields */
+#define GPIO_PDDR_PDD_MASK                       0xFFFFFFFFu
+#define GPIO_PDDR_PDD_SHIFT                      0
+#define GPIO_PDDR_PDD(x)                         (((uint32_t)(((uint32_t)(x))<<GPIO_PDDR_PDD_SHIFT))&GPIO_PDDR_PDD_MASK)
+
+/**
+ * @}
+ */ /* end of group GPIO_Register_Masks */
+
+
+/* GPIO - Peripheral instance base addresses */
+/** Peripheral PTA base address */
+#define PTA_BASE                                 (0x400FF000u)
+/** Peripheral PTA base pointer */
+#define PTA                                      ((GPIO_Type *)PTA_BASE)
+/** Peripheral PTB base address */
+#define PTB_BASE                                 (0x400FF040u)
+/** Peripheral PTB base pointer */
+#define PTB                                      ((GPIO_Type *)PTB_BASE)
+/** Peripheral PTC base address */
+#define PTC_BASE                                 (0x400FF080u)
+/** Peripheral PTC base pointer */
+#define PTC                                      ((GPIO_Type *)PTC_BASE)
+/** Peripheral PTD base address */
+#define PTD_BASE                                 (0x400FF0C0u)
+/** Peripheral PTD base pointer */
+#define PTD                                      ((GPIO_Type *)PTD_BASE)
+/** Peripheral PTE base address */
+#define PTE_BASE                                 (0x400FF100u)
+/** Peripheral PTE base pointer */
+#define PTE                                      ((GPIO_Type *)PTE_BASE)
+/** Array initializer of GPIO peripheral base pointers */
+#define GPIO_BASES                               { PTA, PTB, PTC, PTD, PTE }
+
+/**
+ * @}
+ */ /* end of group GPIO_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2C Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup I2C_Peripheral_Access_Layer I2C Peripheral Access Layer
+ * @{
+ */
+
+/** I2C - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t A1;                                 /**< I2C Address Register 1, offset: 0x0 */
+  __IO uint8_t F;                                  /**< I2C Frequency Divider register, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< I2C Control Register 1, offset: 0x2 */
+  __IO uint8_t S;                                  /**< I2C Status register, offset: 0x3 */
+  __IO uint8_t D;                                  /**< I2C Data I/O register, offset: 0x4 */
+  __IO uint8_t C2;                                 /**< I2C Control Register 2, offset: 0x5 */
+  __IO uint8_t FLT;                                /**< I2C Programmable Input Glitch Filter register, offset: 0x6 */
+  __IO uint8_t RA;                                 /**< I2C Range Address register, offset: 0x7 */
+  __IO uint8_t SMB;                                /**< I2C SMBus Control and Status register, offset: 0x8 */
+  __IO uint8_t A2;                                 /**< I2C Address Register 2, offset: 0x9 */
+  __IO uint8_t SLTH;                               /**< I2C SCL Low Timeout Register High, offset: 0xA */
+  __IO uint8_t SLTL;                               /**< I2C SCL Low Timeout Register Low, offset: 0xB */
+} I2C_Type;
+
+/* ----------------------------------------------------------------------------
+   -- I2C Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup I2C_Register_Masks I2C Register Masks
+ * @{
+ */
+
+/* A1 Bit Fields */
+#define I2C_A1_AD_MASK                           0xFEu
+#define I2C_A1_AD_SHIFT                          1
+#define I2C_A1_AD(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_A1_AD_SHIFT))&I2C_A1_AD_MASK)
+/* F Bit Fields */
+#define I2C_F_ICR_MASK                           0x3Fu
+#define I2C_F_ICR_SHIFT                          0
+#define I2C_F_ICR(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_F_ICR_SHIFT))&I2C_F_ICR_MASK)
+#define I2C_F_MULT_MASK                          0xC0u
+#define I2C_F_MULT_SHIFT                         6
+#define I2C_F_MULT(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_F_MULT_SHIFT))&I2C_F_MULT_MASK)
+/* C1 Bit Fields */
+#define I2C_C1_DMAEN_MASK                        0x1u
+#define I2C_C1_DMAEN_SHIFT                       0
+#define I2C_C1_WUEN_MASK                         0x2u
+#define I2C_C1_WUEN_SHIFT                        1
+#define I2C_C1_RSTA_MASK                         0x4u
+#define I2C_C1_RSTA_SHIFT                        2
+#define I2C_C1_TXAK_MASK                         0x8u
+#define I2C_C1_TXAK_SHIFT                        3
+#define I2C_C1_TX_MASK                           0x10u
+#define I2C_C1_TX_SHIFT                          4
+#define I2C_C1_MST_MASK                          0x20u
+#define I2C_C1_MST_SHIFT                         5
+#define I2C_C1_IICIE_MASK                        0x40u
+#define I2C_C1_IICIE_SHIFT                       6
+#define I2C_C1_IICEN_MASK                        0x80u
+#define I2C_C1_IICEN_SHIFT                       7
+/* S Bit Fields */
+#define I2C_S_RXAK_MASK                          0x1u
+#define I2C_S_RXAK_SHIFT                         0
+#define I2C_S_IICIF_MASK                         0x2u
+#define I2C_S_IICIF_SHIFT                        1
+#define I2C_S_SRW_MASK                           0x4u
+#define I2C_S_SRW_SHIFT                          2
+#define I2C_S_RAM_MASK                           0x8u
+#define I2C_S_RAM_SHIFT                          3
+#define I2C_S_ARBL_MASK                          0x10u
+#define I2C_S_ARBL_SHIFT                         4
+#define I2C_S_BUSY_MASK                          0x20u
+#define I2C_S_BUSY_SHIFT                         5
+#define I2C_S_IAAS_MASK                          0x40u
+#define I2C_S_IAAS_SHIFT                         6
+#define I2C_S_TCF_MASK                           0x80u
+#define I2C_S_TCF_SHIFT                          7
+/* D Bit Fields */
+#define I2C_D_DATA_MASK                          0xFFu
+#define I2C_D_DATA_SHIFT                         0
+#define I2C_D_DATA(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_D_DATA_SHIFT))&I2C_D_DATA_MASK)
+/* C2 Bit Fields */
+#define I2C_C2_AD_MASK                           0x7u
+#define I2C_C2_AD_SHIFT                          0
+#define I2C_C2_AD(x)                             (((uint8_t)(((uint8_t)(x))<<I2C_C2_AD_SHIFT))&I2C_C2_AD_MASK)
+#define I2C_C2_RMEN_MASK                         0x8u
+#define I2C_C2_RMEN_SHIFT                        3
+#define I2C_C2_SBRC_MASK                         0x10u
+#define I2C_C2_SBRC_SHIFT                        4
+#define I2C_C2_HDRS_MASK                         0x20u
+#define I2C_C2_HDRS_SHIFT                        5
+#define I2C_C2_ADEXT_MASK                        0x40u
+#define I2C_C2_ADEXT_SHIFT                       6
+#define I2C_C2_GCAEN_MASK                        0x80u
+#define I2C_C2_GCAEN_SHIFT                       7
+/* FLT Bit Fields */
+#define I2C_FLT_FLT_MASK                         0x1Fu
+#define I2C_FLT_FLT_SHIFT                        0
+#define I2C_FLT_FLT(x)                           (((uint8_t)(((uint8_t)(x))<<I2C_FLT_FLT_SHIFT))&I2C_FLT_FLT_MASK)
+#define I2C_FLT_STOPIE_MASK                      0x20u
+#define I2C_FLT_STOPIE_SHIFT                     5
+#define I2C_FLT_STOPF_MASK                       0x40u
+#define I2C_FLT_STOPF_SHIFT                      6
+#define I2C_FLT_SHEN_MASK                        0x80u
+#define I2C_FLT_SHEN_SHIFT                       7
+/* RA Bit Fields */
+#define I2C_RA_RAD_MASK                          0xFEu
+#define I2C_RA_RAD_SHIFT                         1
+#define I2C_RA_RAD(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_RA_RAD_SHIFT))&I2C_RA_RAD_MASK)
+/* SMB Bit Fields */
+#define I2C_SMB_SHTF2IE_MASK                     0x1u
+#define I2C_SMB_SHTF2IE_SHIFT                    0
+#define I2C_SMB_SHTF2_MASK                       0x2u
+#define I2C_SMB_SHTF2_SHIFT                      1
+#define I2C_SMB_SHTF1_MASK                       0x4u
+#define I2C_SMB_SHTF1_SHIFT                      2
+#define I2C_SMB_SLTF_MASK                        0x8u
+#define I2C_SMB_SLTF_SHIFT                       3
+#define I2C_SMB_TCKSEL_MASK                      0x10u
+#define I2C_SMB_TCKSEL_SHIFT                     4
+#define I2C_SMB_SIICAEN_MASK                     0x20u
+#define I2C_SMB_SIICAEN_SHIFT                    5
+#define I2C_SMB_ALERTEN_MASK                     0x40u
+#define I2C_SMB_ALERTEN_SHIFT                    6
+#define I2C_SMB_FACK_MASK                        0x80u
+#define I2C_SMB_FACK_SHIFT                       7
+/* A2 Bit Fields */
+#define I2C_A2_SAD_MASK                          0xFEu
+#define I2C_A2_SAD_SHIFT                         1
+#define I2C_A2_SAD(x)                            (((uint8_t)(((uint8_t)(x))<<I2C_A2_SAD_SHIFT))&I2C_A2_SAD_MASK)
+/* SLTH Bit Fields */
+#define I2C_SLTH_SSLT_MASK                       0xFFu
+#define I2C_SLTH_SSLT_SHIFT                      0
+#define I2C_SLTH_SSLT(x)                         (((uint8_t)(((uint8_t)(x))<<I2C_SLTH_SSLT_SHIFT))&I2C_SLTH_SSLT_MASK)
+/* SLTL Bit Fields */
+#define I2C_SLTL_SSLT_MASK                       0xFFu
+#define I2C_SLTL_SSLT_SHIFT                      0
+#define I2C_SLTL_SSLT(x)                         (((uint8_t)(((uint8_t)(x))<<I2C_SLTL_SSLT_SHIFT))&I2C_SLTL_SSLT_MASK)
+
+/**
+ * @}
+ */ /* end of group I2C_Register_Masks */
+
+
+/* I2C - Peripheral instance base addresses */
+/** Peripheral I2C0 base address */
+#define I2C0_BASE                                (0x40066000u)
+/** Peripheral I2C0 base pointer */
+#define I2C0                                     ((I2C_Type *)I2C0_BASE)
+/** Peripheral I2C1 base address */
+#define I2C1_BASE                                (0x40067000u)
+/** Peripheral I2C1 base pointer */
+#define I2C1                                     ((I2C_Type *)I2C1_BASE)
+/** Array initializer of I2C peripheral base pointers */
+#define I2C_BASES                                { I2C0, I2C1 }
+
+/**
+ * @}
+ */ /* end of group I2C_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- I2S Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup I2S_Peripheral_Access_Layer I2S Peripheral Access Layer
+ * @{
+ */
+
+/** I2S - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TCSR;                              /**< SAI Transmit Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[4];
+  __IO uint32_t TCR2;                              /**< SAI Transmit Configuration 2 Register, offset: 0x8 */
+  __IO uint32_t TCR3;                              /**< SAI Transmit Configuration 3 Register, offset: 0xC */
+  __IO uint32_t TCR4;                              /**< SAI Transmit Configuration 4 Register, offset: 0x10 */
+  __IO uint32_t TCR5;                              /**< SAI Transmit Configuration 5 Register, offset: 0x14 */
+       uint8_t RESERVED_1[8];
+  __O  uint32_t TDR[1];                            /**< SAI Transmit Data Register, array offset: 0x20, array step: 0x4 */
+       uint8_t RESERVED_2[60];
+  __IO uint32_t TMR;                               /**< SAI Transmit Mask Register, offset: 0x60 */
+       uint8_t RESERVED_3[28];
+  __IO uint32_t RCSR;                              /**< SAI Receive Control Register, offset: 0x80 */
+       uint8_t RESERVED_4[4];
+  __IO uint32_t RCR2;                              /**< SAI Receive Configuration 2 Register, offset: 0x88 */
+  __IO uint32_t RCR3;                              /**< SAI Receive Configuration 3 Register, offset: 0x8C */
+  __IO uint32_t RCR4;                              /**< SAI Receive Configuration 4 Register, offset: 0x90 */
+  __IO uint32_t RCR5;                              /**< SAI Receive Configuration 5 Register, offset: 0x94 */
+       uint8_t RESERVED_5[8];
+  __I  uint32_t RDR[1];                            /**< SAI Receive Data Register, array offset: 0xA0, array step: 0x4 */
+       uint8_t RESERVED_6[60];
+  __IO uint32_t RMR;                               /**< SAI Receive Mask Register, offset: 0xE0 */
+       uint8_t RESERVED_7[28];
+  __IO uint32_t MCR;                               /**< SAI MCLK Control Register, offset: 0x100 */
+  __IO uint32_t MDR;                               /**< SAI MCLK Divide Register, offset: 0x104 */
+} I2S_Type;
+
+/* ----------------------------------------------------------------------------
+   -- I2S Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup I2S_Register_Masks I2S Register Masks
+ * @{
+ */
+
+/* TCSR Bit Fields */
+#define I2S_TCSR_FWDE_MASK                       0x2u
+#define I2S_TCSR_FWDE_SHIFT                      1
+#define I2S_TCSR_FWIE_MASK                       0x200u
+#define I2S_TCSR_FWIE_SHIFT                      9
+#define I2S_TCSR_FEIE_MASK                       0x400u
+#define I2S_TCSR_FEIE_SHIFT                      10
+#define I2S_TCSR_SEIE_MASK                       0x800u
+#define I2S_TCSR_SEIE_SHIFT                      11
+#define I2S_TCSR_WSIE_MASK                       0x1000u
+#define I2S_TCSR_WSIE_SHIFT                      12
+#define I2S_TCSR_FWF_MASK                        0x20000u
+#define I2S_TCSR_FWF_SHIFT                       17
+#define I2S_TCSR_FEF_MASK                        0x40000u
+#define I2S_TCSR_FEF_SHIFT                       18
+#define I2S_TCSR_SEF_MASK                        0x80000u
+#define I2S_TCSR_SEF_SHIFT                       19
+#define I2S_TCSR_WSF_MASK                        0x100000u
+#define I2S_TCSR_WSF_SHIFT                       20
+#define I2S_TCSR_SR_MASK                         0x1000000u
+#define I2S_TCSR_SR_SHIFT                        24
+#define I2S_TCSR_FR_MASK                         0x2000000u
+#define I2S_TCSR_FR_SHIFT                        25
+#define I2S_TCSR_BCE_MASK                        0x10000000u
+#define I2S_TCSR_BCE_SHIFT                       28
+#define I2S_TCSR_DBGE_MASK                       0x20000000u
+#define I2S_TCSR_DBGE_SHIFT                      29
+#define I2S_TCSR_STOPE_MASK                      0x40000000u
+#define I2S_TCSR_STOPE_SHIFT                     30
+#define I2S_TCSR_TE_MASK                         0x80000000u
+#define I2S_TCSR_TE_SHIFT                        31
+/* TCR2 Bit Fields */
+#define I2S_TCR2_DIV_MASK                        0xFFu
+#define I2S_TCR2_DIV_SHIFT                       0
+#define I2S_TCR2_DIV(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR2_DIV_SHIFT))&I2S_TCR2_DIV_MASK)
+#define I2S_TCR2_BCD_MASK                        0x1000000u
+#define I2S_TCR2_BCD_SHIFT                       24
+#define I2S_TCR2_BCP_MASK                        0x2000000u
+#define I2S_TCR2_BCP_SHIFT                       25
+#define I2S_TCR2_CLKMODE_MASK                    0xC000000u
+#define I2S_TCR2_CLKMODE_SHIFT                   26
+#define I2S_TCR2_CLKMODE(x)                      (((uint32_t)(((uint32_t)(x))<<I2S_TCR2_CLKMODE_SHIFT))&I2S_TCR2_CLKMODE_MASK)
+/* TCR3 Bit Fields */
+#define I2S_TCR3_WDFL_MASK                       0x1u
+#define I2S_TCR3_WDFL_SHIFT                      0
+#define I2S_TCR3_TCE_MASK                        0x10000u
+#define I2S_TCR3_TCE_SHIFT                       16
+/* TCR4 Bit Fields */
+#define I2S_TCR4_FSD_MASK                        0x1u
+#define I2S_TCR4_FSD_SHIFT                       0
+#define I2S_TCR4_FSP_MASK                        0x2u
+#define I2S_TCR4_FSP_SHIFT                       1
+#define I2S_TCR4_FSE_MASK                        0x8u
+#define I2S_TCR4_FSE_SHIFT                       3
+#define I2S_TCR4_MF_MASK                         0x10u
+#define I2S_TCR4_MF_SHIFT                        4
+#define I2S_TCR4_SYWD_MASK                       0x1F00u
+#define I2S_TCR4_SYWD_SHIFT                      8
+#define I2S_TCR4_SYWD(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_TCR4_SYWD_SHIFT))&I2S_TCR4_SYWD_MASK)
+#define I2S_TCR4_FRSZ_MASK                       0x10000u
+#define I2S_TCR4_FRSZ_SHIFT                      16
+/* TCR5 Bit Fields */
+#define I2S_TCR5_FBT_MASK                        0x1F00u
+#define I2S_TCR5_FBT_SHIFT                       8
+#define I2S_TCR5_FBT(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR5_FBT_SHIFT))&I2S_TCR5_FBT_MASK)
+#define I2S_TCR5_W0W_MASK                        0x1F0000u
+#define I2S_TCR5_W0W_SHIFT                       16
+#define I2S_TCR5_W0W(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR5_W0W_SHIFT))&I2S_TCR5_W0W_MASK)
+#define I2S_TCR5_WNW_MASK                        0x1F000000u
+#define I2S_TCR5_WNW_SHIFT                       24
+#define I2S_TCR5_WNW(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_TCR5_WNW_SHIFT))&I2S_TCR5_WNW_MASK)
+/* TDR Bit Fields */
+#define I2S_TDR_TDR_MASK                         0xFFFFFFFFu
+#define I2S_TDR_TDR_SHIFT                        0
+#define I2S_TDR_TDR(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_TDR_TDR_SHIFT))&I2S_TDR_TDR_MASK)
+/* TMR Bit Fields */
+#define I2S_TMR_TWM_MASK                         0x3u
+#define I2S_TMR_TWM_SHIFT                        0
+#define I2S_TMR_TWM(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_TMR_TWM_SHIFT))&I2S_TMR_TWM_MASK)
+/* RCSR Bit Fields */
+#define I2S_RCSR_FWDE_MASK                       0x2u
+#define I2S_RCSR_FWDE_SHIFT                      1
+#define I2S_RCSR_FWIE_MASK                       0x200u
+#define I2S_RCSR_FWIE_SHIFT                      9
+#define I2S_RCSR_FEIE_MASK                       0x400u
+#define I2S_RCSR_FEIE_SHIFT                      10
+#define I2S_RCSR_SEIE_MASK                       0x800u
+#define I2S_RCSR_SEIE_SHIFT                      11
+#define I2S_RCSR_WSIE_MASK                       0x1000u
+#define I2S_RCSR_WSIE_SHIFT                      12
+#define I2S_RCSR_FWF_MASK                        0x20000u
+#define I2S_RCSR_FWF_SHIFT                       17
+#define I2S_RCSR_FEF_MASK                        0x40000u
+#define I2S_RCSR_FEF_SHIFT                       18
+#define I2S_RCSR_SEF_MASK                        0x80000u
+#define I2S_RCSR_SEF_SHIFT                       19
+#define I2S_RCSR_WSF_MASK                        0x100000u
+#define I2S_RCSR_WSF_SHIFT                       20
+#define I2S_RCSR_SR_MASK                         0x1000000u
+#define I2S_RCSR_SR_SHIFT                        24
+#define I2S_RCSR_FR_MASK                         0x2000000u
+#define I2S_RCSR_FR_SHIFT                        25
+#define I2S_RCSR_BCE_MASK                        0x10000000u
+#define I2S_RCSR_BCE_SHIFT                       28
+#define I2S_RCSR_DBGE_MASK                       0x20000000u
+#define I2S_RCSR_DBGE_SHIFT                      29
+#define I2S_RCSR_STOPE_MASK                      0x40000000u
+#define I2S_RCSR_STOPE_SHIFT                     30
+#define I2S_RCSR_RE_MASK                         0x80000000u
+#define I2S_RCSR_RE_SHIFT                        31
+/* RCR2 Bit Fields */
+#define I2S_RCR2_DIV_MASK                        0xFFu
+#define I2S_RCR2_DIV_SHIFT                       0
+#define I2S_RCR2_DIV(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR2_DIV_SHIFT))&I2S_RCR2_DIV_MASK)
+#define I2S_RCR2_BCD_MASK                        0x1000000u
+#define I2S_RCR2_BCD_SHIFT                       24
+#define I2S_RCR2_BCP_MASK                        0x2000000u
+#define I2S_RCR2_BCP_SHIFT                       25
+#define I2S_RCR2_CLKMODE_MASK                    0xC000000u
+#define I2S_RCR2_CLKMODE_SHIFT                   26
+#define I2S_RCR2_CLKMODE(x)                      (((uint32_t)(((uint32_t)(x))<<I2S_RCR2_CLKMODE_SHIFT))&I2S_RCR2_CLKMODE_MASK)
+/* RCR3 Bit Fields */
+#define I2S_RCR3_WDFL_MASK                       0x1u
+#define I2S_RCR3_WDFL_SHIFT                      0
+#define I2S_RCR3_RCE_MASK                        0x10000u
+#define I2S_RCR3_RCE_SHIFT                       16
+/* RCR4 Bit Fields */
+#define I2S_RCR4_FSD_MASK                        0x1u
+#define I2S_RCR4_FSD_SHIFT                       0
+#define I2S_RCR4_FSP_MASK                        0x2u
+#define I2S_RCR4_FSP_SHIFT                       1
+#define I2S_RCR4_FSE_MASK                        0x8u
+#define I2S_RCR4_FSE_SHIFT                       3
+#define I2S_RCR4_MF_MASK                         0x10u
+#define I2S_RCR4_MF_SHIFT                        4
+#define I2S_RCR4_SYWD_MASK                       0x1F00u
+#define I2S_RCR4_SYWD_SHIFT                      8
+#define I2S_RCR4_SYWD(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_RCR4_SYWD_SHIFT))&I2S_RCR4_SYWD_MASK)
+#define I2S_RCR4_FRSZ_MASK                       0x10000u
+#define I2S_RCR4_FRSZ_SHIFT                      16
+/* RCR5 Bit Fields */
+#define I2S_RCR5_FBT_MASK                        0x1F00u
+#define I2S_RCR5_FBT_SHIFT                       8
+#define I2S_RCR5_FBT(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR5_FBT_SHIFT))&I2S_RCR5_FBT_MASK)
+#define I2S_RCR5_W0W_MASK                        0x1F0000u
+#define I2S_RCR5_W0W_SHIFT                       16
+#define I2S_RCR5_W0W(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR5_W0W_SHIFT))&I2S_RCR5_W0W_MASK)
+#define I2S_RCR5_WNW_MASK                        0x1F000000u
+#define I2S_RCR5_WNW_SHIFT                       24
+#define I2S_RCR5_WNW(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_RCR5_WNW_SHIFT))&I2S_RCR5_WNW_MASK)
+/* RDR Bit Fields */
+#define I2S_RDR_RDR_MASK                         0xFFFFFFFFu
+#define I2S_RDR_RDR_SHIFT                        0
+#define I2S_RDR_RDR(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_RDR_RDR_SHIFT))&I2S_RDR_RDR_MASK)
+/* RMR Bit Fields */
+#define I2S_RMR_RWM_MASK                         0x3u
+#define I2S_RMR_RWM_SHIFT                        0
+#define I2S_RMR_RWM(x)                           (((uint32_t)(((uint32_t)(x))<<I2S_RMR_RWM_SHIFT))&I2S_RMR_RWM_MASK)
+/* MCR Bit Fields */
+#define I2S_MCR_MICS_MASK                        0x3000000u
+#define I2S_MCR_MICS_SHIFT                       24
+#define I2S_MCR_MICS(x)                          (((uint32_t)(((uint32_t)(x))<<I2S_MCR_MICS_SHIFT))&I2S_MCR_MICS_MASK)
+#define I2S_MCR_MOE_MASK                         0x40000000u
+#define I2S_MCR_MOE_SHIFT                        30
+#define I2S_MCR_DUF_MASK                         0x80000000u
+#define I2S_MCR_DUF_SHIFT                        31
+/* MDR Bit Fields */
+#define I2S_MDR_DIVIDE_MASK                      0xFFFu
+#define I2S_MDR_DIVIDE_SHIFT                     0
+#define I2S_MDR_DIVIDE(x)                        (((uint32_t)(((uint32_t)(x))<<I2S_MDR_DIVIDE_SHIFT))&I2S_MDR_DIVIDE_MASK)
+#define I2S_MDR_FRACT_MASK                       0xFF000u
+#define I2S_MDR_FRACT_SHIFT                      12
+#define I2S_MDR_FRACT(x)                         (((uint32_t)(((uint32_t)(x))<<I2S_MDR_FRACT_SHIFT))&I2S_MDR_FRACT_MASK)
+
+/**
+ * @}
+ */ /* end of group I2S_Register_Masks */
+
+
+/* I2S - Peripheral instance base addresses */
+/** Peripheral I2S0 base address */
+#define I2S0_BASE                                (0x4002F000u)
+/** Peripheral I2S0 base pointer */
+#define I2S0                                     ((I2S_Type *)I2S0_BASE)
+/** Array initializer of I2S peripheral base pointers */
+#define I2S_BASES                                { I2S0 }
+
+/**
+ * @}
+ */ /* end of group I2S_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup LLWU_Peripheral_Access_Layer LLWU Peripheral Access Layer
+ * @{
+ */
+
+/** LLWU - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PE1;                                /**< LLWU Pin Enable 1 register, offset: 0x0 */
+  __IO uint8_t PE2;                                /**< LLWU Pin Enable 2 register, offset: 0x1 */
+  __IO uint8_t PE3;                                /**< LLWU Pin Enable 3 register, offset: 0x2 */
+  __IO uint8_t PE4;                                /**< LLWU Pin Enable 4 register, offset: 0x3 */
+  __IO uint8_t ME;                                 /**< LLWU Module Enable register, offset: 0x4 */
+  __IO uint8_t F1;                                 /**< LLWU Flag 1 register, offset: 0x5 */
+  __IO uint8_t F2;                                 /**< LLWU Flag 2 register, offset: 0x6 */
+  __I  uint8_t F3;                                 /**< LLWU Flag 3 register, offset: 0x7 */
+  __IO uint8_t FILT1;                              /**< LLWU Pin Filter 1 register, offset: 0x8 */
+  __IO uint8_t FILT2;                              /**< LLWU Pin Filter 2 register, offset: 0x9 */
+} LLWU_Type;
+
+/* ----------------------------------------------------------------------------
+   -- LLWU Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup LLWU_Register_Masks LLWU Register Masks
+ * @{
+ */
+
+/* PE1 Bit Fields */
+#define LLWU_PE1_WUPE0_MASK                      0x3u
+#define LLWU_PE1_WUPE0_SHIFT                     0
+#define LLWU_PE1_WUPE0(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE0_SHIFT))&LLWU_PE1_WUPE0_MASK)
+#define LLWU_PE1_WUPE1_MASK                      0xCu
+#define LLWU_PE1_WUPE1_SHIFT                     2
+#define LLWU_PE1_WUPE1(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE1_SHIFT))&LLWU_PE1_WUPE1_MASK)
+#define LLWU_PE1_WUPE2_MASK                      0x30u
+#define LLWU_PE1_WUPE2_SHIFT                     4
+#define LLWU_PE1_WUPE2(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE2_SHIFT))&LLWU_PE1_WUPE2_MASK)
+#define LLWU_PE1_WUPE3_MASK                      0xC0u
+#define LLWU_PE1_WUPE3_SHIFT                     6
+#define LLWU_PE1_WUPE3(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE1_WUPE3_SHIFT))&LLWU_PE1_WUPE3_MASK)
+/* PE2 Bit Fields */
+#define LLWU_PE2_WUPE4_MASK                      0x3u
+#define LLWU_PE2_WUPE4_SHIFT                     0
+#define LLWU_PE2_WUPE4(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE4_SHIFT))&LLWU_PE2_WUPE4_MASK)
+#define LLWU_PE2_WUPE5_MASK                      0xCu
+#define LLWU_PE2_WUPE5_SHIFT                     2
+#define LLWU_PE2_WUPE5(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE5_SHIFT))&LLWU_PE2_WUPE5_MASK)
+#define LLWU_PE2_WUPE6_MASK                      0x30u
+#define LLWU_PE2_WUPE6_SHIFT                     4
+#define LLWU_PE2_WUPE6(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE6_SHIFT))&LLWU_PE2_WUPE6_MASK)
+#define LLWU_PE2_WUPE7_MASK                      0xC0u
+#define LLWU_PE2_WUPE7_SHIFT                     6
+#define LLWU_PE2_WUPE7(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE2_WUPE7_SHIFT))&LLWU_PE2_WUPE7_MASK)
+/* PE3 Bit Fields */
+#define LLWU_PE3_WUPE8_MASK                      0x3u
+#define LLWU_PE3_WUPE8_SHIFT                     0
+#define LLWU_PE3_WUPE8(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE8_SHIFT))&LLWU_PE3_WUPE8_MASK)
+#define LLWU_PE3_WUPE9_MASK                      0xCu
+#define LLWU_PE3_WUPE9_SHIFT                     2
+#define LLWU_PE3_WUPE9(x)                        (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE9_SHIFT))&LLWU_PE3_WUPE9_MASK)
+#define LLWU_PE3_WUPE10_MASK                     0x30u
+#define LLWU_PE3_WUPE10_SHIFT                    4
+#define LLWU_PE3_WUPE10(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE10_SHIFT))&LLWU_PE3_WUPE10_MASK)
+#define LLWU_PE3_WUPE11_MASK                     0xC0u
+#define LLWU_PE3_WUPE11_SHIFT                    6
+#define LLWU_PE3_WUPE11(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE3_WUPE11_SHIFT))&LLWU_PE3_WUPE11_MASK)
+/* PE4 Bit Fields */
+#define LLWU_PE4_WUPE12_MASK                     0x3u
+#define LLWU_PE4_WUPE12_SHIFT                    0
+#define LLWU_PE4_WUPE12(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE12_SHIFT))&LLWU_PE4_WUPE12_MASK)
+#define LLWU_PE4_WUPE13_MASK                     0xCu
+#define LLWU_PE4_WUPE13_SHIFT                    2
+#define LLWU_PE4_WUPE13(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE13_SHIFT))&LLWU_PE4_WUPE13_MASK)
+#define LLWU_PE4_WUPE14_MASK                     0x30u
+#define LLWU_PE4_WUPE14_SHIFT                    4
+#define LLWU_PE4_WUPE14(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE14_SHIFT))&LLWU_PE4_WUPE14_MASK)
+#define LLWU_PE4_WUPE15_MASK                     0xC0u
+#define LLWU_PE4_WUPE15_SHIFT                    6
+#define LLWU_PE4_WUPE15(x)                       (((uint8_t)(((uint8_t)(x))<<LLWU_PE4_WUPE15_SHIFT))&LLWU_PE4_WUPE15_MASK)
+/* ME Bit Fields */
+#define LLWU_ME_WUME0_MASK                       0x1u
+#define LLWU_ME_WUME0_SHIFT                      0
+#define LLWU_ME_WUME1_MASK                       0x2u
+#define LLWU_ME_WUME1_SHIFT                      1
+#define LLWU_ME_WUME2_MASK                       0x4u
+#define LLWU_ME_WUME2_SHIFT                      2
+#define LLWU_ME_WUME3_MASK                       0x8u
+#define LLWU_ME_WUME3_SHIFT                      3
+#define LLWU_ME_WUME4_MASK                       0x10u
+#define LLWU_ME_WUME4_SHIFT                      4
+#define LLWU_ME_WUME5_MASK                       0x20u
+#define LLWU_ME_WUME5_SHIFT                      5
+#define LLWU_ME_WUME6_MASK                       0x40u
+#define LLWU_ME_WUME6_SHIFT                      6
+#define LLWU_ME_WUME7_MASK                       0x80u
+#define LLWU_ME_WUME7_SHIFT                      7
+/* F1 Bit Fields */
+#define LLWU_F1_WUF0_MASK                        0x1u
+#define LLWU_F1_WUF0_SHIFT                       0
+#define LLWU_F1_WUF1_MASK                        0x2u
+#define LLWU_F1_WUF1_SHIFT                       1
+#define LLWU_F1_WUF2_MASK                        0x4u
+#define LLWU_F1_WUF2_SHIFT                       2
+#define LLWU_F1_WUF3_MASK                        0x8u
+#define LLWU_F1_WUF3_SHIFT                       3
+#define LLWU_F1_WUF4_MASK                        0x10u
+#define LLWU_F1_WUF4_SHIFT                       4
+#define LLWU_F1_WUF5_MASK                        0x20u
+#define LLWU_F1_WUF5_SHIFT                       5
+#define LLWU_F1_WUF6_MASK                        0x40u
+#define LLWU_F1_WUF6_SHIFT                       6
+#define LLWU_F1_WUF7_MASK                        0x80u
+#define LLWU_F1_WUF7_SHIFT                       7
+/* F2 Bit Fields */
+#define LLWU_F2_WUF8_MASK                        0x1u
+#define LLWU_F2_WUF8_SHIFT                       0
+#define LLWU_F2_WUF9_MASK                        0x2u
+#define LLWU_F2_WUF9_SHIFT                       1
+#define LLWU_F2_WUF10_MASK                       0x4u
+#define LLWU_F2_WUF10_SHIFT                      2
+#define LLWU_F2_WUF11_MASK                       0x8u
+#define LLWU_F2_WUF11_SHIFT                      3
+#define LLWU_F2_WUF12_MASK                       0x10u
+#define LLWU_F2_WUF12_SHIFT                      4
+#define LLWU_F2_WUF13_MASK                       0x20u
+#define LLWU_F2_WUF13_SHIFT                      5
+#define LLWU_F2_WUF14_MASK                       0x40u
+#define LLWU_F2_WUF14_SHIFT                      6
+#define LLWU_F2_WUF15_MASK                       0x80u
+#define LLWU_F2_WUF15_SHIFT                      7
+/* F3 Bit Fields */
+#define LLWU_F3_MWUF0_MASK                       0x1u
+#define LLWU_F3_MWUF0_SHIFT                      0
+#define LLWU_F3_MWUF1_MASK                       0x2u
+#define LLWU_F3_MWUF1_SHIFT                      1
+#define LLWU_F3_MWUF2_MASK                       0x4u
+#define LLWU_F3_MWUF2_SHIFT                      2
+#define LLWU_F3_MWUF3_MASK                       0x8u
+#define LLWU_F3_MWUF3_SHIFT                      3
+#define LLWU_F3_MWUF4_MASK                       0x10u
+#define LLWU_F3_MWUF4_SHIFT                      4
+#define LLWU_F3_MWUF5_MASK                       0x20u
+#define LLWU_F3_MWUF5_SHIFT                      5
+#define LLWU_F3_MWUF6_MASK                       0x40u
+#define LLWU_F3_MWUF6_SHIFT                      6
+#define LLWU_F3_MWUF7_MASK                       0x80u
+#define LLWU_F3_MWUF7_SHIFT                      7
+/* FILT1 Bit Fields */
+#define LLWU_FILT1_FILTSEL_MASK                  0xFu
+#define LLWU_FILT1_FILTSEL_SHIFT                 0
+#define LLWU_FILT1_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<LLWU_FILT1_FILTSEL_SHIFT))&LLWU_FILT1_FILTSEL_MASK)
+#define LLWU_FILT1_FILTE_MASK                    0x60u
+#define LLWU_FILT1_FILTE_SHIFT                   5
+#define LLWU_FILT1_FILTE(x)                      (((uint8_t)(((uint8_t)(x))<<LLWU_FILT1_FILTE_SHIFT))&LLWU_FILT1_FILTE_MASK)
+#define LLWU_FILT1_FILTF_MASK                    0x80u
+#define LLWU_FILT1_FILTF_SHIFT                   7
+/* FILT2 Bit Fields */
+#define LLWU_FILT2_FILTSEL_MASK                  0xFu
+#define LLWU_FILT2_FILTSEL_SHIFT                 0
+#define LLWU_FILT2_FILTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<LLWU_FILT2_FILTSEL_SHIFT))&LLWU_FILT2_FILTSEL_MASK)
+#define LLWU_FILT2_FILTE_MASK                    0x60u
+#define LLWU_FILT2_FILTE_SHIFT                   5
+#define LLWU_FILT2_FILTE(x)                      (((uint8_t)(((uint8_t)(x))<<LLWU_FILT2_FILTE_SHIFT))&LLWU_FILT2_FILTE_MASK)
+#define LLWU_FILT2_FILTF_MASK                    0x80u
+#define LLWU_FILT2_FILTF_SHIFT                   7
+
+/**
+ * @}
+ */ /* end of group LLWU_Register_Masks */
+
+
+/* LLWU - Peripheral instance base addresses */
+/** Peripheral LLWU base address */
+#define LLWU_BASE                                (0x4007C000u)
+/** Peripheral LLWU base pointer */
+#define LLWU                                     ((LLWU_Type *)LLWU_BASE)
+/** Array initializer of LLWU peripheral base pointers */
+#define LLWU_BASES                               { LLWU }
+
+/**
+ * @}
+ */ /* end of group LLWU_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup LPTMR_Peripheral_Access_Layer LPTMR Peripheral Access Layer
+ * @{
+ */
+
+/** LPTMR - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t CSR;                               /**< Low Power Timer Control Status Register, offset: 0x0 */
+  __IO uint32_t PSR;                               /**< Low Power Timer Prescale Register, offset: 0x4 */
+  __IO uint32_t CMR;                               /**< Low Power Timer Compare Register, offset: 0x8 */
+  __I  uint32_t CNR;                               /**< Low Power Timer Counter Register, offset: 0xC */
+} LPTMR_Type;
+
+/* ----------------------------------------------------------------------------
+   -- LPTMR Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup LPTMR_Register_Masks LPTMR Register Masks
+ * @{
+ */
+
+/* CSR Bit Fields */
+#define LPTMR_CSR_TEN_MASK                       0x1u
+#define LPTMR_CSR_TEN_SHIFT                      0
+#define LPTMR_CSR_TMS_MASK                       0x2u
+#define LPTMR_CSR_TMS_SHIFT                      1
+#define LPTMR_CSR_TFC_MASK                       0x4u
+#define LPTMR_CSR_TFC_SHIFT                      2
+#define LPTMR_CSR_TPP_MASK                       0x8u
+#define LPTMR_CSR_TPP_SHIFT                      3
+#define LPTMR_CSR_TPS_MASK                       0x30u
+#define LPTMR_CSR_TPS_SHIFT                      4
+#define LPTMR_CSR_TPS(x)                         (((uint32_t)(((uint32_t)(x))<<LPTMR_CSR_TPS_SHIFT))&LPTMR_CSR_TPS_MASK)
+#define LPTMR_CSR_TIE_MASK                       0x40u
+#define LPTMR_CSR_TIE_SHIFT                      6
+#define LPTMR_CSR_TCF_MASK                       0x80u
+#define LPTMR_CSR_TCF_SHIFT                      7
+/* PSR Bit Fields */
+#define LPTMR_PSR_PCS_MASK                       0x3u
+#define LPTMR_PSR_PCS_SHIFT                      0
+#define LPTMR_PSR_PCS(x)                         (((uint32_t)(((uint32_t)(x))<<LPTMR_PSR_PCS_SHIFT))&LPTMR_PSR_PCS_MASK)
+#define LPTMR_PSR_PBYP_MASK                      0x4u
+#define LPTMR_PSR_PBYP_SHIFT                     2
+#define LPTMR_PSR_PRESCALE_MASK                  0x78u
+#define LPTMR_PSR_PRESCALE_SHIFT                 3
+#define LPTMR_PSR_PRESCALE(x)                    (((uint32_t)(((uint32_t)(x))<<LPTMR_PSR_PRESCALE_SHIFT))&LPTMR_PSR_PRESCALE_MASK)
+/* CMR Bit Fields */
+#define LPTMR_CMR_COMPARE_MASK                   0xFFFFu
+#define LPTMR_CMR_COMPARE_SHIFT                  0
+#define LPTMR_CMR_COMPARE(x)                     (((uint32_t)(((uint32_t)(x))<<LPTMR_CMR_COMPARE_SHIFT))&LPTMR_CMR_COMPARE_MASK)
+/* CNR Bit Fields */
+#define LPTMR_CNR_COUNTER_MASK                   0xFFFFu
+#define LPTMR_CNR_COUNTER_SHIFT                  0
+#define LPTMR_CNR_COUNTER(x)                     (((uint32_t)(((uint32_t)(x))<<LPTMR_CNR_COUNTER_SHIFT))&LPTMR_CNR_COUNTER_MASK)
+
+/**
+ * @}
+ */ /* end of group LPTMR_Register_Masks */
+
+
+/* LPTMR - Peripheral instance base addresses */
+/** Peripheral LPTMR0 base address */
+#define LPTMR0_BASE                              (0x40040000u)
+/** Peripheral LPTMR0 base pointer */
+#define LPTMR0                                   ((LPTMR_Type *)LPTMR0_BASE)
+/** Array initializer of LPTMR peripheral base pointers */
+#define LPTMR_BASES                              { LPTMR0 }
+
+/**
+ * @}
+ */ /* end of group LPTMR_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCG Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MCG_Peripheral_Access_Layer MCG Peripheral Access Layer
+ * @{
+ */
+
+/** MCG - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t C1;                                 /**< MCG Control 1 Register, offset: 0x0 */
+  __IO uint8_t C2;                                 /**< MCG Control 2 Register, offset: 0x1 */
+  __IO uint8_t C3;                                 /**< MCG Control 3 Register, offset: 0x2 */
+  __IO uint8_t C4;                                 /**< MCG Control 4 Register, offset: 0x3 */
+  __IO uint8_t C5;                                 /**< MCG Control 5 Register, offset: 0x4 */
+  __IO uint8_t C6;                                 /**< MCG Control 6 Register, offset: 0x5 */
+  __I  uint8_t S;                                  /**< MCG Status Register, offset: 0x6 */
+       uint8_t RESERVED_0[1];
+  __IO uint8_t SC;                                 /**< MCG Status and Control Register, offset: 0x8 */
+       uint8_t RESERVED_1[1];
+  __IO uint8_t ATCVH;                              /**< MCG Auto Trim Compare Value High Register, offset: 0xA */
+  __IO uint8_t ATCVL;                              /**< MCG Auto Trim Compare Value Low Register, offset: 0xB */
+  __I  uint8_t C7;                                 /**< MCG Control 7 Register, offset: 0xC */
+  __IO uint8_t C8;                                 /**< MCG Control 8 Register, offset: 0xD */
+  __I  uint8_t C9;                                 /**< MCG Control 9 Register, offset: 0xE */
+  __I  uint8_t C10;                                /**< MCG Control 10 Register, offset: 0xF */
+} MCG_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MCG Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MCG_Register_Masks MCG Register Masks
+ * @{
+ */
+
+/* C1 Bit Fields */
+#define MCG_C1_IREFSTEN_MASK                     0x1u
+#define MCG_C1_IREFSTEN_SHIFT                    0
+#define MCG_C1_IRCLKEN_MASK                      0x2u
+#define MCG_C1_IRCLKEN_SHIFT                     1
+#define MCG_C1_IREFS_MASK                        0x4u
+#define MCG_C1_IREFS_SHIFT                       2
+#define MCG_C1_FRDIV_MASK                        0x38u
+#define MCG_C1_FRDIV_SHIFT                       3
+#define MCG_C1_FRDIV(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C1_FRDIV_SHIFT))&MCG_C1_FRDIV_MASK)
+#define MCG_C1_CLKS_MASK                         0xC0u
+#define MCG_C1_CLKS_SHIFT                        6
+#define MCG_C1_CLKS(x)                           (((uint8_t)(((uint8_t)(x))<<MCG_C1_CLKS_SHIFT))&MCG_C1_CLKS_MASK)
+/* C2 Bit Fields */
+#define MCG_C2_IRCS_MASK                         0x1u
+#define MCG_C2_IRCS_SHIFT                        0
+#define MCG_C2_LP_MASK                           0x2u
+#define MCG_C2_LP_SHIFT                          1
+#define MCG_C2_EREFS0_MASK                       0x4u
+#define MCG_C2_EREFS0_SHIFT                      2
+#define MCG_C2_HGO0_MASK                         0x8u
+#define MCG_C2_HGO0_SHIFT                        3
+#define MCG_C2_RANGE0_MASK                       0x30u
+#define MCG_C2_RANGE0_SHIFT                      4
+#define MCG_C2_RANGE0(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C2_RANGE0_SHIFT))&MCG_C2_RANGE0_MASK)
+#define MCG_C2_FCFTRIM_MASK                      0x40u
+#define MCG_C2_FCFTRIM_SHIFT                     6
+#define MCG_C2_LOCRE0_MASK                       0x80u
+#define MCG_C2_LOCRE0_SHIFT                      7
+/* C3 Bit Fields */
+#define MCG_C3_SCTRIM_MASK                       0xFFu
+#define MCG_C3_SCTRIM_SHIFT                      0
+#define MCG_C3_SCTRIM(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C3_SCTRIM_SHIFT))&MCG_C3_SCTRIM_MASK)
+/* C4 Bit Fields */
+#define MCG_C4_SCFTRIM_MASK                      0x1u
+#define MCG_C4_SCFTRIM_SHIFT                     0
+#define MCG_C4_FCTRIM_MASK                       0x1Eu
+#define MCG_C4_FCTRIM_SHIFT                      1
+#define MCG_C4_FCTRIM(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C4_FCTRIM_SHIFT))&MCG_C4_FCTRIM_MASK)
+#define MCG_C4_DRST_DRS_MASK                     0x60u
+#define MCG_C4_DRST_DRS_SHIFT                    5
+#define MCG_C4_DRST_DRS(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_C4_DRST_DRS_SHIFT))&MCG_C4_DRST_DRS_MASK)
+#define MCG_C4_DMX32_MASK                        0x80u
+#define MCG_C4_DMX32_SHIFT                       7
+/* C5 Bit Fields */
+#define MCG_C5_PRDIV0_MASK                       0x1Fu
+#define MCG_C5_PRDIV0_SHIFT                      0
+#define MCG_C5_PRDIV0(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_C5_PRDIV0_SHIFT))&MCG_C5_PRDIV0_MASK)
+#define MCG_C5_PLLSTEN0_MASK                     0x20u
+#define MCG_C5_PLLSTEN0_SHIFT                    5
+#define MCG_C5_PLLCLKEN0_MASK                    0x40u
+#define MCG_C5_PLLCLKEN0_SHIFT                   6
+/* C6 Bit Fields */
+#define MCG_C6_VDIV0_MASK                        0x1Fu
+#define MCG_C6_VDIV0_SHIFT                       0
+#define MCG_C6_VDIV0(x)                          (((uint8_t)(((uint8_t)(x))<<MCG_C6_VDIV0_SHIFT))&MCG_C6_VDIV0_MASK)
+#define MCG_C6_CME0_MASK                         0x20u
+#define MCG_C6_CME0_SHIFT                        5
+#define MCG_C6_PLLS_MASK                         0x40u
+#define MCG_C6_PLLS_SHIFT                        6
+#define MCG_C6_LOLIE0_MASK                       0x80u
+#define MCG_C6_LOLIE0_SHIFT                      7
+/* S Bit Fields */
+#define MCG_S_IRCST_MASK                         0x1u
+#define MCG_S_IRCST_SHIFT                        0
+#define MCG_S_OSCINIT0_MASK                      0x2u
+#define MCG_S_OSCINIT0_SHIFT                     1
+#define MCG_S_CLKST_MASK                         0xCu
+#define MCG_S_CLKST_SHIFT                        2
+#define MCG_S_CLKST(x)                           (((uint8_t)(((uint8_t)(x))<<MCG_S_CLKST_SHIFT))&MCG_S_CLKST_MASK)
+#define MCG_S_IREFST_MASK                        0x10u
+#define MCG_S_IREFST_SHIFT                       4
+#define MCG_S_PLLST_MASK                         0x20u
+#define MCG_S_PLLST_SHIFT                        5
+#define MCG_S_LOCK0_MASK                         0x40u
+#define MCG_S_LOCK0_SHIFT                        6
+#define MCG_S_LOLS_MASK                          0x80u
+#define MCG_S_LOLS_SHIFT                         7
+/* SC Bit Fields */
+#define MCG_SC_LOCS0_MASK                        0x1u
+#define MCG_SC_LOCS0_SHIFT                       0
+#define MCG_SC_FCRDIV_MASK                       0xEu
+#define MCG_SC_FCRDIV_SHIFT                      1
+#define MCG_SC_FCRDIV(x)                         (((uint8_t)(((uint8_t)(x))<<MCG_SC_FCRDIV_SHIFT))&MCG_SC_FCRDIV_MASK)
+#define MCG_SC_FLTPRSRV_MASK                     0x10u
+#define MCG_SC_FLTPRSRV_SHIFT                    4
+#define MCG_SC_ATMF_MASK                         0x20u
+#define MCG_SC_ATMF_SHIFT                        5
+#define MCG_SC_ATMS_MASK                         0x40u
+#define MCG_SC_ATMS_SHIFT                        6
+#define MCG_SC_ATME_MASK                         0x80u
+#define MCG_SC_ATME_SHIFT                        7
+/* ATCVH Bit Fields */
+#define MCG_ATCVH_ATCVH_MASK                     0xFFu
+#define MCG_ATCVH_ATCVH_SHIFT                    0
+#define MCG_ATCVH_ATCVH(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_ATCVH_ATCVH_SHIFT))&MCG_ATCVH_ATCVH_MASK)
+/* ATCVL Bit Fields */
+#define MCG_ATCVL_ATCVL_MASK                     0xFFu
+#define MCG_ATCVL_ATCVL_SHIFT                    0
+#define MCG_ATCVL_ATCVL(x)                       (((uint8_t)(((uint8_t)(x))<<MCG_ATCVL_ATCVL_SHIFT))&MCG_ATCVL_ATCVL_MASK)
+/* C8 Bit Fields */
+#define MCG_C8_LOLRE_MASK                        0x40u
+#define MCG_C8_LOLRE_SHIFT                       6
+
+/**
+ * @}
+ */ /* end of group MCG_Register_Masks */
+
+
+/* MCG - Peripheral instance base addresses */
+/** Peripheral MCG base address */
+#define MCG_BASE                                 (0x40064000u)
+/** Peripheral MCG base pointer */
+#define MCG                                      ((MCG_Type *)MCG_BASE)
+/** Array initializer of MCG peripheral base pointers */
+#define MCG_BASES                                { MCG }
+
+/**
+ * @}
+ */ /* end of group MCG_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MCM_Peripheral_Access_Layer MCM Peripheral Access Layer
+ * @{
+ */
+
+/** MCM - Register Layout Typedef */
+typedef struct {
+       uint8_t RESERVED_0[8];
+  __I  uint16_t PLASC;                             /**< Crossbar Switch (AXBS) Slave Configuration, offset: 0x8 */
+  __I  uint16_t PLAMC;                             /**< Crossbar Switch (AXBS) Master Configuration, offset: 0xA */
+  __IO uint32_t PLACR;                             /**< Platform Control Register, offset: 0xC */
+       uint8_t RESERVED_1[48];
+  __IO uint32_t CPO;                               /**< Compute Operation Control Register, offset: 0x40 */
+} MCM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MCM_Register_Masks MCM Register Masks
+ * @{
+ */
+
+/* PLASC Bit Fields */
+#define MCM_PLASC_ASC_MASK                       0xFFu
+#define MCM_PLASC_ASC_SHIFT                      0
+#define MCM_PLASC_ASC(x)                         (((uint16_t)(((uint16_t)(x))<<MCM_PLASC_ASC_SHIFT))&MCM_PLASC_ASC_MASK)
+/* PLAMC Bit Fields */
+#define MCM_PLAMC_AMC_MASK                       0xFFu
+#define MCM_PLAMC_AMC_SHIFT                      0
+#define MCM_PLAMC_AMC(x)                         (((uint16_t)(((uint16_t)(x))<<MCM_PLAMC_AMC_SHIFT))&MCM_PLAMC_AMC_MASK)
+/* PLACR Bit Fields */
+#define MCM_PLACR_ARB_MASK                       0x200u
+#define MCM_PLACR_ARB_SHIFT                      9
+#define MCM_PLACR_CFCC_MASK                      0x400u
+#define MCM_PLACR_CFCC_SHIFT                     10
+#define MCM_PLACR_DFCDA_MASK                     0x800u
+#define MCM_PLACR_DFCDA_SHIFT                    11
+#define MCM_PLACR_DFCIC_MASK                     0x1000u
+#define MCM_PLACR_DFCIC_SHIFT                    12
+#define MCM_PLACR_DFCC_MASK                      0x2000u
+#define MCM_PLACR_DFCC_SHIFT                     13
+#define MCM_PLACR_EFDS_MASK                      0x4000u
+#define MCM_PLACR_EFDS_SHIFT                     14
+#define MCM_PLACR_DFCS_MASK                      0x8000u
+#define MCM_PLACR_DFCS_SHIFT                     15
+#define MCM_PLACR_ESFC_MASK                      0x10000u
+#define MCM_PLACR_ESFC_SHIFT                     16
+/* CPO Bit Fields */
+#define MCM_CPO_CPOREQ_MASK                      0x1u
+#define MCM_CPO_CPOREQ_SHIFT                     0
+#define MCM_CPO_CPOACK_MASK                      0x2u
+#define MCM_CPO_CPOACK_SHIFT                     1
+#define MCM_CPO_CPOWOI_MASK                      0x4u
+#define MCM_CPO_CPOWOI_SHIFT                     2
+
+/**
+ * @}
+ */ /* end of group MCM_Register_Masks */
+
+
+/* MCM - Peripheral instance base addresses */
+/** Peripheral MCM base address */
+#define MCM_BASE                                 (0xF0003000u)
+/** Peripheral MCM base pointer */
+#define MCM                                      ((MCM_Type *)MCM_BASE)
+/** Array initializer of MCM peripheral base pointers */
+#define MCM_BASES                                { MCM }
+
+/**
+ * @}
+ */ /* end of group MCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MTB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MTB_Peripheral_Access_Layer MTB Peripheral Access Layer
+ * @{
+ */
+
+/** MTB - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t POSITION;                          /**< MTB Position Register, offset: 0x0 */
+  __IO uint32_t MASTER;                            /**< MTB Master Register, offset: 0x4 */
+  __IO uint32_t FLOW;                              /**< MTB Flow Register, offset: 0x8 */
+  __I  uint32_t BASE;                              /**< MTB Base Register, offset: 0xC */
+       uint8_t RESERVED_0[3824];
+  __I  uint32_t MODECTRL;                          /**< Integration Mode Control Register, offset: 0xF00 */
+       uint8_t RESERVED_1[156];
+  __I  uint32_t TAGSET;                            /**< Claim TAG Set Register, offset: 0xFA0 */
+  __I  uint32_t TAGCLEAR;                          /**< Claim TAG Clear Register, offset: 0xFA4 */
+       uint8_t RESERVED_2[8];
+  __I  uint32_t LOCKACCESS;                        /**< Lock Access Register, offset: 0xFB0 */
+  __I  uint32_t LOCKSTAT;                          /**< Lock Status Register, offset: 0xFB4 */
+  __I  uint32_t AUTHSTAT;                          /**< Authentication Status Register, offset: 0xFB8 */
+  __I  uint32_t DEVICEARCH;                        /**< Device Architecture Register, offset: 0xFBC */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t DEVICECFG;                         /**< Device Configuration Register, offset: 0xFC8 */
+  __I  uint32_t DEVICETYPID;                       /**< Device Type Identifier Register, offset: 0xFCC */
+  __I  uint32_t PERIPHID[8];                       /**< Peripheral ID Register, array offset: 0xFD0, array step: 0x4 */
+  __I  uint32_t COMPID[4];                         /**< Component ID Register, array offset: 0xFF0, array step: 0x4 */
+} MTB_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MTB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MTB_Register_Masks MTB Register Masks
+ * @{
+ */
+
+/* POSITION Bit Fields */
+#define MTB_POSITION_WRAP_MASK                   0x4u
+#define MTB_POSITION_WRAP_SHIFT                  2
+#define MTB_POSITION_POINTER_MASK                0xFFFFFFF8u
+#define MTB_POSITION_POINTER_SHIFT               3
+#define MTB_POSITION_POINTER(x)                  (((uint32_t)(((uint32_t)(x))<<MTB_POSITION_POINTER_SHIFT))&MTB_POSITION_POINTER_MASK)
+/* MASTER Bit Fields */
+#define MTB_MASTER_MASK_MASK                     0x1Fu
+#define MTB_MASTER_MASK_SHIFT                    0
+#define MTB_MASTER_MASK(x)                       (((uint32_t)(((uint32_t)(x))<<MTB_MASTER_MASK_SHIFT))&MTB_MASTER_MASK_MASK)
+#define MTB_MASTER_TSTARTEN_MASK                 0x20u
+#define MTB_MASTER_TSTARTEN_SHIFT                5
+#define MTB_MASTER_TSTOPEN_MASK                  0x40u
+#define MTB_MASTER_TSTOPEN_SHIFT                 6
+#define MTB_MASTER_SFRWPRIV_MASK                 0x80u
+#define MTB_MASTER_SFRWPRIV_SHIFT                7
+#define MTB_MASTER_RAMPRIV_MASK                  0x100u
+#define MTB_MASTER_RAMPRIV_SHIFT                 8
+#define MTB_MASTER_HALTREQ_MASK                  0x200u
+#define MTB_MASTER_HALTREQ_SHIFT                 9
+#define MTB_MASTER_EN_MASK                       0x80000000u
+#define MTB_MASTER_EN_SHIFT                      31
+/* FLOW Bit Fields */
+#define MTB_FLOW_AUTOSTOP_MASK                   0x1u
+#define MTB_FLOW_AUTOSTOP_SHIFT                  0
+#define MTB_FLOW_AUTOHALT_MASK                   0x2u
+#define MTB_FLOW_AUTOHALT_SHIFT                  1
+#define MTB_FLOW_WATERMARK_MASK                  0xFFFFFFF8u
+#define MTB_FLOW_WATERMARK_SHIFT                 3
+#define MTB_FLOW_WATERMARK(x)                    (((uint32_t)(((uint32_t)(x))<<MTB_FLOW_WATERMARK_SHIFT))&MTB_FLOW_WATERMARK_MASK)
+/* BASE Bit Fields */
+#define MTB_BASE_BASEADDR_MASK                   0xFFFFFFFFu
+#define MTB_BASE_BASEADDR_SHIFT                  0
+#define MTB_BASE_BASEADDR(x)                     (((uint32_t)(((uint32_t)(x))<<MTB_BASE_BASEADDR_SHIFT))&MTB_BASE_BASEADDR_MASK)
+/* MODECTRL Bit Fields */
+#define MTB_MODECTRL_MODECTRL_MASK               0xFFFFFFFFu
+#define MTB_MODECTRL_MODECTRL_SHIFT              0
+#define MTB_MODECTRL_MODECTRL(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_MODECTRL_MODECTRL_SHIFT))&MTB_MODECTRL_MODECTRL_MASK)
+/* TAGSET Bit Fields */
+#define MTB_TAGSET_TAGSET_MASK                   0xFFFFFFFFu
+#define MTB_TAGSET_TAGSET_SHIFT                  0
+#define MTB_TAGSET_TAGSET(x)                     (((uint32_t)(((uint32_t)(x))<<MTB_TAGSET_TAGSET_SHIFT))&MTB_TAGSET_TAGSET_MASK)
+/* TAGCLEAR Bit Fields */
+#define MTB_TAGCLEAR_TAGCLEAR_MASK               0xFFFFFFFFu
+#define MTB_TAGCLEAR_TAGCLEAR_SHIFT              0
+#define MTB_TAGCLEAR_TAGCLEAR(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_TAGCLEAR_TAGCLEAR_SHIFT))&MTB_TAGCLEAR_TAGCLEAR_MASK)
+/* LOCKACCESS Bit Fields */
+#define MTB_LOCKACCESS_LOCKACCESS_MASK           0xFFFFFFFFu
+#define MTB_LOCKACCESS_LOCKACCESS_SHIFT          0
+#define MTB_LOCKACCESS_LOCKACCESS(x)             (((uint32_t)(((uint32_t)(x))<<MTB_LOCKACCESS_LOCKACCESS_SHIFT))&MTB_LOCKACCESS_LOCKACCESS_MASK)
+/* LOCKSTAT Bit Fields */
+#define MTB_LOCKSTAT_LOCKSTAT_MASK               0xFFFFFFFFu
+#define MTB_LOCKSTAT_LOCKSTAT_SHIFT              0
+#define MTB_LOCKSTAT_LOCKSTAT(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_LOCKSTAT_LOCKSTAT_SHIFT))&MTB_LOCKSTAT_LOCKSTAT_MASK)
+/* AUTHSTAT Bit Fields */
+#define MTB_AUTHSTAT_BIT0_MASK                   0x1u
+#define MTB_AUTHSTAT_BIT0_SHIFT                  0
+#define MTB_AUTHSTAT_BIT1_MASK                   0x2u
+#define MTB_AUTHSTAT_BIT1_SHIFT                  1
+#define MTB_AUTHSTAT_BIT2_MASK                   0x4u
+#define MTB_AUTHSTAT_BIT2_SHIFT                  2
+#define MTB_AUTHSTAT_BIT3_MASK                   0x8u
+#define MTB_AUTHSTAT_BIT3_SHIFT                  3
+/* DEVICEARCH Bit Fields */
+#define MTB_DEVICEARCH_DEVICEARCH_MASK           0xFFFFFFFFu
+#define MTB_DEVICEARCH_DEVICEARCH_SHIFT          0
+#define MTB_DEVICEARCH_DEVICEARCH(x)             (((uint32_t)(((uint32_t)(x))<<MTB_DEVICEARCH_DEVICEARCH_SHIFT))&MTB_DEVICEARCH_DEVICEARCH_MASK)
+/* DEVICECFG Bit Fields */
+#define MTB_DEVICECFG_DEVICECFG_MASK             0xFFFFFFFFu
+#define MTB_DEVICECFG_DEVICECFG_SHIFT            0
+#define MTB_DEVICECFG_DEVICECFG(x)               (((uint32_t)(((uint32_t)(x))<<MTB_DEVICECFG_DEVICECFG_SHIFT))&MTB_DEVICECFG_DEVICECFG_MASK)
+/* DEVICETYPID Bit Fields */
+#define MTB_DEVICETYPID_DEVICETYPID_MASK         0xFFFFFFFFu
+#define MTB_DEVICETYPID_DEVICETYPID_SHIFT        0
+#define MTB_DEVICETYPID_DEVICETYPID(x)           (((uint32_t)(((uint32_t)(x))<<MTB_DEVICETYPID_DEVICETYPID_SHIFT))&MTB_DEVICETYPID_DEVICETYPID_MASK)
+/* PERIPHID Bit Fields */
+#define MTB_PERIPHID_PERIPHID_MASK               0xFFFFFFFFu
+#define MTB_PERIPHID_PERIPHID_SHIFT              0
+#define MTB_PERIPHID_PERIPHID(x)                 (((uint32_t)(((uint32_t)(x))<<MTB_PERIPHID_PERIPHID_SHIFT))&MTB_PERIPHID_PERIPHID_MASK)
+/* COMPID Bit Fields */
+#define MTB_COMPID_COMPID_MASK                   0xFFFFFFFFu
+#define MTB_COMPID_COMPID_SHIFT                  0
+#define MTB_COMPID_COMPID(x)                     (((uint32_t)(((uint32_t)(x))<<MTB_COMPID_COMPID_SHIFT))&MTB_COMPID_COMPID_MASK)
+
+/**
+ * @}
+ */ /* end of group MTB_Register_Masks */
+
+
+/* MTB - Peripheral instance base addresses */
+/** Peripheral MTB base address */
+#define MTB_BASE                                 (0xF0000000u)
+/** Peripheral MTB base pointer */
+#define MTB                                      ((MTB_Type *)MTB_BASE)
+/** Array initializer of MTB peripheral base pointers */
+#define MTB_BASES                                { MTB }
+
+/**
+ * @}
+ */ /* end of group MTB_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- MTBDWT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MTBDWT_Peripheral_Access_Layer MTBDWT Peripheral Access Layer
+ * @{
+ */
+
+/** MTBDWT - Register Layout Typedef */
+typedef struct {
+  __I  uint32_t CTRL;                              /**< MTB DWT Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[28];
+  struct {                                         /* offset: 0x20, array step: 0x10 */
+    __IO uint32_t COMP;                              /**< MTB_DWT Comparator Register, array offset: 0x20, array step: 0x10 */
+    __IO uint32_t MASK;                              /**< MTB_DWT Comparator Mask Register, array offset: 0x24, array step: 0x10 */
+    __IO uint32_t FCT;                               /**< MTB_DWT Comparator Function Register 0..MTB_DWT Comparator Function Register 1, array offset: 0x28, array step: 0x10 */
+         uint8_t RESERVED_0[4];
+  } COMPARATOR[2];
+       uint8_t RESERVED_1[448];
+  __IO uint32_t TBCTRL;                            /**< MTB_DWT Trace Buffer Control Register, offset: 0x200 */
+       uint8_t RESERVED_2[3524];
+  __I  uint32_t DEVICECFG;                         /**< Device Configuration Register, offset: 0xFC8 */
+  __I  uint32_t DEVICETYPID;                       /**< Device Type Identifier Register, offset: 0xFCC */
+  __I  uint32_t PERIPHID[8];                       /**< Peripheral ID Register, array offset: 0xFD0, array step: 0x4 */
+  __I  uint32_t COMPID[4];                         /**< Component ID Register, array offset: 0xFF0, array step: 0x4 */
+} MTBDWT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- MTBDWT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup MTBDWT_Register_Masks MTBDWT Register Masks
+ * @{
+ */
+
+/* CTRL Bit Fields */
+#define MTBDWT_CTRL_DWTCFGCTRL_MASK              0xFFFFFFFu
+#define MTBDWT_CTRL_DWTCFGCTRL_SHIFT             0
+#define MTBDWT_CTRL_DWTCFGCTRL(x)                (((uint32_t)(((uint32_t)(x))<<MTBDWT_CTRL_DWTCFGCTRL_SHIFT))&MTBDWT_CTRL_DWTCFGCTRL_MASK)
+#define MTBDWT_CTRL_NUMCMP_MASK                  0xF0000000u
+#define MTBDWT_CTRL_NUMCMP_SHIFT                 28
+#define MTBDWT_CTRL_NUMCMP(x)                    (((uint32_t)(((uint32_t)(x))<<MTBDWT_CTRL_NUMCMP_SHIFT))&MTBDWT_CTRL_NUMCMP_MASK)
+/* COMP Bit Fields */
+#define MTBDWT_COMP_COMP_MASK                    0xFFFFFFFFu
+#define MTBDWT_COMP_COMP_SHIFT                   0
+#define MTBDWT_COMP_COMP(x)                      (((uint32_t)(((uint32_t)(x))<<MTBDWT_COMP_COMP_SHIFT))&MTBDWT_COMP_COMP_MASK)
+/* MASK Bit Fields */
+#define MTBDWT_MASK_MASK_MASK                    0x1Fu
+#define MTBDWT_MASK_MASK_SHIFT                   0
+#define MTBDWT_MASK_MASK(x)                      (((uint32_t)(((uint32_t)(x))<<MTBDWT_MASK_MASK_SHIFT))&MTBDWT_MASK_MASK_MASK)
+/* FCT Bit Fields */
+#define MTBDWT_FCT_FUNCTION_MASK                 0xFu
+#define MTBDWT_FCT_FUNCTION_SHIFT                0
+#define MTBDWT_FCT_FUNCTION(x)                   (((uint32_t)(((uint32_t)(x))<<MTBDWT_FCT_FUNCTION_SHIFT))&MTBDWT_FCT_FUNCTION_MASK)
+#define MTBDWT_FCT_DATAVMATCH_MASK               0x100u
+#define MTBDWT_FCT_DATAVMATCH_SHIFT              8
+#define MTBDWT_FCT_DATAVSIZE_MASK                0xC00u
+#define MTBDWT_FCT_DATAVSIZE_SHIFT               10
+#define MTBDWT_FCT_DATAVSIZE(x)                  (((uint32_t)(((uint32_t)(x))<<MTBDWT_FCT_DATAVSIZE_SHIFT))&MTBDWT_FCT_DATAVSIZE_MASK)
+#define MTBDWT_FCT_DATAVADDR0_MASK               0xF000u
+#define MTBDWT_FCT_DATAVADDR0_SHIFT              12
+#define MTBDWT_FCT_DATAVADDR0(x)                 (((uint32_t)(((uint32_t)(x))<<MTBDWT_FCT_DATAVADDR0_SHIFT))&MTBDWT_FCT_DATAVADDR0_MASK)
+#define MTBDWT_FCT_MATCHED_MASK                  0x1000000u
+#define MTBDWT_FCT_MATCHED_SHIFT                 24
+/* TBCTRL Bit Fields */
+#define MTBDWT_TBCTRL_ACOMP0_MASK                0x1u
+#define MTBDWT_TBCTRL_ACOMP0_SHIFT               0
+#define MTBDWT_TBCTRL_ACOMP1_MASK                0x2u
+#define MTBDWT_TBCTRL_ACOMP1_SHIFT               1
+#define MTBDWT_TBCTRL_NUMCOMP_MASK               0xF0000000u
+#define MTBDWT_TBCTRL_NUMCOMP_SHIFT              28
+#define MTBDWT_TBCTRL_NUMCOMP(x)                 (((uint32_t)(((uint32_t)(x))<<MTBDWT_TBCTRL_NUMCOMP_SHIFT))&MTBDWT_TBCTRL_NUMCOMP_MASK)
+/* DEVICECFG Bit Fields */
+#define MTBDWT_DEVICECFG_DEVICECFG_MASK          0xFFFFFFFFu
+#define MTBDWT_DEVICECFG_DEVICECFG_SHIFT         0
+#define MTBDWT_DEVICECFG_DEVICECFG(x)            (((uint32_t)(((uint32_t)(x))<<MTBDWT_DEVICECFG_DEVICECFG_SHIFT))&MTBDWT_DEVICECFG_DEVICECFG_MASK)
+/* DEVICETYPID Bit Fields */
+#define MTBDWT_DEVICETYPID_DEVICETYPID_MASK      0xFFFFFFFFu
+#define MTBDWT_DEVICETYPID_DEVICETYPID_SHIFT     0
+#define MTBDWT_DEVICETYPID_DEVICETYPID(x)        (((uint32_t)(((uint32_t)(x))<<MTBDWT_DEVICETYPID_DEVICETYPID_SHIFT))&MTBDWT_DEVICETYPID_DEVICETYPID_MASK)
+/* PERIPHID Bit Fields */
+#define MTBDWT_PERIPHID_PERIPHID_MASK            0xFFFFFFFFu
+#define MTBDWT_PERIPHID_PERIPHID_SHIFT           0
+#define MTBDWT_PERIPHID_PERIPHID(x)              (((uint32_t)(((uint32_t)(x))<<MTBDWT_PERIPHID_PERIPHID_SHIFT))&MTBDWT_PERIPHID_PERIPHID_MASK)
+/* COMPID Bit Fields */
+#define MTBDWT_COMPID_COMPID_MASK                0xFFFFFFFFu
+#define MTBDWT_COMPID_COMPID_SHIFT               0
+#define MTBDWT_COMPID_COMPID(x)                  (((uint32_t)(((uint32_t)(x))<<MTBDWT_COMPID_COMPID_SHIFT))&MTBDWT_COMPID_COMPID_MASK)
+
+/**
+ * @}
+ */ /* end of group MTBDWT_Register_Masks */
+
+
+/* MTBDWT - Peripheral instance base addresses */
+/** Peripheral MTBDWT base address */
+#define MTBDWT_BASE                              (0xF0001000u)
+/** Peripheral MTBDWT base pointer */
+#define MTBDWT                                   ((MTBDWT_Type *)MTBDWT_BASE)
+/** Array initializer of MTBDWT peripheral base pointers */
+#define MTBDWT_BASES                             { MTBDWT }
+
+/**
+ * @}
+ */ /* end of group MTBDWT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- NV Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup NV_Peripheral_Access_Layer NV Peripheral Access Layer
+ * @{
+ */
+
+/** NV - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t BACKKEY3;                           /**< Backdoor Comparison Key 3., offset: 0x0 */
+  __I  uint8_t BACKKEY2;                           /**< Backdoor Comparison Key 2., offset: 0x1 */
+  __I  uint8_t BACKKEY1;                           /**< Backdoor Comparison Key 1., offset: 0x2 */
+  __I  uint8_t BACKKEY0;                           /**< Backdoor Comparison Key 0., offset: 0x3 */
+  __I  uint8_t BACKKEY7;                           /**< Backdoor Comparison Key 7., offset: 0x4 */
+  __I  uint8_t BACKKEY6;                           /**< Backdoor Comparison Key 6., offset: 0x5 */
+  __I  uint8_t BACKKEY5;                           /**< Backdoor Comparison Key 5., offset: 0x6 */
+  __I  uint8_t BACKKEY4;                           /**< Backdoor Comparison Key 4., offset: 0x7 */
+  __I  uint8_t FPROT3;                             /**< Non-volatile P-Flash Protection 1 - Low Register, offset: 0x8 */
+  __I  uint8_t FPROT2;                             /**< Non-volatile P-Flash Protection 1 - High Register, offset: 0x9 */
+  __I  uint8_t FPROT1;                             /**< Non-volatile P-Flash Protection 0 - Low Register, offset: 0xA */
+  __I  uint8_t FPROT0;                             /**< Non-volatile P-Flash Protection 0 - High Register, offset: 0xB */
+  __I  uint8_t FSEC;                               /**< Non-volatile Flash Security Register, offset: 0xC */
+  __I  uint8_t FOPT;                               /**< Non-volatile Flash Option Register, offset: 0xD */
+} NV_Type;
+
+/* ----------------------------------------------------------------------------
+   -- NV Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup NV_Register_Masks NV Register Masks
+ * @{
+ */
+
+/* BACKKEY3 Bit Fields */
+#define NV_BACKKEY3_KEY_MASK                     0xFFu
+#define NV_BACKKEY3_KEY_SHIFT                    0
+#define NV_BACKKEY3_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY3_KEY_SHIFT))&NV_BACKKEY3_KEY_MASK)
+/* BACKKEY2 Bit Fields */
+#define NV_BACKKEY2_KEY_MASK                     0xFFu
+#define NV_BACKKEY2_KEY_SHIFT                    0
+#define NV_BACKKEY2_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY2_KEY_SHIFT))&NV_BACKKEY2_KEY_MASK)
+/* BACKKEY1 Bit Fields */
+#define NV_BACKKEY1_KEY_MASK                     0xFFu
+#define NV_BACKKEY1_KEY_SHIFT                    0
+#define NV_BACKKEY1_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY1_KEY_SHIFT))&NV_BACKKEY1_KEY_MASK)
+/* BACKKEY0 Bit Fields */
+#define NV_BACKKEY0_KEY_MASK                     0xFFu
+#define NV_BACKKEY0_KEY_SHIFT                    0
+#define NV_BACKKEY0_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY0_KEY_SHIFT))&NV_BACKKEY0_KEY_MASK)
+/* BACKKEY7 Bit Fields */
+#define NV_BACKKEY7_KEY_MASK                     0xFFu
+#define NV_BACKKEY7_KEY_SHIFT                    0
+#define NV_BACKKEY7_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY7_KEY_SHIFT))&NV_BACKKEY7_KEY_MASK)
+/* BACKKEY6 Bit Fields */
+#define NV_BACKKEY6_KEY_MASK                     0xFFu
+#define NV_BACKKEY6_KEY_SHIFT                    0
+#define NV_BACKKEY6_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY6_KEY_SHIFT))&NV_BACKKEY6_KEY_MASK)
+/* BACKKEY5 Bit Fields */
+#define NV_BACKKEY5_KEY_MASK                     0xFFu
+#define NV_BACKKEY5_KEY_SHIFT                    0
+#define NV_BACKKEY5_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY5_KEY_SHIFT))&NV_BACKKEY5_KEY_MASK)
+/* BACKKEY4 Bit Fields */
+#define NV_BACKKEY4_KEY_MASK                     0xFFu
+#define NV_BACKKEY4_KEY_SHIFT                    0
+#define NV_BACKKEY4_KEY(x)                       (((uint8_t)(((uint8_t)(x))<<NV_BACKKEY4_KEY_SHIFT))&NV_BACKKEY4_KEY_MASK)
+/* FPROT3 Bit Fields */
+#define NV_FPROT3_PROT_MASK                      0xFFu
+#define NV_FPROT3_PROT_SHIFT                     0
+#define NV_FPROT3_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT3_PROT_SHIFT))&NV_FPROT3_PROT_MASK)
+/* FPROT2 Bit Fields */
+#define NV_FPROT2_PROT_MASK                      0xFFu
+#define NV_FPROT2_PROT_SHIFT                     0
+#define NV_FPROT2_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT2_PROT_SHIFT))&NV_FPROT2_PROT_MASK)
+/* FPROT1 Bit Fields */
+#define NV_FPROT1_PROT_MASK                      0xFFu
+#define NV_FPROT1_PROT_SHIFT                     0
+#define NV_FPROT1_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT1_PROT_SHIFT))&NV_FPROT1_PROT_MASK)
+/* FPROT0 Bit Fields */
+#define NV_FPROT0_PROT_MASK                      0xFFu
+#define NV_FPROT0_PROT_SHIFT                     0
+#define NV_FPROT0_PROT(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FPROT0_PROT_SHIFT))&NV_FPROT0_PROT_MASK)
+/* FSEC Bit Fields */
+#define NV_FSEC_SEC_MASK                         0x3u
+#define NV_FSEC_SEC_SHIFT                        0
+#define NV_FSEC_SEC(x)                           (((uint8_t)(((uint8_t)(x))<<NV_FSEC_SEC_SHIFT))&NV_FSEC_SEC_MASK)
+#define NV_FSEC_FSLACC_MASK                      0xCu
+#define NV_FSEC_FSLACC_SHIFT                     2
+#define NV_FSEC_FSLACC(x)                        (((uint8_t)(((uint8_t)(x))<<NV_FSEC_FSLACC_SHIFT))&NV_FSEC_FSLACC_MASK)
+#define NV_FSEC_MEEN_MASK                        0x30u
+#define NV_FSEC_MEEN_SHIFT                       4
+#define NV_FSEC_MEEN(x)                          (((uint8_t)(((uint8_t)(x))<<NV_FSEC_MEEN_SHIFT))&NV_FSEC_MEEN_MASK)
+#define NV_FSEC_KEYEN_MASK                       0xC0u
+#define NV_FSEC_KEYEN_SHIFT                      6
+#define NV_FSEC_KEYEN(x)                         (((uint8_t)(((uint8_t)(x))<<NV_FSEC_KEYEN_SHIFT))&NV_FSEC_KEYEN_MASK)
+/* FOPT Bit Fields */
+#define NV_FOPT_LPBOOT0_MASK                     0x1u
+#define NV_FOPT_LPBOOT0_SHIFT                    0
+#define NV_FOPT_NMI_DIS_MASK                     0x4u
+#define NV_FOPT_NMI_DIS_SHIFT                    2
+#define NV_FOPT_RESET_PIN_CFG_MASK               0x8u
+#define NV_FOPT_RESET_PIN_CFG_SHIFT              3
+#define NV_FOPT_LPBOOT1_MASK                     0x10u
+#define NV_FOPT_LPBOOT1_SHIFT                    4
+#define NV_FOPT_FAST_INIT_MASK                   0x20u
+#define NV_FOPT_FAST_INIT_SHIFT                  5
+
+/**
+ * @}
+ */ /* end of group NV_Register_Masks */
+
+
+/* NV - Peripheral instance base addresses */
+/** Peripheral FTFA_FlashConfig base address */
+#define FTFA_FlashConfig_BASE                    (0x400u)
+/** Peripheral FTFA_FlashConfig base pointer */
+#define FTFA_FlashConfig                         ((NV_Type *)FTFA_FlashConfig_BASE)
+/** Array initializer of NV peripheral base pointers */
+#define NV_BASES                                 { FTFA_FlashConfig }
+
+/**
+ * @}
+ */ /* end of group NV_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- OSC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup OSC_Peripheral_Access_Layer OSC Peripheral Access Layer
+ * @{
+ */
+
+/** OSC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t CR;                                 /**< OSC Control Register, offset: 0x0 */
+} OSC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- OSC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup OSC_Register_Masks OSC Register Masks
+ * @{
+ */
+
+/* CR Bit Fields */
+#define OSC_CR_SC16P_MASK                        0x1u
+#define OSC_CR_SC16P_SHIFT                       0
+#define OSC_CR_SC8P_MASK                         0x2u
+#define OSC_CR_SC8P_SHIFT                        1
+#define OSC_CR_SC4P_MASK                         0x4u
+#define OSC_CR_SC4P_SHIFT                        2
+#define OSC_CR_SC2P_MASK                         0x8u
+#define OSC_CR_SC2P_SHIFT                        3
+#define OSC_CR_EREFSTEN_MASK                     0x20u
+#define OSC_CR_EREFSTEN_SHIFT                    5
+#define OSC_CR_ERCLKEN_MASK                      0x80u
+#define OSC_CR_ERCLKEN_SHIFT                     7
+
+/**
+ * @}
+ */ /* end of group OSC_Register_Masks */
+
+
+/* OSC - Peripheral instance base addresses */
+/** Peripheral OSC0 base address */
+#define OSC0_BASE                                (0x40065000u)
+/** Peripheral OSC0 base pointer */
+#define OSC0                                     ((OSC_Type *)OSC0_BASE)
+/** Array initializer of OSC peripheral base pointers */
+#define OSC_BASES                                { OSC0 }
+
+/**
+ * @}
+ */ /* end of group OSC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PIT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup PIT_Peripheral_Access_Layer PIT Peripheral Access Layer
+ * @{
+ */
+
+/** PIT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t MCR;                               /**< PIT Module Control Register, offset: 0x0 */
+       uint8_t RESERVED_0[220];
+  __I  uint32_t LTMR64H;                           /**< PIT Upper Lifetime Timer Register, offset: 0xE0 */
+  __I  uint32_t LTMR64L;                           /**< PIT Lower Lifetime Timer Register, offset: 0xE4 */
+       uint8_t RESERVED_1[24];
+  struct {                                         /* offset: 0x100, array step: 0x10 */
+    __IO uint32_t LDVAL;                             /**< Timer Load Value Register, array offset: 0x100, array step: 0x10 */
+    __I  uint32_t CVAL;                              /**< Current Timer Value Register, array offset: 0x104, array step: 0x10 */
+    __IO uint32_t TCTRL;                             /**< Timer Control Register, array offset: 0x108, array step: 0x10 */
+    __IO uint32_t TFLG;                              /**< Timer Flag Register, array offset: 0x10C, array step: 0x10 */
+  } CHANNEL[2];
+} PIT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PIT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup PIT_Register_Masks PIT Register Masks
+ * @{
+ */
+
+/* MCR Bit Fields */
+#define PIT_MCR_FRZ_MASK                         0x1u
+#define PIT_MCR_FRZ_SHIFT                        0
+#define PIT_MCR_MDIS_MASK                        0x2u
+#define PIT_MCR_MDIS_SHIFT                       1
+/* LTMR64H Bit Fields */
+#define PIT_LTMR64H_LTH_MASK                     0xFFFFFFFFu
+#define PIT_LTMR64H_LTH_SHIFT                    0
+#define PIT_LTMR64H_LTH(x)                       (((uint32_t)(((uint32_t)(x))<<PIT_LTMR64H_LTH_SHIFT))&PIT_LTMR64H_LTH_MASK)
+/* LTMR64L Bit Fields */
+#define PIT_LTMR64L_LTL_MASK                     0xFFFFFFFFu
+#define PIT_LTMR64L_LTL_SHIFT                    0
+#define PIT_LTMR64L_LTL(x)                       (((uint32_t)(((uint32_t)(x))<<PIT_LTMR64L_LTL_SHIFT))&PIT_LTMR64L_LTL_MASK)
+/* LDVAL Bit Fields */
+#define PIT_LDVAL_TSV_MASK                       0xFFFFFFFFu
+#define PIT_LDVAL_TSV_SHIFT                      0
+#define PIT_LDVAL_TSV(x)                         (((uint32_t)(((uint32_t)(x))<<PIT_LDVAL_TSV_SHIFT))&PIT_LDVAL_TSV_MASK)
+/* CVAL Bit Fields */
+#define PIT_CVAL_TVL_MASK                        0xFFFFFFFFu
+#define PIT_CVAL_TVL_SHIFT                       0
+#define PIT_CVAL_TVL(x)                          (((uint32_t)(((uint32_t)(x))<<PIT_CVAL_TVL_SHIFT))&PIT_CVAL_TVL_MASK)
+/* TCTRL Bit Fields */
+#define PIT_TCTRL_TEN_MASK                       0x1u
+#define PIT_TCTRL_TEN_SHIFT                      0
+#define PIT_TCTRL_TIE_MASK                       0x2u
+#define PIT_TCTRL_TIE_SHIFT                      1
+#define PIT_TCTRL_CHN_MASK                       0x4u
+#define PIT_TCTRL_CHN_SHIFT                      2
+/* TFLG Bit Fields */
+#define PIT_TFLG_TIF_MASK                        0x1u
+#define PIT_TFLG_TIF_SHIFT                       0
+
+/**
+ * @}
+ */ /* end of group PIT_Register_Masks */
+
+
+/* PIT - Peripheral instance base addresses */
+/** Peripheral PIT base address */
+#define PIT_BASE                                 (0x40037000u)
+/** Peripheral PIT base pointer */
+#define PIT                                      ((PIT_Type *)PIT_BASE)
+/** Array initializer of PIT peripheral base pointers */
+#define PIT_BASES                                { PIT }
+
+/**
+ * @}
+ */ /* end of group PIT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup PMC_Peripheral_Access_Layer PMC Peripheral Access Layer
+ * @{
+ */
+
+/** PMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t LVDSC1;                             /**< Low Voltage Detect Status And Control 1 register, offset: 0x0 */
+  __IO uint8_t LVDSC2;                             /**< Low Voltage Detect Status And Control 2 register, offset: 0x1 */
+  __IO uint8_t REGSC;                              /**< Regulator Status And Control register, offset: 0x2 */
+} PMC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup PMC_Register_Masks PMC Register Masks
+ * @{
+ */
+
+/* LVDSC1 Bit Fields */
+#define PMC_LVDSC1_LVDV_MASK                     0x3u
+#define PMC_LVDSC1_LVDV_SHIFT                    0
+#define PMC_LVDSC1_LVDV(x)                       (((uint8_t)(((uint8_t)(x))<<PMC_LVDSC1_LVDV_SHIFT))&PMC_LVDSC1_LVDV_MASK)
+#define PMC_LVDSC1_LVDRE_MASK                    0x10u
+#define PMC_LVDSC1_LVDRE_SHIFT                   4
+#define PMC_LVDSC1_LVDIE_MASK                    0x20u
+#define PMC_LVDSC1_LVDIE_SHIFT                   5
+#define PMC_LVDSC1_LVDACK_MASK                   0x40u
+#define PMC_LVDSC1_LVDACK_SHIFT                  6
+#define PMC_LVDSC1_LVDF_MASK                     0x80u
+#define PMC_LVDSC1_LVDF_SHIFT                    7
+/* LVDSC2 Bit Fields */
+#define PMC_LVDSC2_LVWV_MASK                     0x3u
+#define PMC_LVDSC2_LVWV_SHIFT                    0
+#define PMC_LVDSC2_LVWV(x)                       (((uint8_t)(((uint8_t)(x))<<PMC_LVDSC2_LVWV_SHIFT))&PMC_LVDSC2_LVWV_MASK)
+#define PMC_LVDSC2_LVWIE_MASK                    0x20u
+#define PMC_LVDSC2_LVWIE_SHIFT                   5
+#define PMC_LVDSC2_LVWACK_MASK                   0x40u
+#define PMC_LVDSC2_LVWACK_SHIFT                  6
+#define PMC_LVDSC2_LVWF_MASK                     0x80u
+#define PMC_LVDSC2_LVWF_SHIFT                    7
+/* REGSC Bit Fields */
+#define PMC_REGSC_BGBE_MASK                      0x1u
+#define PMC_REGSC_BGBE_SHIFT                     0
+#define PMC_REGSC_REGONS_MASK                    0x4u
+#define PMC_REGSC_REGONS_SHIFT                   2
+#define PMC_REGSC_ACKISO_MASK                    0x8u
+#define PMC_REGSC_ACKISO_SHIFT                   3
+#define PMC_REGSC_BGEN_MASK                      0x10u
+#define PMC_REGSC_BGEN_SHIFT                     4
+
+/**
+ * @}
+ */ /* end of group PMC_Register_Masks */
+
+
+/* PMC - Peripheral instance base addresses */
+/** Peripheral PMC base address */
+#define PMC_BASE                                 (0x4007D000u)
+/** Peripheral PMC base pointer */
+#define PMC                                      ((PMC_Type *)PMC_BASE)
+/** Array initializer of PMC peripheral base pointers */
+#define PMC_BASES                                { PMC }
+
+/**
+ * @}
+ */ /* end of group PMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- PORT Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup PORT_Peripheral_Access_Layer PORT Peripheral Access Layer
+ * @{
+ */
+
+/** PORT - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t PCR[32];                           /**< Pin Control Register n, array offset: 0x0, array step: 0x4 */
+  __O  uint32_t GPCLR;                             /**< Global Pin Control Low Register, offset: 0x80 */
+  __O  uint32_t GPCHR;                             /**< Global Pin Control High Register, offset: 0x84 */
+       uint8_t RESERVED_0[24];
+  __IO uint32_t ISFR;                              /**< Interrupt Status Flag Register, offset: 0xA0 */
+} PORT_Type;
+
+/* ----------------------------------------------------------------------------
+   -- PORT Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup PORT_Register_Masks PORT Register Masks
+ * @{
+ */
+
+/* PCR Bit Fields */
+#define PORT_PCR_PS_MASK                         0x1u
+#define PORT_PCR_PS_SHIFT                        0
+#define PORT_PCR_PE_MASK                         0x2u
+#define PORT_PCR_PE_SHIFT                        1
+#define PORT_PCR_SRE_MASK                        0x4u
+#define PORT_PCR_SRE_SHIFT                       2
+#define PORT_PCR_PFE_MASK                        0x10u
+#define PORT_PCR_PFE_SHIFT                       4
+#define PORT_PCR_DSE_MASK                        0x40u
+#define PORT_PCR_DSE_SHIFT                       6
+#define PORT_PCR_MUX_MASK                        0x700u
+#define PORT_PCR_MUX_SHIFT                       8
+#define PORT_PCR_MUX(x)                          (((uint32_t)(((uint32_t)(x))<<PORT_PCR_MUX_SHIFT))&PORT_PCR_MUX_MASK)
+#define PORT_PCR_IRQC_MASK                       0xF0000u
+#define PORT_PCR_IRQC_SHIFT                      16
+#define PORT_PCR_IRQC(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_PCR_IRQC_SHIFT))&PORT_PCR_IRQC_MASK)
+#define PORT_PCR_ISF_MASK                        0x1000000u
+#define PORT_PCR_ISF_SHIFT                       24
+/* GPCLR Bit Fields */
+#define PORT_GPCLR_GPWD_MASK                     0xFFFFu
+#define PORT_GPCLR_GPWD_SHIFT                    0
+#define PORT_GPCLR_GPWD(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCLR_GPWD_SHIFT))&PORT_GPCLR_GPWD_MASK)
+#define PORT_GPCLR_GPWE_MASK                     0xFFFF0000u
+#define PORT_GPCLR_GPWE_SHIFT                    16
+#define PORT_GPCLR_GPWE(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCLR_GPWE_SHIFT))&PORT_GPCLR_GPWE_MASK)
+/* GPCHR Bit Fields */
+#define PORT_GPCHR_GPWD_MASK                     0xFFFFu
+#define PORT_GPCHR_GPWD_SHIFT                    0
+#define PORT_GPCHR_GPWD(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCHR_GPWD_SHIFT))&PORT_GPCHR_GPWD_MASK)
+#define PORT_GPCHR_GPWE_MASK                     0xFFFF0000u
+#define PORT_GPCHR_GPWE_SHIFT                    16
+#define PORT_GPCHR_GPWE(x)                       (((uint32_t)(((uint32_t)(x))<<PORT_GPCHR_GPWE_SHIFT))&PORT_GPCHR_GPWE_MASK)
+/* ISFR Bit Fields */
+#define PORT_ISFR_ISF_MASK                       0xFFFFFFFFu
+#define PORT_ISFR_ISF_SHIFT                      0
+#define PORT_ISFR_ISF(x)                         (((uint32_t)(((uint32_t)(x))<<PORT_ISFR_ISF_SHIFT))&PORT_ISFR_ISF_MASK)
+
+/**
+ * @}
+ */ /* end of group PORT_Register_Masks */
+
+
+/* PORT - Peripheral instance base addresses */
+/** Peripheral PORTA base address */
+#define PORTA_BASE                               (0x40049000u)
+/** Peripheral PORTA base pointer */
+#define PORTA                                    ((PORT_Type *)PORTA_BASE)
+/** Peripheral PORTB base address */
+#define PORTB_BASE                               (0x4004A000u)
+/** Peripheral PORTB base pointer */
+#define PORTB                                    ((PORT_Type *)PORTB_BASE)
+/** Peripheral PORTC base address */
+#define PORTC_BASE                               (0x4004B000u)
+/** Peripheral PORTC base pointer */
+#define PORTC                                    ((PORT_Type *)PORTC_BASE)
+/** Peripheral PORTD base address */
+#define PORTD_BASE                               (0x4004C000u)
+/** Peripheral PORTD base pointer */
+#define PORTD                                    ((PORT_Type *)PORTD_BASE)
+/** Peripheral PORTE base address */
+#define PORTE_BASE                               (0x4004D000u)
+/** Peripheral PORTE base pointer */
+#define PORTE                                    ((PORT_Type *)PORTE_BASE)
+/** Array initializer of PORT peripheral base pointers */
+#define PORT_BASES                               { PORTA, PORTB, PORTC, PORTD, PORTE }
+
+/**
+ * @}
+ */ /* end of group PORT_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RCM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup RCM_Peripheral_Access_Layer RCM Peripheral Access Layer
+ * @{
+ */
+
+/** RCM - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t SRS0;                               /**< System Reset Status Register 0, offset: 0x0 */
+  __I  uint8_t SRS1;                               /**< System Reset Status Register 1, offset: 0x1 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t RPFC;                               /**< Reset Pin Filter Control register, offset: 0x4 */
+  __IO uint8_t RPFW;                               /**< Reset Pin Filter Width register, offset: 0x5 */
+} RCM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RCM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup RCM_Register_Masks RCM Register Masks
+ * @{
+ */
+
+/* SRS0 Bit Fields */
+#define RCM_SRS0_WAKEUP_MASK                     0x1u
+#define RCM_SRS0_WAKEUP_SHIFT                    0
+#define RCM_SRS0_LVD_MASK                        0x2u
+#define RCM_SRS0_LVD_SHIFT                       1
+#define RCM_SRS0_LOC_MASK                        0x4u
+#define RCM_SRS0_LOC_SHIFT                       2
+#define RCM_SRS0_LOL_MASK                        0x8u
+#define RCM_SRS0_LOL_SHIFT                       3
+#define RCM_SRS0_WDOG_MASK                       0x20u
+#define RCM_SRS0_WDOG_SHIFT                      5
+#define RCM_SRS0_PIN_MASK                        0x40u
+#define RCM_SRS0_PIN_SHIFT                       6
+#define RCM_SRS0_POR_MASK                        0x80u
+#define RCM_SRS0_POR_SHIFT                       7
+/* SRS1 Bit Fields */
+#define RCM_SRS1_LOCKUP_MASK                     0x2u
+#define RCM_SRS1_LOCKUP_SHIFT                    1
+#define RCM_SRS1_SW_MASK                         0x4u
+#define RCM_SRS1_SW_SHIFT                        2
+#define RCM_SRS1_MDM_AP_MASK                     0x8u
+#define RCM_SRS1_MDM_AP_SHIFT                    3
+#define RCM_SRS1_SACKERR_MASK                    0x20u
+#define RCM_SRS1_SACKERR_SHIFT                   5
+/* RPFC Bit Fields */
+#define RCM_RPFC_RSTFLTSRW_MASK                  0x3u
+#define RCM_RPFC_RSTFLTSRW_SHIFT                 0
+#define RCM_RPFC_RSTFLTSRW(x)                    (((uint8_t)(((uint8_t)(x))<<RCM_RPFC_RSTFLTSRW_SHIFT))&RCM_RPFC_RSTFLTSRW_MASK)
+#define RCM_RPFC_RSTFLTSS_MASK                   0x4u
+#define RCM_RPFC_RSTFLTSS_SHIFT                  2
+/* RPFW Bit Fields */
+#define RCM_RPFW_RSTFLTSEL_MASK                  0x1Fu
+#define RCM_RPFW_RSTFLTSEL_SHIFT                 0
+#define RCM_RPFW_RSTFLTSEL(x)                    (((uint8_t)(((uint8_t)(x))<<RCM_RPFW_RSTFLTSEL_SHIFT))&RCM_RPFW_RSTFLTSEL_MASK)
+
+/**
+ * @}
+ */ /* end of group RCM_Register_Masks */
+
+
+/* RCM - Peripheral instance base addresses */
+/** Peripheral RCM base address */
+#define RCM_BASE                                 (0x4007F000u)
+/** Peripheral RCM base pointer */
+#define RCM                                      ((RCM_Type *)RCM_BASE)
+/** Array initializer of RCM peripheral base pointers */
+#define RCM_BASES                                { RCM }
+
+/**
+ * @}
+ */ /* end of group RCM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- ROM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup ROM_Peripheral_Access_Layer ROM Peripheral Access Layer
+ * @{
+ */
+
+/** ROM - Register Layout Typedef */
+typedef struct {
+  __I  uint32_t ENTRY[3];                          /**< Entry, array offset: 0x0, array step: 0x4 */
+  __I  uint32_t TABLEMARK;                         /**< End of Table Marker Register, offset: 0xC */
+       uint8_t RESERVED_0[4028];
+  __I  uint32_t SYSACCESS;                         /**< System Access Register, offset: 0xFCC */
+  __I  uint32_t PERIPHID4;                         /**< Peripheral ID Register, offset: 0xFD0 */
+  __I  uint32_t PERIPHID5;                         /**< Peripheral ID Register, offset: 0xFD4 */
+  __I  uint32_t PERIPHID6;                         /**< Peripheral ID Register, offset: 0xFD8 */
+  __I  uint32_t PERIPHID7;                         /**< Peripheral ID Register, offset: 0xFDC */
+  __I  uint32_t PERIPHID0;                         /**< Peripheral ID Register, offset: 0xFE0 */
+  __I  uint32_t PERIPHID1;                         /**< Peripheral ID Register, offset: 0xFE4 */
+  __I  uint32_t PERIPHID2;                         /**< Peripheral ID Register, offset: 0xFE8 */
+  __I  uint32_t PERIPHID3;                         /**< Peripheral ID Register, offset: 0xFEC */
+  __I  uint32_t COMPID[4];                         /**< Component ID Register, array offset: 0xFF0, array step: 0x4 */
+} ROM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- ROM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup ROM_Register_Masks ROM Register Masks
+ * @{
+ */
+
+/* ENTRY Bit Fields */
+#define ROM_ENTRY_ENTRY_MASK                     0xFFFFFFFFu
+#define ROM_ENTRY_ENTRY_SHIFT                    0
+#define ROM_ENTRY_ENTRY(x)                       (((uint32_t)(((uint32_t)(x))<<ROM_ENTRY_ENTRY_SHIFT))&ROM_ENTRY_ENTRY_MASK)
+/* TABLEMARK Bit Fields */
+#define ROM_TABLEMARK_MARK_MASK                  0xFFFFFFFFu
+#define ROM_TABLEMARK_MARK_SHIFT                 0
+#define ROM_TABLEMARK_MARK(x)                    (((uint32_t)(((uint32_t)(x))<<ROM_TABLEMARK_MARK_SHIFT))&ROM_TABLEMARK_MARK_MASK)
+/* SYSACCESS Bit Fields */
+#define ROM_SYSACCESS_SYSACCESS_MASK             0xFFFFFFFFu
+#define ROM_SYSACCESS_SYSACCESS_SHIFT            0
+#define ROM_SYSACCESS_SYSACCESS(x)               (((uint32_t)(((uint32_t)(x))<<ROM_SYSACCESS_SYSACCESS_SHIFT))&ROM_SYSACCESS_SYSACCESS_MASK)
+/* PERIPHID4 Bit Fields */
+#define ROM_PERIPHID4_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID4_PERIPHID_SHIFT             0
+#define ROM_PERIPHID4_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID4_PERIPHID_SHIFT))&ROM_PERIPHID4_PERIPHID_MASK)
+/* PERIPHID5 Bit Fields */
+#define ROM_PERIPHID5_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID5_PERIPHID_SHIFT             0
+#define ROM_PERIPHID5_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID5_PERIPHID_SHIFT))&ROM_PERIPHID5_PERIPHID_MASK)
+/* PERIPHID6 Bit Fields */
+#define ROM_PERIPHID6_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID6_PERIPHID_SHIFT             0
+#define ROM_PERIPHID6_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID6_PERIPHID_SHIFT))&ROM_PERIPHID6_PERIPHID_MASK)
+/* PERIPHID7 Bit Fields */
+#define ROM_PERIPHID7_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID7_PERIPHID_SHIFT             0
+#define ROM_PERIPHID7_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID7_PERIPHID_SHIFT))&ROM_PERIPHID7_PERIPHID_MASK)
+/* PERIPHID0 Bit Fields */
+#define ROM_PERIPHID0_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID0_PERIPHID_SHIFT             0
+#define ROM_PERIPHID0_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID0_PERIPHID_SHIFT))&ROM_PERIPHID0_PERIPHID_MASK)
+/* PERIPHID1 Bit Fields */
+#define ROM_PERIPHID1_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID1_PERIPHID_SHIFT             0
+#define ROM_PERIPHID1_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID1_PERIPHID_SHIFT))&ROM_PERIPHID1_PERIPHID_MASK)
+/* PERIPHID2 Bit Fields */
+#define ROM_PERIPHID2_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID2_PERIPHID_SHIFT             0
+#define ROM_PERIPHID2_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID2_PERIPHID_SHIFT))&ROM_PERIPHID2_PERIPHID_MASK)
+/* PERIPHID3 Bit Fields */
+#define ROM_PERIPHID3_PERIPHID_MASK              0xFFFFFFFFu
+#define ROM_PERIPHID3_PERIPHID_SHIFT             0
+#define ROM_PERIPHID3_PERIPHID(x)                (((uint32_t)(((uint32_t)(x))<<ROM_PERIPHID3_PERIPHID_SHIFT))&ROM_PERIPHID3_PERIPHID_MASK)
+/* COMPID Bit Fields */
+#define ROM_COMPID_COMPID_MASK                   0xFFFFFFFFu
+#define ROM_COMPID_COMPID_SHIFT                  0
+#define ROM_COMPID_COMPID(x)                     (((uint32_t)(((uint32_t)(x))<<ROM_COMPID_COMPID_SHIFT))&ROM_COMPID_COMPID_MASK)
+
+/**
+ * @}
+ */ /* end of group ROM_Register_Masks */
+
+
+/* ROM - Peripheral instance base addresses */
+/** Peripheral ROM base address */
+#define ROM_BASE                                 (0xF0002000u)
+/** Peripheral ROM base pointer */
+#define ROM                                      ((ROM_Type *)ROM_BASE)
+/** Array initializer of ROM peripheral base pointers */
+#define ROM_BASES                                { ROM }
+
+/**
+ * @}
+ */ /* end of group ROM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- RTC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup RTC_Peripheral_Access_Layer RTC Peripheral Access Layer
+ * @{
+ */
+
+/** RTC - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t TSR;                               /**< RTC Time Seconds Register, offset: 0x0 */
+  __IO uint32_t TPR;                               /**< RTC Time Prescaler Register, offset: 0x4 */
+  __IO uint32_t TAR;                               /**< RTC Time Alarm Register, offset: 0x8 */
+  __IO uint32_t TCR;                               /**< RTC Time Compensation Register, offset: 0xC */
+  __IO uint32_t CR;                                /**< RTC Control Register, offset: 0x10 */
+  __IO uint32_t SR;                                /**< RTC Status Register, offset: 0x14 */
+  __IO uint32_t LR;                                /**< RTC Lock Register, offset: 0x18 */
+  __IO uint32_t IER;                               /**< RTC Interrupt Enable Register, offset: 0x1C */
+} RTC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- RTC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup RTC_Register_Masks RTC Register Masks
+ * @{
+ */
+
+/* TSR Bit Fields */
+#define RTC_TSR_TSR_MASK                         0xFFFFFFFFu
+#define RTC_TSR_TSR_SHIFT                        0
+#define RTC_TSR_TSR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TSR_TSR_SHIFT))&RTC_TSR_TSR_MASK)
+/* TPR Bit Fields */
+#define RTC_TPR_TPR_MASK                         0xFFFFu
+#define RTC_TPR_TPR_SHIFT                        0
+#define RTC_TPR_TPR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TPR_TPR_SHIFT))&RTC_TPR_TPR_MASK)
+/* TAR Bit Fields */
+#define RTC_TAR_TAR_MASK                         0xFFFFFFFFu
+#define RTC_TAR_TAR_SHIFT                        0
+#define RTC_TAR_TAR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TAR_TAR_SHIFT))&RTC_TAR_TAR_MASK)
+/* TCR Bit Fields */
+#define RTC_TCR_TCR_MASK                         0xFFu
+#define RTC_TCR_TCR_SHIFT                        0
+#define RTC_TCR_TCR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_TCR_SHIFT))&RTC_TCR_TCR_MASK)
+#define RTC_TCR_CIR_MASK                         0xFF00u
+#define RTC_TCR_CIR_SHIFT                        8
+#define RTC_TCR_CIR(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_CIR_SHIFT))&RTC_TCR_CIR_MASK)
+#define RTC_TCR_TCV_MASK                         0xFF0000u
+#define RTC_TCR_TCV_SHIFT                        16
+#define RTC_TCR_TCV(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_TCV_SHIFT))&RTC_TCR_TCV_MASK)
+#define RTC_TCR_CIC_MASK                         0xFF000000u
+#define RTC_TCR_CIC_SHIFT                        24
+#define RTC_TCR_CIC(x)                           (((uint32_t)(((uint32_t)(x))<<RTC_TCR_CIC_SHIFT))&RTC_TCR_CIC_MASK)
+/* CR Bit Fields */
+#define RTC_CR_SWR_MASK                          0x1u
+#define RTC_CR_SWR_SHIFT                         0
+#define RTC_CR_WPE_MASK                          0x2u
+#define RTC_CR_WPE_SHIFT                         1
+#define RTC_CR_SUP_MASK                          0x4u
+#define RTC_CR_SUP_SHIFT                         2
+#define RTC_CR_UM_MASK                           0x8u
+#define RTC_CR_UM_SHIFT                          3
+#define RTC_CR_OSCE_MASK                         0x100u
+#define RTC_CR_OSCE_SHIFT                        8
+#define RTC_CR_CLKO_MASK                         0x200u
+#define RTC_CR_CLKO_SHIFT                        9
+#define RTC_CR_SC16P_MASK                        0x400u
+#define RTC_CR_SC16P_SHIFT                       10
+#define RTC_CR_SC8P_MASK                         0x800u
+#define RTC_CR_SC8P_SHIFT                        11
+#define RTC_CR_SC4P_MASK                         0x1000u
+#define RTC_CR_SC4P_SHIFT                        12
+#define RTC_CR_SC2P_MASK                         0x2000u
+#define RTC_CR_SC2P_SHIFT                        13
+/* SR Bit Fields */
+#define RTC_SR_TIF_MASK                          0x1u
+#define RTC_SR_TIF_SHIFT                         0
+#define RTC_SR_TOF_MASK                          0x2u
+#define RTC_SR_TOF_SHIFT                         1
+#define RTC_SR_TAF_MASK                          0x4u
+#define RTC_SR_TAF_SHIFT                         2
+#define RTC_SR_TCE_MASK                          0x10u
+#define RTC_SR_TCE_SHIFT                         4
+/* LR Bit Fields */
+#define RTC_LR_TCL_MASK                          0x8u
+#define RTC_LR_TCL_SHIFT                         3
+#define RTC_LR_CRL_MASK                          0x10u
+#define RTC_LR_CRL_SHIFT                         4
+#define RTC_LR_SRL_MASK                          0x20u
+#define RTC_LR_SRL_SHIFT                         5
+#define RTC_LR_LRL_MASK                          0x40u
+#define RTC_LR_LRL_SHIFT                         6
+/* IER Bit Fields */
+#define RTC_IER_TIIE_MASK                        0x1u
+#define RTC_IER_TIIE_SHIFT                       0
+#define RTC_IER_TOIE_MASK                        0x2u
+#define RTC_IER_TOIE_SHIFT                       1
+#define RTC_IER_TAIE_MASK                        0x4u
+#define RTC_IER_TAIE_SHIFT                       2
+#define RTC_IER_TSIE_MASK                        0x10u
+#define RTC_IER_TSIE_SHIFT                       4
+#define RTC_IER_WPON_MASK                        0x80u
+#define RTC_IER_WPON_SHIFT                       7
+
+/**
+ * @}
+ */ /* end of group RTC_Register_Masks */
+
+
+/* RTC - Peripheral instance base addresses */
+/** Peripheral RTC base address */
+#define RTC_BASE                                 (0x4003D000u)
+/** Peripheral RTC base pointer */
+#define RTC                                      ((RTC_Type *)RTC_BASE)
+/** Array initializer of RTC peripheral base pointers */
+#define RTC_BASES                                { RTC }
+
+/**
+ * @}
+ */ /* end of group RTC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SIM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup SIM_Peripheral_Access_Layer SIM Peripheral Access Layer
+ * @{
+ */
+
+/** SIM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SOPT1;                             /**< System Options Register 1, offset: 0x0 */
+  __IO uint32_t SOPT1CFG;                          /**< SOPT1 Configuration Register, offset: 0x4 */
+       uint8_t RESERVED_0[4092];
+  __IO uint32_t SOPT2;                             /**< System Options Register 2, offset: 0x1004 */
+       uint8_t RESERVED_1[4];
+  __IO uint32_t SOPT4;                             /**< System Options Register 4, offset: 0x100C */
+  __IO uint32_t SOPT5;                             /**< System Options Register 5, offset: 0x1010 */
+       uint8_t RESERVED_2[4];
+  __IO uint32_t SOPT7;                             /**< System Options Register 7, offset: 0x1018 */
+       uint8_t RESERVED_3[8];
+  __I  uint32_t SDID;                              /**< System Device Identification Register, offset: 0x1024 */
+       uint8_t RESERVED_4[12];
+  __IO uint32_t SCGC4;                             /**< System Clock Gating Control Register 4, offset: 0x1034 */
+  __IO uint32_t SCGC5;                             /**< System Clock Gating Control Register 5, offset: 0x1038 */
+  __IO uint32_t SCGC6;                             /**< System Clock Gating Control Register 6, offset: 0x103C */
+  __IO uint32_t SCGC7;                             /**< System Clock Gating Control Register 7, offset: 0x1040 */
+  __IO uint32_t CLKDIV1;                           /**< System Clock Divider Register 1, offset: 0x1044 */
+       uint8_t RESERVED_5[4];
+  __IO uint32_t FCFG1;                             /**< Flash Configuration Register 1, offset: 0x104C */
+  __I  uint32_t FCFG2;                             /**< Flash Configuration Register 2, offset: 0x1050 */
+       uint8_t RESERVED_6[4];
+  __I  uint32_t UIDMH;                             /**< Unique Identification Register Mid-High, offset: 0x1058 */
+  __I  uint32_t UIDML;                             /**< Unique Identification Register Mid Low, offset: 0x105C */
+  __I  uint32_t UIDL;                              /**< Unique Identification Register Low, offset: 0x1060 */
+       uint8_t RESERVED_7[156];
+  __IO uint32_t COPC;                              /**< COP Control Register, offset: 0x1100 */
+  __O  uint32_t SRVCOP;                            /**< Service COP Register, offset: 0x1104 */
+} SIM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SIM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup SIM_Register_Masks SIM Register Masks
+ * @{
+ */
+
+/* SOPT1 Bit Fields */
+#define SIM_SOPT1_OSC32KSEL_MASK                 0xC0000u
+#define SIM_SOPT1_OSC32KSEL_SHIFT                18
+#define SIM_SOPT1_OSC32KSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT1_OSC32KSEL_SHIFT))&SIM_SOPT1_OSC32KSEL_MASK)
+#define SIM_SOPT1_USBVSTBY_MASK                  0x20000000u
+#define SIM_SOPT1_USBVSTBY_SHIFT                 29
+#define SIM_SOPT1_USBSSTBY_MASK                  0x40000000u
+#define SIM_SOPT1_USBSSTBY_SHIFT                 30
+#define SIM_SOPT1_USBREGEN_MASK                  0x80000000u
+#define SIM_SOPT1_USBREGEN_SHIFT                 31
+/* SOPT1CFG Bit Fields */
+#define SIM_SOPT1CFG_URWE_MASK                   0x1000000u
+#define SIM_SOPT1CFG_URWE_SHIFT                  24
+#define SIM_SOPT1CFG_UVSWE_MASK                  0x2000000u
+#define SIM_SOPT1CFG_UVSWE_SHIFT                 25
+#define SIM_SOPT1CFG_USSWE_MASK                  0x4000000u
+#define SIM_SOPT1CFG_USSWE_SHIFT                 26
+/* SOPT2 Bit Fields */
+#define SIM_SOPT2_RTCCLKOUTSEL_MASK              0x10u
+#define SIM_SOPT2_RTCCLKOUTSEL_SHIFT             4
+#define SIM_SOPT2_CLKOUTSEL_MASK                 0xE0u
+#define SIM_SOPT2_CLKOUTSEL_SHIFT                5
+#define SIM_SOPT2_CLKOUTSEL(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_CLKOUTSEL_SHIFT))&SIM_SOPT2_CLKOUTSEL_MASK)
+#define SIM_SOPT2_PLLFLLSEL_MASK                 0x10000u
+#define SIM_SOPT2_PLLFLLSEL_SHIFT                16
+#define SIM_SOPT2_USBSRC_MASK                    0x40000u
+#define SIM_SOPT2_USBSRC_SHIFT                   18
+#define SIM_SOPT2_TPMSRC_MASK                    0x3000000u
+#define SIM_SOPT2_TPMSRC_SHIFT                   24
+#define SIM_SOPT2_TPMSRC(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_TPMSRC_SHIFT))&SIM_SOPT2_TPMSRC_MASK)
+#define SIM_SOPT2_UART0SRC_MASK                  0xC000000u
+#define SIM_SOPT2_UART0SRC_SHIFT                 26
+#define SIM_SOPT2_UART0SRC(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_SOPT2_UART0SRC_SHIFT))&SIM_SOPT2_UART0SRC_MASK)
+/* SOPT4 Bit Fields */
+#define SIM_SOPT4_TPM1CH0SRC_MASK                0xC0000u
+#define SIM_SOPT4_TPM1CH0SRC_SHIFT               18
+#define SIM_SOPT4_TPM1CH0SRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT4_TPM1CH0SRC_SHIFT))&SIM_SOPT4_TPM1CH0SRC_MASK)
+#define SIM_SOPT4_TPM2CH0SRC_MASK                0x100000u
+#define SIM_SOPT4_TPM2CH0SRC_SHIFT               20
+#define SIM_SOPT4_TPM0CLKSEL_MASK                0x1000000u
+#define SIM_SOPT4_TPM0CLKSEL_SHIFT               24
+#define SIM_SOPT4_TPM1CLKSEL_MASK                0x2000000u
+#define SIM_SOPT4_TPM1CLKSEL_SHIFT               25
+#define SIM_SOPT4_TPM2CLKSEL_MASK                0x4000000u
+#define SIM_SOPT4_TPM2CLKSEL_SHIFT               26
+/* SOPT5 Bit Fields */
+#define SIM_SOPT5_UART0TXSRC_MASK                0x3u
+#define SIM_SOPT5_UART0TXSRC_SHIFT               0
+#define SIM_SOPT5_UART0TXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART0TXSRC_SHIFT))&SIM_SOPT5_UART0TXSRC_MASK)
+#define SIM_SOPT5_UART0RXSRC_MASK                0x4u
+#define SIM_SOPT5_UART0RXSRC_SHIFT               2
+#define SIM_SOPT5_UART1TXSRC_MASK                0x30u
+#define SIM_SOPT5_UART1TXSRC_SHIFT               4
+#define SIM_SOPT5_UART1TXSRC(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT5_UART1TXSRC_SHIFT))&SIM_SOPT5_UART1TXSRC_MASK)
+#define SIM_SOPT5_UART1RXSRC_MASK                0x40u
+#define SIM_SOPT5_UART1RXSRC_SHIFT               6
+#define SIM_SOPT5_UART0ODE_MASK                  0x10000u
+#define SIM_SOPT5_UART0ODE_SHIFT                 16
+#define SIM_SOPT5_UART1ODE_MASK                  0x20000u
+#define SIM_SOPT5_UART1ODE_SHIFT                 17
+#define SIM_SOPT5_UART2ODE_MASK                  0x40000u
+#define SIM_SOPT5_UART2ODE_SHIFT                 18
+/* SOPT7 Bit Fields */
+#define SIM_SOPT7_ADC0TRGSEL_MASK                0xFu
+#define SIM_SOPT7_ADC0TRGSEL_SHIFT               0
+#define SIM_SOPT7_ADC0TRGSEL(x)                  (((uint32_t)(((uint32_t)(x))<<SIM_SOPT7_ADC0TRGSEL_SHIFT))&SIM_SOPT7_ADC0TRGSEL_MASK)
+#define SIM_SOPT7_ADC0PRETRGSEL_MASK             0x10u
+#define SIM_SOPT7_ADC0PRETRGSEL_SHIFT            4
+#define SIM_SOPT7_ADC0ALTTRGEN_MASK              0x80u
+#define SIM_SOPT7_ADC0ALTTRGEN_SHIFT             7
+/* SDID Bit Fields */
+#define SIM_SDID_PINID_MASK                      0xFu
+#define SIM_SDID_PINID_SHIFT                     0
+#define SIM_SDID_PINID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_PINID_SHIFT))&SIM_SDID_PINID_MASK)
+#define SIM_SDID_DIEID_MASK                      0xF80u
+#define SIM_SDID_DIEID_SHIFT                     7
+#define SIM_SDID_DIEID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_DIEID_SHIFT))&SIM_SDID_DIEID_MASK)
+#define SIM_SDID_REVID_MASK                      0xF000u
+#define SIM_SDID_REVID_SHIFT                     12
+#define SIM_SDID_REVID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_REVID_SHIFT))&SIM_SDID_REVID_MASK)
+#define SIM_SDID_SRAMSIZE_MASK                   0xF0000u
+#define SIM_SDID_SRAMSIZE_SHIFT                  16
+#define SIM_SDID_SRAMSIZE(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SRAMSIZE_SHIFT))&SIM_SDID_SRAMSIZE_MASK)
+#define SIM_SDID_SERIESID_MASK                   0xF00000u
+#define SIM_SDID_SERIESID_SHIFT                  20
+#define SIM_SDID_SERIESID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SERIESID_SHIFT))&SIM_SDID_SERIESID_MASK)
+#define SIM_SDID_SUBFAMID_MASK                   0xF000000u
+#define SIM_SDID_SUBFAMID_SHIFT                  24
+#define SIM_SDID_SUBFAMID(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SDID_SUBFAMID_SHIFT))&SIM_SDID_SUBFAMID_MASK)
+#define SIM_SDID_FAMID_MASK                      0xF0000000u
+#define SIM_SDID_FAMID_SHIFT                     28
+#define SIM_SDID_FAMID(x)                        (((uint32_t)(((uint32_t)(x))<<SIM_SDID_FAMID_SHIFT))&SIM_SDID_FAMID_MASK)
+/* SCGC4 Bit Fields */
+#define SIM_SCGC4_I2C0_MASK                      0x40u
+#define SIM_SCGC4_I2C0_SHIFT                     6
+#define SIM_SCGC4_I2C1_MASK                      0x80u
+#define SIM_SCGC4_I2C1_SHIFT                     7
+#define SIM_SCGC4_UART0_MASK                     0x400u
+#define SIM_SCGC4_UART0_SHIFT                    10
+#define SIM_SCGC4_UART1_MASK                     0x800u
+#define SIM_SCGC4_UART1_SHIFT                    11
+#define SIM_SCGC4_UART2_MASK                     0x1000u
+#define SIM_SCGC4_UART2_SHIFT                    12
+#define SIM_SCGC4_USBOTG_MASK                    0x40000u
+#define SIM_SCGC4_USBOTG_SHIFT                   18
+#define SIM_SCGC4_CMP_MASK                       0x80000u
+#define SIM_SCGC4_CMP_SHIFT                      19
+#define SIM_SCGC4_SPI0_MASK                      0x400000u
+#define SIM_SCGC4_SPI0_SHIFT                     22
+#define SIM_SCGC4_SPI1_MASK                      0x800000u
+#define SIM_SCGC4_SPI1_SHIFT                     23
+/* SCGC5 Bit Fields */
+#define SIM_SCGC5_LPTMR_MASK                     0x1u
+#define SIM_SCGC5_LPTMR_SHIFT                    0
+#define SIM_SCGC5_TSI_MASK                       0x20u
+#define SIM_SCGC5_TSI_SHIFT                      5
+#define SIM_SCGC5_PORTA_MASK                     0x200u
+#define SIM_SCGC5_PORTA_SHIFT                    9
+#define SIM_SCGC5_PORTB_MASK                     0x400u
+#define SIM_SCGC5_PORTB_SHIFT                    10
+#define SIM_SCGC5_PORTC_MASK                     0x800u
+#define SIM_SCGC5_PORTC_SHIFT                    11
+#define SIM_SCGC5_PORTD_MASK                     0x1000u
+#define SIM_SCGC5_PORTD_SHIFT                    12
+#define SIM_SCGC5_PORTE_MASK                     0x2000u
+#define SIM_SCGC5_PORTE_SHIFT                    13
+/* SCGC6 Bit Fields */
+#define SIM_SCGC6_FTF_MASK                       0x1u
+#define SIM_SCGC6_FTF_SHIFT                      0
+#define SIM_SCGC6_DMAMUX_MASK                    0x2u
+#define SIM_SCGC6_DMAMUX_SHIFT                   1
+#define SIM_SCGC6_I2S_MASK                       0x8000u
+#define SIM_SCGC6_I2S_SHIFT                      15
+#define SIM_SCGC6_PIT_MASK                       0x800000u
+#define SIM_SCGC6_PIT_SHIFT                      23
+#define SIM_SCGC6_TPM0_MASK                      0x1000000u
+#define SIM_SCGC6_TPM0_SHIFT                     24
+#define SIM_SCGC6_TPM1_MASK                      0x2000000u
+#define SIM_SCGC6_TPM1_SHIFT                     25
+#define SIM_SCGC6_TPM2_MASK                      0x4000000u
+#define SIM_SCGC6_TPM2_SHIFT                     26
+#define SIM_SCGC6_ADC0_MASK                      0x8000000u
+#define SIM_SCGC6_ADC0_SHIFT                     27
+#define SIM_SCGC6_RTC_MASK                       0x20000000u
+#define SIM_SCGC6_RTC_SHIFT                      29
+#define SIM_SCGC6_DAC0_MASK                      0x80000000u
+#define SIM_SCGC6_DAC0_SHIFT                     31
+/* SCGC7 Bit Fields */
+#define SIM_SCGC7_DMA_MASK                       0x100u
+#define SIM_SCGC7_DMA_SHIFT                      8
+/* CLKDIV1 Bit Fields */
+#define SIM_CLKDIV1_OUTDIV4_MASK                 0x70000u
+#define SIM_CLKDIV1_OUTDIV4_SHIFT                16
+#define SIM_CLKDIV1_OUTDIV4(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV4_SHIFT))&SIM_CLKDIV1_OUTDIV4_MASK)
+#define SIM_CLKDIV1_OUTDIV1_MASK                 0xF0000000u
+#define SIM_CLKDIV1_OUTDIV1_SHIFT                28
+#define SIM_CLKDIV1_OUTDIV1(x)                   (((uint32_t)(((uint32_t)(x))<<SIM_CLKDIV1_OUTDIV1_SHIFT))&SIM_CLKDIV1_OUTDIV1_MASK)
+/* FCFG1 Bit Fields */
+#define SIM_FCFG1_FLASHDIS_MASK                  0x1u
+#define SIM_FCFG1_FLASHDIS_SHIFT                 0
+#define SIM_FCFG1_FLASHDOZE_MASK                 0x2u
+#define SIM_FCFG1_FLASHDOZE_SHIFT                1
+#define SIM_FCFG1_PFSIZE_MASK                    0xF000000u
+#define SIM_FCFG1_PFSIZE_SHIFT                   24
+#define SIM_FCFG1_PFSIZE(x)                      (((uint32_t)(((uint32_t)(x))<<SIM_FCFG1_PFSIZE_SHIFT))&SIM_FCFG1_PFSIZE_MASK)
+/* FCFG2 Bit Fields */
+#define SIM_FCFG2_MAXADDR1_MASK                  0x7F0000u
+#define SIM_FCFG2_MAXADDR1_SHIFT                 16
+#define SIM_FCFG2_MAXADDR1(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_FCFG2_MAXADDR1_SHIFT))&SIM_FCFG2_MAXADDR1_MASK)
+#define SIM_FCFG2_MAXADDR0_MASK                  0x7F000000u
+#define SIM_FCFG2_MAXADDR0_SHIFT                 24
+#define SIM_FCFG2_MAXADDR0(x)                    (((uint32_t)(((uint32_t)(x))<<SIM_FCFG2_MAXADDR0_SHIFT))&SIM_FCFG2_MAXADDR0_MASK)
+/* UIDMH Bit Fields */
+#define SIM_UIDMH_UID_MASK                       0xFFFFu
+#define SIM_UIDMH_UID_SHIFT                      0
+#define SIM_UIDMH_UID(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_UIDMH_UID_SHIFT))&SIM_UIDMH_UID_MASK)
+/* UIDML Bit Fields */
+#define SIM_UIDML_UID_MASK                       0xFFFFFFFFu
+#define SIM_UIDML_UID_SHIFT                      0
+#define SIM_UIDML_UID(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_UIDML_UID_SHIFT))&SIM_UIDML_UID_MASK)
+/* UIDL Bit Fields */
+#define SIM_UIDL_UID_MASK                        0xFFFFFFFFu
+#define SIM_UIDL_UID_SHIFT                       0
+#define SIM_UIDL_UID(x)                          (((uint32_t)(((uint32_t)(x))<<SIM_UIDL_UID_SHIFT))&SIM_UIDL_UID_MASK)
+/* COPC Bit Fields */
+#define SIM_COPC_COPW_MASK                       0x1u
+#define SIM_COPC_COPW_SHIFT                      0
+#define SIM_COPC_COPCLKS_MASK                    0x2u
+#define SIM_COPC_COPCLKS_SHIFT                   1
+#define SIM_COPC_COPT_MASK                       0xCu
+#define SIM_COPC_COPT_SHIFT                      2
+#define SIM_COPC_COPT(x)                         (((uint32_t)(((uint32_t)(x))<<SIM_COPC_COPT_SHIFT))&SIM_COPC_COPT_MASK)
+/* SRVCOP Bit Fields */
+#define SIM_SRVCOP_SRVCOP_MASK                   0xFFu
+#define SIM_SRVCOP_SRVCOP_SHIFT                  0
+#define SIM_SRVCOP_SRVCOP(x)                     (((uint32_t)(((uint32_t)(x))<<SIM_SRVCOP_SRVCOP_SHIFT))&SIM_SRVCOP_SRVCOP_MASK)
+
+/**
+ * @}
+ */ /* end of group SIM_Register_Masks */
+
+
+/* SIM - Peripheral instance base addresses */
+/** Peripheral SIM base address */
+#define SIM_BASE                                 (0x40047000u)
+/** Peripheral SIM base pointer */
+#define SIM                                      ((SIM_Type *)SIM_BASE)
+/** Array initializer of SIM peripheral base pointers */
+#define SIM_BASES                                { SIM }
+
+/**
+ * @}
+ */ /* end of group SIM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SMC Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup SMC_Peripheral_Access_Layer SMC Peripheral Access Layer
+ * @{
+ */
+
+/** SMC - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t PMPROT;                             /**< Power Mode Protection register, offset: 0x0 */
+  __IO uint8_t PMCTRL;                             /**< Power Mode Control register, offset: 0x1 */
+  __IO uint8_t STOPCTRL;                           /**< Stop Control Register, offset: 0x2 */
+  __I  uint8_t PMSTAT;                             /**< Power Mode Status register, offset: 0x3 */
+} SMC_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SMC Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup SMC_Register_Masks SMC Register Masks
+ * @{
+ */
+
+/* PMPROT Bit Fields */
+#define SMC_PMPROT_AVLLS_MASK                    0x2u
+#define SMC_PMPROT_AVLLS_SHIFT                   1
+#define SMC_PMPROT_ALLS_MASK                     0x8u
+#define SMC_PMPROT_ALLS_SHIFT                    3
+#define SMC_PMPROT_AVLP_MASK                     0x20u
+#define SMC_PMPROT_AVLP_SHIFT                    5
+/* PMCTRL Bit Fields */
+#define SMC_PMCTRL_STOPM_MASK                    0x7u
+#define SMC_PMCTRL_STOPM_SHIFT                   0
+#define SMC_PMCTRL_STOPM(x)                      (((uint8_t)(((uint8_t)(x))<<SMC_PMCTRL_STOPM_SHIFT))&SMC_PMCTRL_STOPM_MASK)
+#define SMC_PMCTRL_STOPA_MASK                    0x8u
+#define SMC_PMCTRL_STOPA_SHIFT                   3
+#define SMC_PMCTRL_RUNM_MASK                     0x60u
+#define SMC_PMCTRL_RUNM_SHIFT                    5
+#define SMC_PMCTRL_RUNM(x)                       (((uint8_t)(((uint8_t)(x))<<SMC_PMCTRL_RUNM_SHIFT))&SMC_PMCTRL_RUNM_MASK)
+/* STOPCTRL Bit Fields */
+#define SMC_STOPCTRL_VLLSM_MASK                  0x7u
+#define SMC_STOPCTRL_VLLSM_SHIFT                 0
+#define SMC_STOPCTRL_VLLSM(x)                    (((uint8_t)(((uint8_t)(x))<<SMC_STOPCTRL_VLLSM_SHIFT))&SMC_STOPCTRL_VLLSM_MASK)
+#define SMC_STOPCTRL_PORPO_MASK                  0x20u
+#define SMC_STOPCTRL_PORPO_SHIFT                 5
+#define SMC_STOPCTRL_PSTOPO_MASK                 0xC0u
+#define SMC_STOPCTRL_PSTOPO_SHIFT                6
+#define SMC_STOPCTRL_PSTOPO(x)                   (((uint8_t)(((uint8_t)(x))<<SMC_STOPCTRL_PSTOPO_SHIFT))&SMC_STOPCTRL_PSTOPO_MASK)
+/* PMSTAT Bit Fields */
+#define SMC_PMSTAT_PMSTAT_MASK                   0x7Fu
+#define SMC_PMSTAT_PMSTAT_SHIFT                  0
+#define SMC_PMSTAT_PMSTAT(x)                     (((uint8_t)(((uint8_t)(x))<<SMC_PMSTAT_PMSTAT_SHIFT))&SMC_PMSTAT_PMSTAT_MASK)
+
+/**
+ * @}
+ */ /* end of group SMC_Register_Masks */
+
+
+/* SMC - Peripheral instance base addresses */
+/** Peripheral SMC base address */
+#define SMC_BASE                                 (0x4007E000u)
+/** Peripheral SMC base pointer */
+#define SMC                                      ((SMC_Type *)SMC_BASE)
+/** Array initializer of SMC peripheral base pointers */
+#define SMC_BASES                                { SMC }
+
+/**
+ * @}
+ */ /* end of group SMC_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- SPI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup SPI_Peripheral_Access_Layer SPI Peripheral Access Layer
+ * @{
+ */
+
+/** SPI - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t S;                                  /**< SPI status register, offset: 0x0 */
+  __IO uint8_t BR;                                 /**< SPI baud rate register, offset: 0x1 */
+  __IO uint8_t C2;                                 /**< SPI control register 2, offset: 0x2 */
+  __IO uint8_t C1;                                 /**< SPI control register 1, offset: 0x3 */
+  __IO uint8_t ML;                                 /**< SPI match register low, offset: 0x4 */
+  __IO uint8_t MH;                                 /**< SPI match register high, offset: 0x5 */
+  __IO uint8_t DL;                                 /**< SPI data register low, offset: 0x6 */
+  __IO uint8_t DH;                                 /**< SPI data register high, offset: 0x7 */
+       uint8_t RESERVED_0[2];
+  __IO uint8_t CI;                                 /**< SPI clear interrupt register, offset: 0xA */
+  __IO uint8_t C3;                                 /**< SPI control register 3, offset: 0xB */
+} SPI_Type;
+
+/* ----------------------------------------------------------------------------
+   -- SPI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup SPI_Register_Masks SPI Register Masks
+ * @{
+ */
+
+/* S Bit Fields */
+#define SPI_S_RFIFOEF_MASK                       0x1u
+#define SPI_S_RFIFOEF_SHIFT                      0
+#define SPI_S_TXFULLF_MASK                       0x2u
+#define SPI_S_TXFULLF_SHIFT                      1
+#define SPI_S_TNEAREF_MASK                       0x4u
+#define SPI_S_TNEAREF_SHIFT                      2
+#define SPI_S_RNFULLF_MASK                       0x8u
+#define SPI_S_RNFULLF_SHIFT                      3
+#define SPI_S_MODF_MASK                          0x10u
+#define SPI_S_MODF_SHIFT                         4
+#define SPI_S_SPTEF_MASK                         0x20u
+#define SPI_S_SPTEF_SHIFT                        5
+#define SPI_S_SPMF_MASK                          0x40u
+#define SPI_S_SPMF_SHIFT                         6
+#define SPI_S_SPRF_MASK                          0x80u
+#define SPI_S_SPRF_SHIFT                         7
+/* BR Bit Fields */
+#define SPI_BR_SPR_MASK                          0xFu
+#define SPI_BR_SPR_SHIFT                         0
+#define SPI_BR_SPR(x)                            (((uint8_t)(((uint8_t)(x))<<SPI_BR_SPR_SHIFT))&SPI_BR_SPR_MASK)
+#define SPI_BR_SPPR_MASK                         0x70u
+#define SPI_BR_SPPR_SHIFT                        4
+#define SPI_BR_SPPR(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_BR_SPPR_SHIFT))&SPI_BR_SPPR_MASK)
+/* C2 Bit Fields */
+#define SPI_C2_SPC0_MASK                         0x1u
+#define SPI_C2_SPC0_SHIFT                        0
+#define SPI_C2_SPISWAI_MASK                      0x2u
+#define SPI_C2_SPISWAI_SHIFT                     1
+#define SPI_C2_RXDMAE_MASK                       0x4u
+#define SPI_C2_RXDMAE_SHIFT                      2
+#define SPI_C2_BIDIROE_MASK                      0x8u
+#define SPI_C2_BIDIROE_SHIFT                     3
+#define SPI_C2_MODFEN_MASK                       0x10u
+#define SPI_C2_MODFEN_SHIFT                      4
+#define SPI_C2_TXDMAE_MASK                       0x20u
+#define SPI_C2_TXDMAE_SHIFT                      5
+#define SPI_C2_SPIMODE_MASK                      0x40u
+#define SPI_C2_SPIMODE_SHIFT                     6
+#define SPI_C2_SPMIE_MASK                        0x80u
+#define SPI_C2_SPMIE_SHIFT                       7
+/* C1 Bit Fields */
+#define SPI_C1_LSBFE_MASK                        0x1u
+#define SPI_C1_LSBFE_SHIFT                       0
+#define SPI_C1_SSOE_MASK                         0x2u
+#define SPI_C1_SSOE_SHIFT                        1
+#define SPI_C1_CPHA_MASK                         0x4u
+#define SPI_C1_CPHA_SHIFT                        2
+#define SPI_C1_CPOL_MASK                         0x8u
+#define SPI_C1_CPOL_SHIFT                        3
+#define SPI_C1_MSTR_MASK                         0x10u
+#define SPI_C1_MSTR_SHIFT                        4
+#define SPI_C1_SPTIE_MASK                        0x20u
+#define SPI_C1_SPTIE_SHIFT                       5
+#define SPI_C1_SPE_MASK                          0x40u
+#define SPI_C1_SPE_SHIFT                         6
+#define SPI_C1_SPIE_MASK                         0x80u
+#define SPI_C1_SPIE_SHIFT                        7
+/* ML Bit Fields */
+#define SPI_ML_Bits_MASK                         0xFFu
+#define SPI_ML_Bits_SHIFT                        0
+#define SPI_ML_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_ML_Bits_SHIFT))&SPI_ML_Bits_MASK)
+/* MH Bit Fields */
+#define SPI_MH_Bits_MASK                         0xFFu
+#define SPI_MH_Bits_SHIFT                        0
+#define SPI_MH_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_MH_Bits_SHIFT))&SPI_MH_Bits_MASK)
+/* DL Bit Fields */
+#define SPI_DL_Bits_MASK                         0xFFu
+#define SPI_DL_Bits_SHIFT                        0
+#define SPI_DL_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_DL_Bits_SHIFT))&SPI_DL_Bits_MASK)
+/* DH Bit Fields */
+#define SPI_DH_Bits_MASK                         0xFFu
+#define SPI_DH_Bits_SHIFT                        0
+#define SPI_DH_Bits(x)                           (((uint8_t)(((uint8_t)(x))<<SPI_DH_Bits_SHIFT))&SPI_DH_Bits_MASK)
+/* CI Bit Fields */
+#define SPI_CI_SPRFCI_MASK                       0x1u
+#define SPI_CI_SPRFCI_SHIFT                      0
+#define SPI_CI_SPTEFCI_MASK                      0x2u
+#define SPI_CI_SPTEFCI_SHIFT                     1
+#define SPI_CI_RNFULLFCI_MASK                    0x4u
+#define SPI_CI_RNFULLFCI_SHIFT                   2
+#define SPI_CI_TNEAREFCI_MASK                    0x8u
+#define SPI_CI_TNEAREFCI_SHIFT                   3
+#define SPI_CI_RXFOF_MASK                        0x10u
+#define SPI_CI_RXFOF_SHIFT                       4
+#define SPI_CI_TXFOF_MASK                        0x20u
+#define SPI_CI_TXFOF_SHIFT                       5
+#define SPI_CI_RXFERR_MASK                       0x40u
+#define SPI_CI_RXFERR_SHIFT                      6
+#define SPI_CI_TXFERR_MASK                       0x80u
+#define SPI_CI_TXFERR_SHIFT                      7
+/* C3 Bit Fields */
+#define SPI_C3_FIFOMODE_MASK                     0x1u
+#define SPI_C3_FIFOMODE_SHIFT                    0
+#define SPI_C3_RNFULLIEN_MASK                    0x2u
+#define SPI_C3_RNFULLIEN_SHIFT                   1
+#define SPI_C3_TNEARIEN_MASK                     0x4u
+#define SPI_C3_TNEARIEN_SHIFT                    2
+#define SPI_C3_INTCLR_MASK                       0x8u
+#define SPI_C3_INTCLR_SHIFT                      3
+#define SPI_C3_RNFULLF_MARK_MASK                 0x10u
+#define SPI_C3_RNFULLF_MARK_SHIFT                4
+#define SPI_C3_TNEAREF_MARK_MASK                 0x20u
+#define SPI_C3_TNEAREF_MARK_SHIFT                5
+
+/**
+ * @}
+ */ /* end of group SPI_Register_Masks */
+
+
+/* SPI - Peripheral instance base addresses */
+/** Peripheral SPI0 base address */
+#define SPI0_BASE                                (0x40076000u)
+/** Peripheral SPI0 base pointer */
+#define SPI0                                     ((SPI_Type *)SPI0_BASE)
+/** Peripheral SPI1 base address */
+#define SPI1_BASE                                (0x40077000u)
+/** Peripheral SPI1 base pointer */
+#define SPI1                                     ((SPI_Type *)SPI1_BASE)
+/** Array initializer of SPI peripheral base pointers */
+#define SPI_BASES                                { SPI0, SPI1 }
+
+/**
+ * @}
+ */ /* end of group SPI_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- TPM Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup TPM_Peripheral_Access_Layer TPM Peripheral Access Layer
+ * @{
+ */
+
+/** TPM - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t SC;                                /**< Status and Control, offset: 0x0 */
+  __IO uint32_t CNT;                               /**< Counter, offset: 0x4 */
+  __IO uint32_t MOD;                               /**< Modulo, offset: 0x8 */
+  struct {                                         /* offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnSC;                              /**< Channel (n) Status and Control, array offset: 0xC, array step: 0x8 */
+    __IO uint32_t CnV;                               /**< Channel (n) Value, array offset: 0x10, array step: 0x8 */
+  } CONTROLS[6];
+       uint8_t RESERVED_0[20];
+  __IO uint32_t STATUS;                            /**< Capture and Compare Status, offset: 0x50 */
+       uint8_t RESERVED_1[48];
+  __IO uint32_t CONF;                              /**< Configuration, offset: 0x84 */
+} TPM_Type;
+
+/* ----------------------------------------------------------------------------
+   -- TPM Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup TPM_Register_Masks TPM Register Masks
+ * @{
+ */
+
+/* SC Bit Fields */
+#define TPM_SC_PS_MASK                           0x7u
+#define TPM_SC_PS_SHIFT                          0
+#define TPM_SC_PS(x)                             (((uint32_t)(((uint32_t)(x))<<TPM_SC_PS_SHIFT))&TPM_SC_PS_MASK)
+#define TPM_SC_CMOD_MASK                         0x18u
+#define TPM_SC_CMOD_SHIFT                        3
+#define TPM_SC_CMOD(x)                           (((uint32_t)(((uint32_t)(x))<<TPM_SC_CMOD_SHIFT))&TPM_SC_CMOD_MASK)
+#define TPM_SC_CPWMS_MASK                        0x20u
+#define TPM_SC_CPWMS_SHIFT                       5
+#define TPM_SC_TOIE_MASK                         0x40u
+#define TPM_SC_TOIE_SHIFT                        6
+#define TPM_SC_TOF_MASK                          0x80u
+#define TPM_SC_TOF_SHIFT                         7
+#define TPM_SC_DMA_MASK                          0x100u
+#define TPM_SC_DMA_SHIFT                         8
+/* CNT Bit Fields */
+#define TPM_CNT_COUNT_MASK                       0xFFFFu
+#define TPM_CNT_COUNT_SHIFT                      0
+#define TPM_CNT_COUNT(x)                         (((uint32_t)(((uint32_t)(x))<<TPM_CNT_COUNT_SHIFT))&TPM_CNT_COUNT_MASK)
+/* MOD Bit Fields */
+#define TPM_MOD_MOD_MASK                         0xFFFFu
+#define TPM_MOD_MOD_SHIFT                        0
+#define TPM_MOD_MOD(x)                           (((uint32_t)(((uint32_t)(x))<<TPM_MOD_MOD_SHIFT))&TPM_MOD_MOD_MASK)
+/* CnSC Bit Fields */
+#define TPM_CnSC_DMA_MASK                        0x1u
+#define TPM_CnSC_DMA_SHIFT                       0
+#define TPM_CnSC_ELSA_MASK                       0x4u
+#define TPM_CnSC_ELSA_SHIFT                      2
+#define TPM_CnSC_ELSB_MASK                       0x8u
+#define TPM_CnSC_ELSB_SHIFT                      3
+#define TPM_CnSC_MSA_MASK                        0x10u
+#define TPM_CnSC_MSA_SHIFT                       4
+#define TPM_CnSC_MSB_MASK                        0x20u
+#define TPM_CnSC_MSB_SHIFT                       5
+#define TPM_CnSC_CHIE_MASK                       0x40u
+#define TPM_CnSC_CHIE_SHIFT                      6
+#define TPM_CnSC_CHF_MASK                        0x80u
+#define TPM_CnSC_CHF_SHIFT                       7
+/* CnV Bit Fields */
+#define TPM_CnV_VAL_MASK                         0xFFFFu
+#define TPM_CnV_VAL_SHIFT                        0
+#define TPM_CnV_VAL(x)                           (((uint32_t)(((uint32_t)(x))<<TPM_CnV_VAL_SHIFT))&TPM_CnV_VAL_MASK)
+/* STATUS Bit Fields */
+#define TPM_STATUS_CH0F_MASK                     0x1u
+#define TPM_STATUS_CH0F_SHIFT                    0
+#define TPM_STATUS_CH1F_MASK                     0x2u
+#define TPM_STATUS_CH1F_SHIFT                    1
+#define TPM_STATUS_CH2F_MASK                     0x4u
+#define TPM_STATUS_CH2F_SHIFT                    2
+#define TPM_STATUS_CH3F_MASK                     0x8u
+#define TPM_STATUS_CH3F_SHIFT                    3
+#define TPM_STATUS_CH4F_MASK                     0x10u
+#define TPM_STATUS_CH4F_SHIFT                    4
+#define TPM_STATUS_CH5F_MASK                     0x20u
+#define TPM_STATUS_CH5F_SHIFT                    5
+#define TPM_STATUS_TOF_MASK                      0x100u
+#define TPM_STATUS_TOF_SHIFT                     8
+/* CONF Bit Fields */
+#define TPM_CONF_DOZEEN_MASK                     0x20u
+#define TPM_CONF_DOZEEN_SHIFT                    5
+#define TPM_CONF_DBGMODE_MASK                    0xC0u
+#define TPM_CONF_DBGMODE_SHIFT                   6
+#define TPM_CONF_DBGMODE(x)                      (((uint32_t)(((uint32_t)(x))<<TPM_CONF_DBGMODE_SHIFT))&TPM_CONF_DBGMODE_MASK)
+#define TPM_CONF_GTBEEN_MASK                     0x200u
+#define TPM_CONF_GTBEEN_SHIFT                    9
+#define TPM_CONF_CSOT_MASK                       0x10000u
+#define TPM_CONF_CSOT_SHIFT                      16
+#define TPM_CONF_CSOO_MASK                       0x20000u
+#define TPM_CONF_CSOO_SHIFT                      17
+#define TPM_CONF_CROT_MASK                       0x40000u
+#define TPM_CONF_CROT_SHIFT                      18
+#define TPM_CONF_TRGSEL_MASK                     0xF000000u
+#define TPM_CONF_TRGSEL_SHIFT                    24
+#define TPM_CONF_TRGSEL(x)                       (((uint32_t)(((uint32_t)(x))<<TPM_CONF_TRGSEL_SHIFT))&TPM_CONF_TRGSEL_MASK)
+
+/**
+ * @}
+ */ /* end of group TPM_Register_Masks */
+
+
+/* TPM - Peripheral instance base addresses */
+/** Peripheral TPM0 base address */
+#define TPM0_BASE                                (0x40038000u)
+/** Peripheral TPM0 base pointer */
+#define TPM0                                     ((TPM_Type *)TPM0_BASE)
+/** Peripheral TPM1 base address */
+#define TPM1_BASE                                (0x40039000u)
+/** Peripheral TPM1 base pointer */
+#define TPM1                                     ((TPM_Type *)TPM1_BASE)
+/** Peripheral TPM2 base address */
+#define TPM2_BASE                                (0x4003A000u)
+/** Peripheral TPM2 base pointer */
+#define TPM2                                     ((TPM_Type *)TPM2_BASE)
+/** Array initializer of TPM peripheral base pointers */
+#define TPM_BASES                                { TPM0, TPM1, TPM2 }
+
+/**
+ * @}
+ */ /* end of group TPM_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- TSI Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup TSI_Peripheral_Access_Layer TSI Peripheral Access Layer
+ * @{
+ */
+
+/** TSI - Register Layout Typedef */
+typedef struct {
+  __IO uint32_t GENCS;                             /**< TSI General Control and Status Register, offset: 0x0 */
+  __IO uint32_t DATA;                              /**< TSI DATA Register, offset: 0x4 */
+  __IO uint32_t TSHD;                              /**< TSI Threshold Register, offset: 0x8 */
+} TSI_Type;
+
+/* ----------------------------------------------------------------------------
+   -- TSI Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup TSI_Register_Masks TSI Register Masks
+ * @{
+ */
+
+/* GENCS Bit Fields */
+#define TSI_GENCS_CURSW_MASK                     0x2u
+#define TSI_GENCS_CURSW_SHIFT                    1
+#define TSI_GENCS_EOSF_MASK                      0x4u
+#define TSI_GENCS_EOSF_SHIFT                     2
+#define TSI_GENCS_SCNIP_MASK                     0x8u
+#define TSI_GENCS_SCNIP_SHIFT                    3
+#define TSI_GENCS_STM_MASK                       0x10u
+#define TSI_GENCS_STM_SHIFT                      4
+#define TSI_GENCS_STPE_MASK                      0x20u
+#define TSI_GENCS_STPE_SHIFT                     5
+#define TSI_GENCS_TSIIEN_MASK                    0x40u
+#define TSI_GENCS_TSIIEN_SHIFT                   6
+#define TSI_GENCS_TSIEN_MASK                     0x80u
+#define TSI_GENCS_TSIEN_SHIFT                    7
+#define TSI_GENCS_NSCN_MASK                      0x1F00u
+#define TSI_GENCS_NSCN_SHIFT                     8
+#define TSI_GENCS_NSCN(x)                        (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_NSCN_SHIFT))&TSI_GENCS_NSCN_MASK)
+#define TSI_GENCS_PS_MASK                        0xE000u
+#define TSI_GENCS_PS_SHIFT                       13
+#define TSI_GENCS_PS(x)                          (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_PS_SHIFT))&TSI_GENCS_PS_MASK)
+#define TSI_GENCS_EXTCHRG_MASK                   0x70000u
+#define TSI_GENCS_EXTCHRG_SHIFT                  16
+#define TSI_GENCS_EXTCHRG(x)                     (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_EXTCHRG_SHIFT))&TSI_GENCS_EXTCHRG_MASK)
+#define TSI_GENCS_DVOLT_MASK                     0x180000u
+#define TSI_GENCS_DVOLT_SHIFT                    19
+#define TSI_GENCS_DVOLT(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_DVOLT_SHIFT))&TSI_GENCS_DVOLT_MASK)
+#define TSI_GENCS_REFCHRG_MASK                   0xE00000u
+#define TSI_GENCS_REFCHRG_SHIFT                  21
+#define TSI_GENCS_REFCHRG(x)                     (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_REFCHRG_SHIFT))&TSI_GENCS_REFCHRG_MASK)
+#define TSI_GENCS_MODE_MASK                      0xF000000u
+#define TSI_GENCS_MODE_SHIFT                     24
+#define TSI_GENCS_MODE(x)                        (((uint32_t)(((uint32_t)(x))<<TSI_GENCS_MODE_SHIFT))&TSI_GENCS_MODE_MASK)
+#define TSI_GENCS_ESOR_MASK                      0x10000000u
+#define TSI_GENCS_ESOR_SHIFT                     28
+#define TSI_GENCS_OUTRGF_MASK                    0x80000000u
+#define TSI_GENCS_OUTRGF_SHIFT                   31
+/* DATA Bit Fields */
+#define TSI_DATA_TSICNT_MASK                     0xFFFFu
+#define TSI_DATA_TSICNT_SHIFT                    0
+#define TSI_DATA_TSICNT(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_DATA_TSICNT_SHIFT))&TSI_DATA_TSICNT_MASK)
+#define TSI_DATA_SWTS_MASK                       0x400000u
+#define TSI_DATA_SWTS_SHIFT                      22
+#define TSI_DATA_DMAEN_MASK                      0x800000u
+#define TSI_DATA_DMAEN_SHIFT                     23
+#define TSI_DATA_TSICH_MASK                      0xF0000000u
+#define TSI_DATA_TSICH_SHIFT                     28
+#define TSI_DATA_TSICH(x)                        (((uint32_t)(((uint32_t)(x))<<TSI_DATA_TSICH_SHIFT))&TSI_DATA_TSICH_MASK)
+/* TSHD Bit Fields */
+#define TSI_TSHD_THRESL_MASK                     0xFFFFu
+#define TSI_TSHD_THRESL_SHIFT                    0
+#define TSI_TSHD_THRESL(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_TSHD_THRESL_SHIFT))&TSI_TSHD_THRESL_MASK)
+#define TSI_TSHD_THRESH_MASK                     0xFFFF0000u
+#define TSI_TSHD_THRESH_SHIFT                    16
+#define TSI_TSHD_THRESH(x)                       (((uint32_t)(((uint32_t)(x))<<TSI_TSHD_THRESH_SHIFT))&TSI_TSHD_THRESH_MASK)
+
+/**
+ * @}
+ */ /* end of group TSI_Register_Masks */
+
+
+/* TSI - Peripheral instance base addresses */
+/** Peripheral TSI0 base address */
+#define TSI0_BASE                                (0x40045000u)
+/** Peripheral TSI0 base pointer */
+#define TSI0                                     ((TSI_Type *)TSI0_BASE)
+/** Array initializer of TSI peripheral base pointers */
+#define TSI_BASES                                { TSI0 }
+
+/**
+ * @}
+ */ /* end of group TSI_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup UART_Peripheral_Access_Layer UART Peripheral Access Layer
+ * @{
+ */
+
+/** UART - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t BDH;                                /**< UART Baud Rate Register: High, offset: 0x0 */
+  __IO uint8_t BDL;                                /**< UART Baud Rate Register: Low, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< UART Control Register 1, offset: 0x2 */
+  __IO uint8_t C2;                                 /**< UART Control Register 2, offset: 0x3 */
+  __I  uint8_t S1;                                 /**< UART Status Register 1, offset: 0x4 */
+  __IO uint8_t S2;                                 /**< UART Status Register 2, offset: 0x5 */
+  __IO uint8_t C3;                                 /**< UART Control Register 3, offset: 0x6 */
+  __IO uint8_t D;                                  /**< UART Data Register, offset: 0x7 */
+  __IO uint8_t C4;                                 /**< UART Control Register 4, offset: 0x8 */
+} UART_Type;
+
+/* ----------------------------------------------------------------------------
+   -- UART Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup UART_Register_Masks UART Register Masks
+ * @{
+ */
+
+/* BDH Bit Fields */
+#define UART_BDH_SBR_MASK                        0x1Fu
+#define UART_BDH_SBR_SHIFT                       0
+#define UART_BDH_SBR(x)                          (((uint8_t)(((uint8_t)(x))<<UART_BDH_SBR_SHIFT))&UART_BDH_SBR_MASK)
+#define UART_BDH_SBNS_MASK                       0x20u
+#define UART_BDH_SBNS_SHIFT                      5
+#define UART_BDH_RXEDGIE_MASK                    0x40u
+#define UART_BDH_RXEDGIE_SHIFT                   6
+#define UART_BDH_LBKDIE_MASK                     0x80u
+#define UART_BDH_LBKDIE_SHIFT                    7
+/* BDL Bit Fields */
+#define UART_BDL_SBR_MASK                        0xFFu
+#define UART_BDL_SBR_SHIFT                       0
+#define UART_BDL_SBR(x)                          (((uint8_t)(((uint8_t)(x))<<UART_BDL_SBR_SHIFT))&UART_BDL_SBR_MASK)
+/* C1 Bit Fields */
+#define UART_C1_PT_MASK                          0x1u
+#define UART_C1_PT_SHIFT                         0
+#define UART_C1_PE_MASK                          0x2u
+#define UART_C1_PE_SHIFT                         1
+#define UART_C1_ILT_MASK                         0x4u
+#define UART_C1_ILT_SHIFT                        2
+#define UART_C1_WAKE_MASK                        0x8u
+#define UART_C1_WAKE_SHIFT                       3
+#define UART_C1_M_MASK                           0x10u
+#define UART_C1_M_SHIFT                          4
+#define UART_C1_RSRC_MASK                        0x20u
+#define UART_C1_RSRC_SHIFT                       5
+#define UART_C1_UARTSWAI_MASK                    0x40u
+#define UART_C1_UARTSWAI_SHIFT                   6
+#define UART_C1_LOOPS_MASK                       0x80u
+#define UART_C1_LOOPS_SHIFT                      7
+/* C2 Bit Fields */
+#define UART_C2_SBK_MASK                         0x1u
+#define UART_C2_SBK_SHIFT                        0
+#define UART_C2_RWU_MASK                         0x2u
+#define UART_C2_RWU_SHIFT                        1
+#define UART_C2_RE_MASK                          0x4u
+#define UART_C2_RE_SHIFT                         2
+#define UART_C2_TE_MASK                          0x8u
+#define UART_C2_TE_SHIFT                         3
+#define UART_C2_ILIE_MASK                        0x10u
+#define UART_C2_ILIE_SHIFT                       4
+#define UART_C2_RIE_MASK                         0x20u
+#define UART_C2_RIE_SHIFT                        5
+#define UART_C2_TCIE_MASK                        0x40u
+#define UART_C2_TCIE_SHIFT                       6
+#define UART_C2_TIE_MASK                         0x80u
+#define UART_C2_TIE_SHIFT                        7
+/* S1 Bit Fields */
+#define UART_S1_PF_MASK                          0x1u
+#define UART_S1_PF_SHIFT                         0
+#define UART_S1_FE_MASK                          0x2u
+#define UART_S1_FE_SHIFT                         1
+#define UART_S1_NF_MASK                          0x4u
+#define UART_S1_NF_SHIFT                         2
+#define UART_S1_OR_MASK                          0x8u
+#define UART_S1_OR_SHIFT                         3
+#define UART_S1_IDLE_MASK                        0x10u
+#define UART_S1_IDLE_SHIFT                       4
+#define UART_S1_RDRF_MASK                        0x20u
+#define UART_S1_RDRF_SHIFT                       5
+#define UART_S1_TC_MASK                          0x40u
+#define UART_S1_TC_SHIFT                         6
+#define UART_S1_TDRE_MASK                        0x80u
+#define UART_S1_TDRE_SHIFT                       7
+/* S2 Bit Fields */
+#define UART_S2_RAF_MASK                         0x1u
+#define UART_S2_RAF_SHIFT                        0
+#define UART_S2_LBKDE_MASK                       0x2u
+#define UART_S2_LBKDE_SHIFT                      1
+#define UART_S2_BRK13_MASK                       0x4u
+#define UART_S2_BRK13_SHIFT                      2
+#define UART_S2_RWUID_MASK                       0x8u
+#define UART_S2_RWUID_SHIFT                      3
+#define UART_S2_RXINV_MASK                       0x10u
+#define UART_S2_RXINV_SHIFT                      4
+#define UART_S2_RXEDGIF_MASK                     0x40u
+#define UART_S2_RXEDGIF_SHIFT                    6
+#define UART_S2_LBKDIF_MASK                      0x80u
+#define UART_S2_LBKDIF_SHIFT                     7
+/* C3 Bit Fields */
+#define UART_C3_PEIE_MASK                        0x1u
+#define UART_C3_PEIE_SHIFT                       0
+#define UART_C3_FEIE_MASK                        0x2u
+#define UART_C3_FEIE_SHIFT                       1
+#define UART_C3_NEIE_MASK                        0x4u
+#define UART_C3_NEIE_SHIFT                       2
+#define UART_C3_ORIE_MASK                        0x8u
+#define UART_C3_ORIE_SHIFT                       3
+#define UART_C3_TXINV_MASK                       0x10u
+#define UART_C3_TXINV_SHIFT                      4
+#define UART_C3_TXDIR_MASK                       0x20u
+#define UART_C3_TXDIR_SHIFT                      5
+#define UART_C3_T8_MASK                          0x40u
+#define UART_C3_T8_SHIFT                         6
+#define UART_C3_R8_MASK                          0x80u
+#define UART_C3_R8_SHIFT                         7
+/* D Bit Fields */
+#define UART_D_R0T0_MASK                         0x1u
+#define UART_D_R0T0_SHIFT                        0
+#define UART_D_R1T1_MASK                         0x2u
+#define UART_D_R1T1_SHIFT                        1
+#define UART_D_R2T2_MASK                         0x4u
+#define UART_D_R2T2_SHIFT                        2
+#define UART_D_R3T3_MASK                         0x8u
+#define UART_D_R3T3_SHIFT                        3
+#define UART_D_R4T4_MASK                         0x10u
+#define UART_D_R4T4_SHIFT                        4
+#define UART_D_R5T5_MASK                         0x20u
+#define UART_D_R5T5_SHIFT                        5
+#define UART_D_R6T6_MASK                         0x40u
+#define UART_D_R6T6_SHIFT                        6
+#define UART_D_R7T7_MASK                         0x80u
+#define UART_D_R7T7_SHIFT                        7
+/* C4 Bit Fields */
+#define UART_C4_RDMAS_MASK                       0x20u
+#define UART_C4_RDMAS_SHIFT                      5
+#define UART_C4_TDMAS_MASK                       0x80u
+#define UART_C4_TDMAS_SHIFT                      7
+
+/**
+ * @}
+ */ /* end of group UART_Register_Masks */
+
+
+/* UART - Peripheral instance base addresses */
+/** Peripheral UART1 base address */
+#define UART1_BASE                               (0x4006B000u)
+/** Peripheral UART1 base pointer */
+#define UART1                                    ((UART_Type *)UART1_BASE)
+/** Peripheral UART2 base address */
+#define UART2_BASE                               (0x4006C000u)
+/** Peripheral UART2 base pointer */
+#define UART2                                    ((UART_Type *)UART2_BASE)
+/** Array initializer of UART peripheral base pointers */
+#define UART_BASES                               { UART1, UART2 }
+
+/**
+ * @}
+ */ /* end of group UART_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- UART0 Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup UART0_Peripheral_Access_Layer UART0 Peripheral Access Layer
+ * @{
+ */
+
+/** UART0 - Register Layout Typedef */
+typedef struct {
+  __IO uint8_t BDH;                                /**< UART Baud Rate Register High, offset: 0x0 */
+  __IO uint8_t BDL;                                /**< UART Baud Rate Register Low, offset: 0x1 */
+  __IO uint8_t C1;                                 /**< UART Control Register 1, offset: 0x2 */
+  __IO uint8_t C2;                                 /**< UART Control Register 2, offset: 0x3 */
+  __IO uint8_t S1;                                 /**< UART Status Register 1, offset: 0x4 */
+  __IO uint8_t S2;                                 /**< UART Status Register 2, offset: 0x5 */
+  __IO uint8_t C3;                                 /**< UART Control Register 3, offset: 0x6 */
+  __IO uint8_t D;                                  /**< UART Data Register, offset: 0x7 */
+  __IO uint8_t MA1;                                /**< UART Match Address Registers 1, offset: 0x8 */
+  __IO uint8_t MA2;                                /**< UART Match Address Registers 2, offset: 0x9 */
+  __IO uint8_t C4;                                 /**< UART Control Register 4, offset: 0xA */
+  __IO uint8_t C5;                                 /**< UART Control Register 5, offset: 0xB */
+} UART0_Type;
+
+/* ----------------------------------------------------------------------------
+   -- UART0 Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup UART0_Register_Masks UART0 Register Masks
+ * @{
+ */
+
+/* BDH Bit Fields */
+#define UART0_BDH_SBR_MASK                       0x1Fu
+#define UART0_BDH_SBR_SHIFT                      0
+#define UART0_BDH_SBR(x)                         (((uint8_t)(((uint8_t)(x))<<UART0_BDH_SBR_SHIFT))&UART0_BDH_SBR_MASK)
+#define UART0_BDH_SBNS_MASK                      0x20u
+#define UART0_BDH_SBNS_SHIFT                     5
+#define UART0_BDH_RXEDGIE_MASK                   0x40u
+#define UART0_BDH_RXEDGIE_SHIFT                  6
+#define UART0_BDH_LBKDIE_MASK                    0x80u
+#define UART0_BDH_LBKDIE_SHIFT                   7
+/* BDL Bit Fields */
+#define UART0_BDL_SBR_MASK                       0xFFu
+#define UART0_BDL_SBR_SHIFT                      0
+#define UART0_BDL_SBR(x)                         (((uint8_t)(((uint8_t)(x))<<UART0_BDL_SBR_SHIFT))&UART0_BDL_SBR_MASK)
+/* C1 Bit Fields */
+#define UART0_C1_PT_MASK                         0x1u
+#define UART0_C1_PT_SHIFT                        0
+#define UART0_C1_PE_MASK                         0x2u
+#define UART0_C1_PE_SHIFT                        1
+#define UART0_C1_ILT_MASK                        0x4u
+#define UART0_C1_ILT_SHIFT                       2
+#define UART0_C1_WAKE_MASK                       0x8u
+#define UART0_C1_WAKE_SHIFT                      3
+#define UART0_C1_M_MASK                          0x10u
+#define UART0_C1_M_SHIFT                         4
+#define UART0_C1_RSRC_MASK                       0x20u
+#define UART0_C1_RSRC_SHIFT                      5
+#define UART0_C1_DOZEEN_MASK                     0x40u
+#define UART0_C1_DOZEEN_SHIFT                    6
+#define UART0_C1_LOOPS_MASK                      0x80u
+#define UART0_C1_LOOPS_SHIFT                     7
+/* C2 Bit Fields */
+#define UART0_C2_SBK_MASK                        0x1u
+#define UART0_C2_SBK_SHIFT                       0
+#define UART0_C2_RWU_MASK                        0x2u
+#define UART0_C2_RWU_SHIFT                       1
+#define UART0_C2_RE_MASK                         0x4u
+#define UART0_C2_RE_SHIFT                        2
+#define UART0_C2_TE_MASK                         0x8u
+#define UART0_C2_TE_SHIFT                        3
+#define UART0_C2_ILIE_MASK                       0x10u
+#define UART0_C2_ILIE_SHIFT                      4
+#define UART0_C2_RIE_MASK                        0x20u
+#define UART0_C2_RIE_SHIFT                       5
+#define UART0_C2_TCIE_MASK                       0x40u
+#define UART0_C2_TCIE_SHIFT                      6
+#define UART0_C2_TIE_MASK                        0x80u
+#define UART0_C2_TIE_SHIFT                       7
+/* S1 Bit Fields */
+#define UART0_S1_PF_MASK                         0x1u
+#define UART0_S1_PF_SHIFT                        0
+#define UART0_S1_FE_MASK                         0x2u
+#define UART0_S1_FE_SHIFT                        1
+#define UART0_S1_NF_MASK                         0x4u
+#define UART0_S1_NF_SHIFT                        2
+#define UART0_S1_OR_MASK                         0x8u
+#define UART0_S1_OR_SHIFT                        3
+#define UART0_S1_IDLE_MASK                       0x10u
+#define UART0_S1_IDLE_SHIFT                      4
+#define UART0_S1_RDRF_MASK                       0x20u
+#define UART0_S1_RDRF_SHIFT                      5
+#define UART0_S1_TC_MASK                         0x40u
+#define UART0_S1_TC_SHIFT                        6
+#define UART0_S1_TDRE_MASK                       0x80u
+#define UART0_S1_TDRE_SHIFT                      7
+/* S2 Bit Fields */
+#define UART0_S2_RAF_MASK                        0x1u
+#define UART0_S2_RAF_SHIFT                       0
+#define UART0_S2_LBKDE_MASK                      0x2u
+#define UART0_S2_LBKDE_SHIFT                     1
+#define UART0_S2_BRK13_MASK                      0x4u
+#define UART0_S2_BRK13_SHIFT                     2
+#define UART0_S2_RWUID_MASK                      0x8u
+#define UART0_S2_RWUID_SHIFT                     3
+#define UART0_S2_RXINV_MASK                      0x10u
+#define UART0_S2_RXINV_SHIFT                     4
+#define UART0_S2_MSBF_MASK                       0x20u
+#define UART0_S2_MSBF_SHIFT                      5
+#define UART0_S2_RXEDGIF_MASK                    0x40u
+#define UART0_S2_RXEDGIF_SHIFT                   6
+#define UART0_S2_LBKDIF_MASK                     0x80u
+#define UART0_S2_LBKDIF_SHIFT                    7
+/* C3 Bit Fields */
+#define UART0_C3_PEIE_MASK                       0x1u
+#define UART0_C3_PEIE_SHIFT                      0
+#define UART0_C3_FEIE_MASK                       0x2u
+#define UART0_C3_FEIE_SHIFT                      1
+#define UART0_C3_NEIE_MASK                       0x4u
+#define UART0_C3_NEIE_SHIFT                      2
+#define UART0_C3_ORIE_MASK                       0x8u
+#define UART0_C3_ORIE_SHIFT                      3
+#define UART0_C3_TXINV_MASK                      0x10u
+#define UART0_C3_TXINV_SHIFT                     4
+#define UART0_C3_TXDIR_MASK                      0x20u
+#define UART0_C3_TXDIR_SHIFT                     5
+#define UART0_C3_R9T8_MASK                       0x40u
+#define UART0_C3_R9T8_SHIFT                      6
+#define UART0_C3_R8T9_MASK                       0x80u
+#define UART0_C3_R8T9_SHIFT                      7
+/* D Bit Fields */
+#define UART0_D_R0T0_MASK                        0x1u
+#define UART0_D_R0T0_SHIFT                       0
+#define UART0_D_R1T1_MASK                        0x2u
+#define UART0_D_R1T1_SHIFT                       1
+#define UART0_D_R2T2_MASK                        0x4u
+#define UART0_D_R2T2_SHIFT                       2
+#define UART0_D_R3T3_MASK                        0x8u
+#define UART0_D_R3T3_SHIFT                       3
+#define UART0_D_R4T4_MASK                        0x10u
+#define UART0_D_R4T4_SHIFT                       4
+#define UART0_D_R5T5_MASK                        0x20u
+#define UART0_D_R5T5_SHIFT                       5
+#define UART0_D_R6T6_MASK                        0x40u
+#define UART0_D_R6T6_SHIFT                       6
+#define UART0_D_R7T7_MASK                        0x80u
+#define UART0_D_R7T7_SHIFT                       7
+/* MA1 Bit Fields */
+#define UART0_MA1_MA_MASK                        0xFFu
+#define UART0_MA1_MA_SHIFT                       0
+#define UART0_MA1_MA(x)                          (((uint8_t)(((uint8_t)(x))<<UART0_MA1_MA_SHIFT))&UART0_MA1_MA_MASK)
+/* MA2 Bit Fields */
+#define UART0_MA2_MA_MASK                        0xFFu
+#define UART0_MA2_MA_SHIFT                       0
+#define UART0_MA2_MA(x)                          (((uint8_t)(((uint8_t)(x))<<UART0_MA2_MA_SHIFT))&UART0_MA2_MA_MASK)
+/* C4 Bit Fields */
+#define UART0_C4_OSR_MASK                        0x1Fu
+#define UART0_C4_OSR_SHIFT                       0
+#define UART0_C4_OSR(x)                          (((uint8_t)(((uint8_t)(x))<<UART0_C4_OSR_SHIFT))&UART0_C4_OSR_MASK)
+#define UART0_C4_M10_MASK                        0x20u
+#define UART0_C4_M10_SHIFT                       5
+#define UART0_C4_MAEN2_MASK                      0x40u
+#define UART0_C4_MAEN2_SHIFT                     6
+#define UART0_C4_MAEN1_MASK                      0x80u
+#define UART0_C4_MAEN1_SHIFT                     7
+/* C5 Bit Fields */
+#define UART0_C5_RESYNCDIS_MASK                  0x1u
+#define UART0_C5_RESYNCDIS_SHIFT                 0
+#define UART0_C5_BOTHEDGE_MASK                   0x2u
+#define UART0_C5_BOTHEDGE_SHIFT                  1
+#define UART0_C5_RDMAE_MASK                      0x20u
+#define UART0_C5_RDMAE_SHIFT                     5
+#define UART0_C5_TDMAE_MASK                      0x80u
+#define UART0_C5_TDMAE_SHIFT                     7
+
+/**
+ * @}
+ */ /* end of group UART0_Register_Masks */
+
+
+/* UART0 - Peripheral instance base addresses */
+/** Peripheral UART0 base address */
+#define UART0_BASE                               (0x4006A000u)
+/** Peripheral UART0 base pointer */
+#define UART0                                    ((UART0_Type *)UART0_BASE)
+/** Array initializer of UART0 peripheral base pointers */
+#define UART0_BASES                              { UART0 }
+
+/**
+ * @}
+ */ /* end of group UART0_Peripheral_Access_Layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- USB Peripheral Access Layer
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup USB_Peripheral_Access_Layer USB Peripheral Access Layer
+ * @{
+ */
+
+/** USB - Register Layout Typedef */
+typedef struct {
+  __I  uint8_t PERID;                              /**< Peripheral ID register, offset: 0x0 */
+       uint8_t RESERVED_0[3];
+  __I  uint8_t IDCOMP;                             /**< Peripheral ID Complement register, offset: 0x4 */
+       uint8_t RESERVED_1[3];
+  __I  uint8_t REV;                                /**< Peripheral Revision register, offset: 0x8 */
+       uint8_t RESERVED_2[3];
+  __I  uint8_t ADDINFO;                            /**< Peripheral Additional Info register, offset: 0xC */
+       uint8_t RESERVED_3[3];
+  __IO uint8_t OTGISTAT;                           /**< OTG Interrupt Status register, offset: 0x10 */
+       uint8_t RESERVED_4[3];
+  __IO uint8_t OTGICR;                             /**< OTG Interrupt Control Register, offset: 0x14 */
+       uint8_t RESERVED_5[3];
+  __IO uint8_t OTGSTAT;                            /**< OTG Status register, offset: 0x18 */
+       uint8_t RESERVED_6[3];
+  __IO uint8_t OTGCTL;                             /**< OTG Control register, offset: 0x1C */
+       uint8_t RESERVED_7[99];
+  __IO uint8_t ISTAT;                              /**< Interrupt Status register, offset: 0x80 */
+       uint8_t RESERVED_8[3];
+  __IO uint8_t INTEN;                              /**< Interrupt Enable register, offset: 0x84 */
+       uint8_t RESERVED_9[3];
+  __IO uint8_t ERRSTAT;                            /**< Error Interrupt Status register, offset: 0x88 */
+       uint8_t RESERVED_10[3];
+  __IO uint8_t ERREN;                              /**< Error Interrupt Enable register, offset: 0x8C */
+       uint8_t RESERVED_11[3];
+  __I  uint8_t STAT;                               /**< Status register, offset: 0x90 */
+       uint8_t RESERVED_12[3];
+  __IO uint8_t CTL;                                /**< Control register, offset: 0x94 */
+       uint8_t RESERVED_13[3];
+  __IO uint8_t ADDR;                               /**< Address register, offset: 0x98 */
+       uint8_t RESERVED_14[3];
+  __IO uint8_t BDTPAGE1;                           /**< BDT Page Register 1, offset: 0x9C */
+       uint8_t RESERVED_15[3];
+  __IO uint8_t FRMNUML;                            /**< Frame Number Register Low, offset: 0xA0 */
+       uint8_t RESERVED_16[3];
+  __IO uint8_t FRMNUMH;                            /**< Frame Number Register High, offset: 0xA4 */
+       uint8_t RESERVED_17[3];
+  __IO uint8_t TOKEN;                              /**< Token register, offset: 0xA8 */
+       uint8_t RESERVED_18[3];
+  __IO uint8_t SOFTHLD;                            /**< SOF Threshold Register, offset: 0xAC */
+       uint8_t RESERVED_19[3];
+  __IO uint8_t BDTPAGE2;                           /**< BDT Page Register 2, offset: 0xB0 */
+       uint8_t RESERVED_20[3];
+  __IO uint8_t BDTPAGE3;                           /**< BDT Page Register 3, offset: 0xB4 */
+       uint8_t RESERVED_21[11];
+  struct {                                         /* offset: 0xC0, array step: 0x4 */
+    __IO uint8_t ENDPT;                              /**< Endpoint Control register, array offset: 0xC0, array step: 0x4 */
+         uint8_t RESERVED_0[3];
+  } ENDPOINT[16];
+  __IO uint8_t USBCTRL;                            /**< USB Control register, offset: 0x100 */
+       uint8_t RESERVED_22[3];
+  __I  uint8_t OBSERVE;                            /**< USB OTG Observe register, offset: 0x104 */
+       uint8_t RESERVED_23[3];
+  __IO uint8_t CONTROL;                            /**< USB OTG Control register, offset: 0x108 */
+       uint8_t RESERVED_24[3];
+  __IO uint8_t USBTRC0;                            /**< USB Transceiver Control Register 0, offset: 0x10C */
+       uint8_t RESERVED_25[7];
+  __IO uint8_t USBFRMADJUST;                       /**< Frame Adjust Register, offset: 0x114 */
+} USB_Type;
+
+/* ----------------------------------------------------------------------------
+   -- USB Register Masks
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup USB_Register_Masks USB Register Masks
+ * @{
+ */
+
+/* PERID Bit Fields */
+#define USB_PERID_ID_MASK                        0x3Fu
+#define USB_PERID_ID_SHIFT                       0
+#define USB_PERID_ID(x)                          (((uint8_t)(((uint8_t)(x))<<USB_PERID_ID_SHIFT))&USB_PERID_ID_MASK)
+/* IDCOMP Bit Fields */
+#define USB_IDCOMP_NID_MASK                      0x3Fu
+#define USB_IDCOMP_NID_SHIFT                     0
+#define USB_IDCOMP_NID(x)                        (((uint8_t)(((uint8_t)(x))<<USB_IDCOMP_NID_SHIFT))&USB_IDCOMP_NID_MASK)
+/* REV Bit Fields */
+#define USB_REV_REV_MASK                         0xFFu
+#define USB_REV_REV_SHIFT                        0
+#define USB_REV_REV(x)                           (((uint8_t)(((uint8_t)(x))<<USB_REV_REV_SHIFT))&USB_REV_REV_MASK)
+/* ADDINFO Bit Fields */
+#define USB_ADDINFO_IEHOST_MASK                  0x1u
+#define USB_ADDINFO_IEHOST_SHIFT                 0
+#define USB_ADDINFO_IRQNUM_MASK                  0xF8u
+#define USB_ADDINFO_IRQNUM_SHIFT                 3
+#define USB_ADDINFO_IRQNUM(x)                    (((uint8_t)(((uint8_t)(x))<<USB_ADDINFO_IRQNUM_SHIFT))&USB_ADDINFO_IRQNUM_MASK)
+/* OTGISTAT Bit Fields */
+#define USB_OTGISTAT_AVBUSCHG_MASK               0x1u
+#define USB_OTGISTAT_AVBUSCHG_SHIFT              0
+#define USB_OTGISTAT_B_SESS_CHG_MASK             0x4u
+#define USB_OTGISTAT_B_SESS_CHG_SHIFT            2
+#define USB_OTGISTAT_SESSVLDCHG_MASK             0x8u
+#define USB_OTGISTAT_SESSVLDCHG_SHIFT            3
+#define USB_OTGISTAT_LINE_STATE_CHG_MASK         0x20u
+#define USB_OTGISTAT_LINE_STATE_CHG_SHIFT        5
+#define USB_OTGISTAT_ONEMSEC_MASK                0x40u
+#define USB_OTGISTAT_ONEMSEC_SHIFT               6
+#define USB_OTGISTAT_IDCHG_MASK                  0x80u
+#define USB_OTGISTAT_IDCHG_SHIFT                 7
+/* OTGICR Bit Fields */
+#define USB_OTGICR_AVBUSEN_MASK                  0x1u
+#define USB_OTGICR_AVBUSEN_SHIFT                 0
+#define USB_OTGICR_BSESSEN_MASK                  0x4u
+#define USB_OTGICR_BSESSEN_SHIFT                 2
+#define USB_OTGICR_SESSVLDEN_MASK                0x8u
+#define USB_OTGICR_SESSVLDEN_SHIFT               3
+#define USB_OTGICR_LINESTATEEN_MASK              0x20u
+#define USB_OTGICR_LINESTATEEN_SHIFT             5
+#define USB_OTGICR_ONEMSECEN_MASK                0x40u
+#define USB_OTGICR_ONEMSECEN_SHIFT               6
+#define USB_OTGICR_IDEN_MASK                     0x80u
+#define USB_OTGICR_IDEN_SHIFT                    7
+/* OTGSTAT Bit Fields */
+#define USB_OTGSTAT_AVBUSVLD_MASK                0x1u
+#define USB_OTGSTAT_AVBUSVLD_SHIFT               0
+#define USB_OTGSTAT_BSESSEND_MASK                0x4u
+#define USB_OTGSTAT_BSESSEND_SHIFT               2
+#define USB_OTGSTAT_SESS_VLD_MASK                0x8u
+#define USB_OTGSTAT_SESS_VLD_SHIFT               3
+#define USB_OTGSTAT_LINESTATESTABLE_MASK         0x20u
+#define USB_OTGSTAT_LINESTATESTABLE_SHIFT        5
+#define USB_OTGSTAT_ONEMSECEN_MASK               0x40u
+#define USB_OTGSTAT_ONEMSECEN_SHIFT              6
+#define USB_OTGSTAT_ID_MASK                      0x80u
+#define USB_OTGSTAT_ID_SHIFT                     7
+/* OTGCTL Bit Fields */
+#define USB_OTGCTL_OTGEN_MASK                    0x4u
+#define USB_OTGCTL_OTGEN_SHIFT                   2
+#define USB_OTGCTL_DMLOW_MASK                    0x10u
+#define USB_OTGCTL_DMLOW_SHIFT                   4
+#define USB_OTGCTL_DPLOW_MASK                    0x20u
+#define USB_OTGCTL_DPLOW_SHIFT                   5
+#define USB_OTGCTL_DPHIGH_MASK                   0x80u
+#define USB_OTGCTL_DPHIGH_SHIFT                  7
+/* ISTAT Bit Fields */
+#define USB_ISTAT_USBRST_MASK                    0x1u
+#define USB_ISTAT_USBRST_SHIFT                   0
+#define USB_ISTAT_ERROR_MASK                     0x2u
+#define USB_ISTAT_ERROR_SHIFT                    1
+#define USB_ISTAT_SOFTOK_MASK                    0x4u
+#define USB_ISTAT_SOFTOK_SHIFT                   2
+#define USB_ISTAT_TOKDNE_MASK                    0x8u
+#define USB_ISTAT_TOKDNE_SHIFT                   3
+#define USB_ISTAT_SLEEP_MASK                     0x10u
+#define USB_ISTAT_SLEEP_SHIFT                    4
+#define USB_ISTAT_RESUME_MASK                    0x20u
+#define USB_ISTAT_RESUME_SHIFT                   5
+#define USB_ISTAT_ATTACH_MASK                    0x40u
+#define USB_ISTAT_ATTACH_SHIFT                   6
+#define USB_ISTAT_STALL_MASK                     0x80u
+#define USB_ISTAT_STALL_SHIFT                    7
+/* INTEN Bit Fields */
+#define USB_INTEN_USBRSTEN_MASK                  0x1u
+#define USB_INTEN_USBRSTEN_SHIFT                 0
+#define USB_INTEN_ERROREN_MASK                   0x2u
+#define USB_INTEN_ERROREN_SHIFT                  1
+#define USB_INTEN_SOFTOKEN_MASK                  0x4u
+#define USB_INTEN_SOFTOKEN_SHIFT                 2
+#define USB_INTEN_TOKDNEEN_MASK                  0x8u
+#define USB_INTEN_TOKDNEEN_SHIFT                 3
+#define USB_INTEN_SLEEPEN_MASK                   0x10u
+#define USB_INTEN_SLEEPEN_SHIFT                  4
+#define USB_INTEN_RESUMEEN_MASK                  0x20u
+#define USB_INTEN_RESUMEEN_SHIFT                 5
+#define USB_INTEN_ATTACHEN_MASK                  0x40u
+#define USB_INTEN_ATTACHEN_SHIFT                 6
+#define USB_INTEN_STALLEN_MASK                   0x80u
+#define USB_INTEN_STALLEN_SHIFT                  7
+/* ERRSTAT Bit Fields */
+#define USB_ERRSTAT_PIDERR_MASK                  0x1u
+#define USB_ERRSTAT_PIDERR_SHIFT                 0
+#define USB_ERRSTAT_CRC5EOF_MASK                 0x2u
+#define USB_ERRSTAT_CRC5EOF_SHIFT                1
+#define USB_ERRSTAT_CRC16_MASK                   0x4u
+#define USB_ERRSTAT_CRC16_SHIFT                  2
+#define USB_ERRSTAT_DFN8_MASK                    0x8u
+#define USB_ERRSTAT_DFN8_SHIFT                   3
+#define USB_ERRSTAT_BTOERR_MASK                  0x10u
+#define USB_ERRSTAT_BTOERR_SHIFT                 4
+#define USB_ERRSTAT_DMAERR_MASK                  0x20u
+#define USB_ERRSTAT_DMAERR_SHIFT                 5
+#define USB_ERRSTAT_BTSERR_MASK                  0x80u
+#define USB_ERRSTAT_BTSERR_SHIFT                 7
+/* ERREN Bit Fields */
+#define USB_ERREN_PIDERREN_MASK                  0x1u
+#define USB_ERREN_PIDERREN_SHIFT                 0
+#define USB_ERREN_CRC5EOFEN_MASK                 0x2u
+#define USB_ERREN_CRC5EOFEN_SHIFT                1
+#define USB_ERREN_CRC16EN_MASK                   0x4u
+#define USB_ERREN_CRC16EN_SHIFT                  2
+#define USB_ERREN_DFN8EN_MASK                    0x8u
+#define USB_ERREN_DFN8EN_SHIFT                   3
+#define USB_ERREN_BTOERREN_MASK                  0x10u
+#define USB_ERREN_BTOERREN_SHIFT                 4
+#define USB_ERREN_DMAERREN_MASK                  0x20u
+#define USB_ERREN_DMAERREN_SHIFT                 5
+#define USB_ERREN_BTSERREN_MASK                  0x80u
+#define USB_ERREN_BTSERREN_SHIFT                 7
+/* STAT Bit Fields */
+#define USB_STAT_ODD_MASK                        0x4u
+#define USB_STAT_ODD_SHIFT                       2
+#define USB_STAT_TX_MASK                         0x8u
+#define USB_STAT_TX_SHIFT                        3
+#define USB_STAT_ENDP_MASK                       0xF0u
+#define USB_STAT_ENDP_SHIFT                      4
+#define USB_STAT_ENDP(x)                         (((uint8_t)(((uint8_t)(x))<<USB_STAT_ENDP_SHIFT))&USB_STAT_ENDP_MASK)
+/* CTL Bit Fields */
+#define USB_CTL_USBENSOFEN_MASK                  0x1u
+#define USB_CTL_USBENSOFEN_SHIFT                 0
+#define USB_CTL_ODDRST_MASK                      0x2u
+#define USB_CTL_ODDRST_SHIFT                     1
+#define USB_CTL_RESUME_MASK                      0x4u
+#define USB_CTL_RESUME_SHIFT                     2
+#define USB_CTL_HOSTMODEEN_MASK                  0x8u
+#define USB_CTL_HOSTMODEEN_SHIFT                 3
+#define USB_CTL_RESET_MASK                       0x10u
+#define USB_CTL_RESET_SHIFT                      4
+#define USB_CTL_TXSUSPENDTOKENBUSY_MASK          0x20u
+#define USB_CTL_TXSUSPENDTOKENBUSY_SHIFT         5
+#define USB_CTL_SE0_MASK                         0x40u
+#define USB_CTL_SE0_SHIFT                        6
+#define USB_CTL_JSTATE_MASK                      0x80u
+#define USB_CTL_JSTATE_SHIFT                     7
+/* ADDR Bit Fields */
+#define USB_ADDR_ADDR_MASK                       0x7Fu
+#define USB_ADDR_ADDR_SHIFT                      0
+#define USB_ADDR_ADDR(x)                         (((uint8_t)(((uint8_t)(x))<<USB_ADDR_ADDR_SHIFT))&USB_ADDR_ADDR_MASK)
+#define USB_ADDR_LSEN_MASK                       0x80u
+#define USB_ADDR_LSEN_SHIFT                      7
+/* BDTPAGE1 Bit Fields */
+#define USB_BDTPAGE1_BDTBA_MASK                  0xFEu
+#define USB_BDTPAGE1_BDTBA_SHIFT                 1
+#define USB_BDTPAGE1_BDTBA(x)                    (((uint8_t)(((uint8_t)(x))<<USB_BDTPAGE1_BDTBA_SHIFT))&USB_BDTPAGE1_BDTBA_MASK)
+/* FRMNUML Bit Fields */
+#define USB_FRMNUML_FRM_MASK                     0xFFu
+#define USB_FRMNUML_FRM_SHIFT                    0
+#define USB_FRMNUML_FRM(x)                       (((uint8_t)(((uint8_t)(x))<<USB_FRMNUML_FRM_SHIFT))&USB_FRMNUML_FRM_MASK)
+/* FRMNUMH Bit Fields */
+#define USB_FRMNUMH_FRM_MASK                     0x7u
+#define USB_FRMNUMH_FRM_SHIFT                    0
+#define USB_FRMNUMH_FRM(x)                       (((uint8_t)(((uint8_t)(x))<<USB_FRMNUMH_FRM_SHIFT))&USB_FRMNUMH_FRM_MASK)
+/* TOKEN Bit Fields */
+#define USB_TOKEN_TOKENENDPT_MASK                0xFu
+#define USB_TOKEN_TOKENENDPT_SHIFT               0
+#define USB_TOKEN_TOKENENDPT(x)                  (((uint8_t)(((uint8_t)(x))<<USB_TOKEN_TOKENENDPT_SHIFT))&USB_TOKEN_TOKENENDPT_MASK)
+#define USB_TOKEN_TOKENPID_MASK                  0xF0u
+#define USB_TOKEN_TOKENPID_SHIFT                 4
+#define USB_TOKEN_TOKENPID(x)                    (((uint8_t)(((uint8_t)(x))<<USB_TOKEN_TOKENPID_SHIFT))&USB_TOKEN_TOKENPID_MASK)
+/* SOFTHLD Bit Fields */
+#define USB_SOFTHLD_CNT_MASK                     0xFFu
+#define USB_SOFTHLD_CNT_SHIFT                    0
+#define USB_SOFTHLD_CNT(x)                       (((uint8_t)(((uint8_t)(x))<<USB_SOFTHLD_CNT_SHIFT))&USB_SOFTHLD_CNT_MASK)
+/* BDTPAGE2 Bit Fields */
+#define USB_BDTPAGE2_BDTBA_MASK                  0xFFu
+#define USB_BDTPAGE2_BDTBA_SHIFT                 0
+#define USB_BDTPAGE2_BDTBA(x)                    (((uint8_t)(((uint8_t)(x))<<USB_BDTPAGE2_BDTBA_SHIFT))&USB_BDTPAGE2_BDTBA_MASK)
+/* BDTPAGE3 Bit Fields */
+#define USB_BDTPAGE3_BDTBA_MASK                  0xFFu
+#define USB_BDTPAGE3_BDTBA_SHIFT                 0
+#define USB_BDTPAGE3_BDTBA(x)                    (((uint8_t)(((uint8_t)(x))<<USB_BDTPAGE3_BDTBA_SHIFT))&USB_BDTPAGE3_BDTBA_MASK)
+/* ENDPT Bit Fields */
+#define USB_ENDPT_EPHSHK_MASK                    0x1u
+#define USB_ENDPT_EPHSHK_SHIFT                   0
+#define USB_ENDPT_EPSTALL_MASK                   0x2u
+#define USB_ENDPT_EPSTALL_SHIFT                  1
+#define USB_ENDPT_EPTXEN_MASK                    0x4u
+#define USB_ENDPT_EPTXEN_SHIFT                   2
+#define USB_ENDPT_EPRXEN_MASK                    0x8u
+#define USB_ENDPT_EPRXEN_SHIFT                   3
+#define USB_ENDPT_EPCTLDIS_MASK                  0x10u
+#define USB_ENDPT_EPCTLDIS_SHIFT                 4
+#define USB_ENDPT_RETRYDIS_MASK                  0x40u
+#define USB_ENDPT_RETRYDIS_SHIFT                 6
+#define USB_ENDPT_HOSTWOHUB_MASK                 0x80u
+#define USB_ENDPT_HOSTWOHUB_SHIFT                7
+/* USBCTRL Bit Fields */
+#define USB_USBCTRL_PDE_MASK                     0x40u
+#define USB_USBCTRL_PDE_SHIFT                    6
+#define USB_USBCTRL_SUSP_MASK                    0x80u
+#define USB_USBCTRL_SUSP_SHIFT                   7
+/* OBSERVE Bit Fields */
+#define USB_OBSERVE_DMPD_MASK                    0x10u
+#define USB_OBSERVE_DMPD_SHIFT                   4
+#define USB_OBSERVE_DPPD_MASK                    0x40u
+#define USB_OBSERVE_DPPD_SHIFT                   6
+#define USB_OBSERVE_DPPU_MASK                    0x80u
+#define USB_OBSERVE_DPPU_SHIFT                   7
+/* CONTROL Bit Fields */
+#define USB_CONTROL_DPPULLUPNONOTG_MASK          0x10u
+#define USB_CONTROL_DPPULLUPNONOTG_SHIFT         4
+/* USBTRC0 Bit Fields */
+#define USB_USBTRC0_USB_RESUME_INT_MASK          0x1u
+#define USB_USBTRC0_USB_RESUME_INT_SHIFT         0
+#define USB_USBTRC0_SYNC_DET_MASK                0x2u
+#define USB_USBTRC0_SYNC_DET_SHIFT               1
+#define USB_USBTRC0_USBRESMEN_MASK               0x20u
+#define USB_USBTRC0_USBRESMEN_SHIFT              5
+#define USB_USBTRC0_USBRESET_MASK                0x80u
+#define USB_USBTRC0_USBRESET_SHIFT               7
+/* USBFRMADJUST Bit Fields */
+#define USB_USBFRMADJUST_ADJ_MASK                0xFFu
+#define USB_USBFRMADJUST_ADJ_SHIFT               0
+#define USB_USBFRMADJUST_ADJ(x)                  (((uint8_t)(((uint8_t)(x))<<USB_USBFRMADJUST_ADJ_SHIFT))&USB_USBFRMADJUST_ADJ_MASK)
+
+/**
+ * @}
+ */ /* end of group USB_Register_Masks */
+
+
+/* USB - Peripheral instance base addresses */
+/** Peripheral USB0 base address */
+#define USB0_BASE                                (0x40072000u)
+/** Peripheral USB0 base pointer */
+#define USB0                                     ((USB_Type *)USB0_BASE)
+/** Array initializer of USB peripheral base pointers */
+#define USB_BASES                                { USB0 }
+
+/**
+ * @}
+ */ /* end of group USB_Peripheral_Access_Layer */
+
+
+/*
+** End of section using anonymous unions
+*/
+
+#if defined(__ARMCC_VERSION)
+  #pragma pop
+#elif defined(__CWCC__)
+  #pragma pop
+#elif defined(__GNUC__)
+  /* leave anonymous unions enabled */
+#elif defined(__IAR_SYSTEMS_ICC__)
+  #pragma language=default
+#else
+  #error Not supported compiler type
+#endif
+
+/**
+ * @}
+ */ /* end of group Peripheral_access_layer */
+
+
+/* ----------------------------------------------------------------------------
+   -- Backward Compatibility
+   ---------------------------------------------------------------------------- */
+
+/**
+ * @addtogroup Backward_Compatibility_Symbols Backward Compatibility
+ * @{
+ */
+
+/* No backward compatibility issues. */
+
+/**
+ * @}
+ */ /* end of group Backward_Compatibility_Symbols */
+
+
+#endif  /* #if !defined(MKL26Z4_H_) */
+
+/* MKL26Z4.h, eof. */

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_ARM_MICRO/MKL26Z4.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_ARM_MICRO/MKL26Z4.sct
@@ -1,0 +1,14 @@
+
+LR_IROM1 0x00000000 0x20000  {    ; load region size_region (32k)
+  ER_IROM1 0x00000000 0x20000  {  ; load address = execution address
+   *.o (RESET, +First)
+   *(InRoot$$Sections)
+   .ANY (+RO)
+  }
+  ; 8_byte_aligned(48 vect * 4 bytes) =  8_byte_aligned(0xC0) = 0xC0
+  ; 0x4000 - 0xC0 = 0x3F40
+  RW_IRAM1 0x1FFFF0C0 0x3F40 {
+   .ANY (+RW +ZI)
+  }
+}
+

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_ARM_MICRO/startup_MKL26Z4.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_ARM_MICRO/startup_MKL26Z4.s
@@ -1,0 +1,365 @@
+; * ---------------------------------------------------------------------------------------
+; *  @file:    startup_MKL26Z4.s
+; *  @purpose: CMSIS Cortex-M0P Core Device Startup File
+; *            MKL26Z4
+; *  @version: 1.7
+; *  @date:    2015-2-18
+; *  @build:   b150218
+; * ---------------------------------------------------------------------------------------
+; *
+; * Copyright (c) 1997 - 2015 , Freescale Semiconductor, Inc.
+; * All rights reserved.
+; *
+; * Redistribution and use in source and binary forms, with or without modification,
+; * are permitted provided that the following conditions are met:
+; *
+; * o Redistributions of source code must retain the above copyright notice, this list
+; *   of conditions and the following disclaimer.
+; *
+; * o Redistributions in binary form must reproduce the above copyright notice, this
+; *   list of conditions and the following disclaimer in the documentation and/or
+; *   other materials provided with the distribution.
+; *
+; * o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+; *   contributors may be used to endorse or promote products derived from this
+; *   software without specific prior written permission.
+; *
+; * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+; * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+; * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+; * ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+; * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+; * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+; * ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+; *
+; *------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+; *
+; *****************************************************************************/
+
+
+                PRESERVE8
+                THUMB
+
+
+; Vector Table Mapped to Address 0 at Reset
+
+                AREA    RESET, DATA, READONLY
+                EXPORT  __Vectors
+                EXPORT  __Vectors_End
+                EXPORT  __Vectors_Size
+                IMPORT  |Image$$ARM_LIB_STACK$$ZI$$Limit|
+
+__Vectors       DCD     |Image$$ARM_LIB_STACK$$ZI$$Limit| ; Top of Stack
+                DCD     Reset_Handler  ; Reset Handler
+                DCD     NMI_Handler                         ;NMI Handler
+                DCD     HardFault_Handler                   ;Hard Fault Handler
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     SVC_Handler                         ;SVCall Handler
+                DCD     0                                   ;Reserved
+                DCD     0                                   ;Reserved
+                DCD     PendSV_Handler                      ;PendSV Handler
+                DCD     SysTick_Handler                     ;SysTick Handler
+
+                                                            ;External Interrupts
+                DCD     DMA0_IRQHandler                     ;DMA channel 0 transfer complete and error interrupt
+                DCD     DMA1_IRQHandler                     ;DMA channel 1 transfer complete and error interrupt
+                DCD     DMA2_IRQHandler                     ;DMA channel 2 transfer complete and error interrupt
+                DCD     DMA3_IRQHandler                     ;DMA channel 3 transfer complete and error interrupt
+                DCD     Reserved20_IRQHandler               ;Reserved interrupt
+                DCD     FTFA_IRQHandler                     ;FTFA command complete and read collision
+                DCD     LVD_LVW_IRQHandler                  ;Low-voltage detect, low-voltage warning
+                DCD     LLWU_IRQHandler                     ;Low Leakage Wakeup
+                DCD     I2C0_IRQHandler                     ;I2C0 interrupt
+                DCD     I2C1_IRQHandler                     ;I2C1 interrupt
+                DCD     SPI0_IRQHandler                     ;SPI0 single interrupt vector for all sources
+                DCD     SPI1_IRQHandler                     ;SPI1 single interrupt vector for all sources
+                DCD     UART0_IRQHandler                    ;UART0 status and error
+                DCD     UART1_IRQHandler                    ;UART1 status and error
+                DCD     UART2_IRQHandler                    ;UART2 status and error
+                DCD     ADC0_IRQHandler                     ;ADC0 interrupt
+                DCD     CMP0_IRQHandler                     ;CMP0 interrupt
+                DCD     TPM0_IRQHandler                     ;TPM0 single interrupt vector for all sources
+                DCD     TPM1_IRQHandler                     ;TPM1 single interrupt vector for all sources
+                DCD     TPM2_IRQHandler                     ;TPM2 single interrupt vector for all sources
+                DCD     RTC_IRQHandler                      ;RTC alarm interrupt
+                DCD     RTC_Seconds_IRQHandler              ;RTC seconds interrupt
+                DCD     PIT_IRQHandler                      ;PIT single interrupt vector for all channels
+                DCD     I2S0_IRQHandler                     ;I2S0 Single interrupt vector for all sources
+                DCD     USB0_IRQHandler                     ;USB0 OTG
+                DCD     DAC0_IRQHandler                     ;DAC0 interrupt
+                DCD     TSI0_IRQHandler                     ;TSI0 interrupt
+                DCD     MCG_IRQHandler                      ;MCG interrupt
+                DCD     LPTMR0_IRQHandler                   ;LPTMR0 interrupt
+                DCD     Reserved45_IRQHandler               ;Reserved interrupt
+                DCD     PORTA_IRQHandler                    ;PORTA pin detect
+                DCD     PORTC_PORTD_IRQHandler              ;Single interrupt vector for PORTC and PORTD pin detect
+__Vectors_End
+
+__Vectors_Size 	EQU     __Vectors_End - __Vectors
+
+; <h> Flash Configuration
+;   <i> 16-byte flash configuration field that stores default protection settings (loaded on reset)
+;   <i> and security information that allows the MCU to restrict access to the FTFL module.
+;   <h> Backdoor Comparison Key
+;     <o0>  Backdoor Comparison Key 0.  <0x0-0xFF:2>
+;     <o1>  Backdoor Comparison Key 1.  <0x0-0xFF:2>
+;     <o2>  Backdoor Comparison Key 2.  <0x0-0xFF:2>
+;     <o3>  Backdoor Comparison Key 3.  <0x0-0xFF:2>
+;     <o4>  Backdoor Comparison Key 4.  <0x0-0xFF:2>
+;     <o5>  Backdoor Comparison Key 5.  <0x0-0xFF:2>
+;     <o6>  Backdoor Comparison Key 6.  <0x0-0xFF:2>
+;     <o7>  Backdoor Comparison Key 7.  <0x0-0xFF:2>
+BackDoorK0      EQU     0xFF
+BackDoorK1      EQU     0xFF
+BackDoorK2      EQU     0xFF
+BackDoorK3      EQU     0xFF
+BackDoorK4      EQU     0xFF
+BackDoorK5      EQU     0xFF
+BackDoorK6      EQU     0xFF
+BackDoorK7      EQU     0xFF
+;   </h>
+;   <h> Program flash protection bytes (FPROT)
+;     <i> Each program flash region can be protected from program and erase operation by setting the associated PROT bit.
+;     <i> Each bit protects a 1/32 region of the program flash memory.
+;     <h> FPROT0
+;       <i> Program Flash Region Protect Register 0
+;       <i> 1/32 - 8/32 region
+;       <o.0>   FPROT0.0
+;       <o.1>   FPROT0.1
+;       <o.2>   FPROT0.2
+;       <o.3>   FPROT0.3
+;       <o.4>   FPROT0.4
+;       <o.5>   FPROT0.5
+;       <o.6>   FPROT0.6
+;       <o.7>   FPROT0.7
+nFPROT0         EQU     0x00
+FPROT0          EQU     nFPROT0:EOR:0xFF
+;     </h>
+;     <h> FPROT1
+;       <i> Program Flash Region Protect Register 1
+;       <i> 9/32 - 16/32 region
+;       <o.0>   FPROT1.0
+;       <o.1>   FPROT1.1
+;       <o.2>   FPROT1.2
+;       <o.3>   FPROT1.3
+;       <o.4>   FPROT1.4
+;       <o.5>   FPROT1.5
+;       <o.6>   FPROT1.6
+;       <o.7>   FPROT1.7
+nFPROT1         EQU     0x00
+FPROT1          EQU     nFPROT1:EOR:0xFF
+;     </h>
+;     <h> FPROT2
+;       <i> Program Flash Region Protect Register 2
+;       <i> 17/32 - 24/32 region
+;       <o.0>   FPROT2.0
+;       <o.1>   FPROT2.1
+;       <o.2>   FPROT2.2
+;       <o.3>   FPROT2.3
+;       <o.4>   FPROT2.4
+;       <o.5>   FPROT2.5
+;       <o.6>   FPROT2.6
+;       <o.7>   FPROT2.7
+nFPROT2         EQU     0x00
+FPROT2          EQU     nFPROT2:EOR:0xFF
+;     </h>
+;     <h> FPROT3
+;       <i> Program Flash Region Protect Register 3
+;       <i> 25/32 - 32/32 region
+;       <o.0>   FPROT3.0
+;       <o.1>   FPROT3.1
+;       <o.2>   FPROT3.2
+;       <o.3>   FPROT3.3
+;       <o.4>   FPROT3.4
+;       <o.5>   FPROT3.5
+;       <o.6>   FPROT3.6
+;       <o.7>   FPROT3.7
+nFPROT3         EQU     0x00
+FPROT3          EQU     nFPROT3:EOR:0xFF
+;     </h>
+;   </h>
+;   <h> Flash nonvolatile option byte (FOPT)
+;     <i> Allows the user to customize the operation of the MCU at boot time.
+;     <o.0> LPBOOT0
+;       <0=> Core and system clock divider (OUTDIV1) is 0x7 (divide by 8) when LPBOOT1=0 or 0x1 (divide by 2) when LPBOOT1=1.
+;       <1=> Core and system clock divider (OUTDIV1) is 0x3 (divide by 4) when LPBOOT1=0 or 0x0 (divide by 1) when LPBOOT1=1.
+;     <o.2> NMI_DIS
+;       <0=> NMI interrupts are always blocked
+;       <1=> NMI_b pin/interrupts reset default to enabled
+;     <o.3> RESET_PIN_CFG
+;       <0=> RESET pin is disabled following a POR and cannot be enabled as reset function
+;       <1=> RESET_b pin is dedicated
+;     <o.4> LPBOOT1
+;       <0=> Core and system clock divider (OUTDIV1) is 0x7 (divide by 8) when LPBOOT0=0 or 0x3 (divide by 4) when LPBOOT0=1.
+;       <1=> Core and system clock divider (OUTDIV1) is 0x1 (divide by 2) when LPBOOT0=0 or 0x0 (divide by 1) when LPBOOT0=1.
+;     <o.5> FAST_INIT
+;       <0=> Slower initialization
+;       <1=> Fast Initialization
+FOPT          EQU     0xFF
+;   </h>
+;   <h> Flash security byte (FSEC)
+;     <i> WARNING: If SEC field is configured as "MCU security status is secure" and MEEN field is configured as "Mass erase is disabled",
+;     <i> MCU's security status cannot be set back to unsecure state since Mass erase via the debugger is blocked !!!
+;     <o.0..1> SEC
+;       <2=> MCU security status is unsecure
+;       <3=> MCU security status is secure
+;         <i> Flash Security
+;     <o.2..3> FSLACC
+;       <2=> Freescale factory access denied
+;       <3=> Freescale factory access granted
+;         <i> Freescale Failure Analysis Access Code
+;     <o.4..5> MEEN
+;       <2=> Mass erase is disabled
+;       <3=> Mass erase is enabled
+;     <o.6..7> KEYEN
+;       <2=> Backdoor key access enabled
+;       <3=> Backdoor key access disabled
+;         <i> Backdoor Key Security Enable
+FSEC          EQU     0xFE
+;   </h>
+; </h>
+                IF      :LNOT::DEF:RAM_TARGET
+                AREA    FlashConfig, DATA, READONLY
+__FlashConfig
+                DCB     BackDoorK0, BackDoorK1, BackDoorK2, BackDoorK3
+                DCB     BackDoorK4, BackDoorK5, BackDoorK6, BackDoorK7
+                DCB     FPROT0    , FPROT1    , FPROT2    , FPROT3
+                DCB     FSEC      , FOPT      , 0xFF      , 0xFF
+                ENDIF
+
+
+                AREA    |.text|, CODE, READONLY
+
+; Reset Handler
+
+Reset_Handler   PROC
+                EXPORT  Reset_Handler             [WEAK]
+                IMPORT  SystemInit
+                IMPORT  init_data_bss
+                IMPORT  __main
+
+                IF      :LNOT::DEF:RAM_TARGET
+                LDR R0, =FlashConfig    ; dummy read, workaround for flashConfig
+                ENDIF
+
+                CPSID   I               ; Mask interrupts
+                LDR     R0, =SystemInit
+                BLX     R0
+                LDR     R0, =init_data_bss
+                BLX     R0
+                CPSIE   i               ; Unmask interrupts
+                LDR     R0, =__main
+                BX      R0
+                ENDP
+
+
+; Dummy Exception Handlers (infinite loops which can be modified)
+NMI_Handler\
+                PROC
+                EXPORT  NMI_Handler         [WEAK]
+                B       .
+                ENDP
+HardFault_Handler\
+                PROC
+                EXPORT  HardFault_Handler         [WEAK]
+                B       .
+                ENDP
+SVC_Handler\
+                PROC
+                EXPORT  SVC_Handler         [WEAK]
+                B       .
+                ENDP
+PendSV_Handler\
+                PROC
+                EXPORT  PendSV_Handler         [WEAK]
+                B       .
+                ENDP
+SysTick_Handler\
+                PROC
+                EXPORT  SysTick_Handler         [WEAK]
+                B       .
+                ENDP
+Default_Handler\
+                PROC
+                EXPORT  DMA0_IRQHandler         [WEAK]
+                EXPORT  DMA1_IRQHandler         [WEAK]
+                EXPORT  DMA2_IRQHandler         [WEAK]
+                EXPORT  DMA3_IRQHandler         [WEAK]
+                EXPORT  Reserved20_IRQHandler         [WEAK]
+                EXPORT  FTFA_IRQHandler         [WEAK]
+                EXPORT  LVD_LVW_IRQHandler         [WEAK]
+                EXPORT  LLWU_IRQHandler         [WEAK]
+                EXPORT  I2C0_IRQHandler         [WEAK]
+                EXPORT  I2C1_IRQHandler         [WEAK]
+                EXPORT  SPI0_IRQHandler         [WEAK]
+                EXPORT  SPI1_IRQHandler         [WEAK]
+                EXPORT  UART0_IRQHandler         [WEAK]
+                EXPORT  UART1_IRQHandler         [WEAK]
+                EXPORT  UART2_IRQHandler         [WEAK]
+                EXPORT  ADC0_IRQHandler         [WEAK]
+                EXPORT  CMP0_IRQHandler         [WEAK]
+                EXPORT  TPM0_IRQHandler         [WEAK]
+                EXPORT  TPM1_IRQHandler         [WEAK]
+                EXPORT  TPM2_IRQHandler         [WEAK]
+                EXPORT  RTC_IRQHandler         [WEAK]
+                EXPORT  RTC_Seconds_IRQHandler         [WEAK]
+                EXPORT  PIT_IRQHandler         [WEAK]
+                EXPORT  I2S0_IRQHandler         [WEAK]
+                EXPORT  USB0_IRQHandler         [WEAK]
+                EXPORT  DAC0_IRQHandler         [WEAK]
+                EXPORT  TSI0_IRQHandler         [WEAK]
+                EXPORT  MCG_IRQHandler         [WEAK]
+                EXPORT  LPTMR0_IRQHandler         [WEAK]
+                EXPORT  Reserved45_IRQHandler         [WEAK]
+                EXPORT  PORTA_IRQHandler         [WEAK]
+                EXPORT  PORTC_PORTD_IRQHandler         [WEAK]
+                EXPORT  DefaultISR         [WEAK]
+DMA0_IRQHandler
+DMA1_IRQHandler
+DMA2_IRQHandler
+DMA3_IRQHandler
+Reserved20_IRQHandler
+FTFA_IRQHandler
+LVD_LVW_IRQHandler
+LLWU_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+SPI0_IRQHandler
+SPI1_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+UART2_IRQHandler
+ADC0_IRQHandler
+CMP0_IRQHandler
+TPM0_IRQHandler
+TPM1_IRQHandler
+TPM2_IRQHandler
+RTC_IRQHandler
+RTC_Seconds_IRQHandler
+PIT_IRQHandler
+I2S0_IRQHandler
+USB0_IRQHandler
+DAC0_IRQHandler
+TSI0_IRQHandler
+MCG_IRQHandler
+LPTMR0_IRQHandler
+Reserved45_IRQHandler
+PORTA_IRQHandler
+PORTC_PORTD_IRQHandler
+DefaultISR
+                LDR    R0, =DefaultISR
+                BX     R0
+                ENDP
+                  ALIGN
+
+
+                END

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_ARM_MICRO/sys.cpp
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_ARM_MICRO/sys.cpp
@@ -1,0 +1,31 @@
+/* mbed Microcontroller Library - stackheap
+ * Copyright (C) 2009-2011 ARM Limited. All rights reserved.
+ * 
+ * Setup a fixed single stack/heap memory model, 
+ *  between the top of the RW/ZI region and the stackpointer
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif 
+
+#include <rt_misc.h>
+#include <stdint.h>
+
+extern char Image$$RW_IRAM1$$ZI$$Limit[];
+
+extern __value_in_regs struct __initial_stackheap __user_setup_stackheap(uint32_t R0, uint32_t R1, uint32_t R2, uint32_t R3) {
+    uint32_t zi_limit = (uint32_t)Image$$RW_IRAM1$$ZI$$Limit;
+    uint32_t sp_limit = __current_sp();
+
+    zi_limit = (zi_limit + 7) & ~0x7;    // ensure zi_limit is 8-byte aligned
+
+    struct __initial_stackheap r;
+    r.heap_base = zi_limit;
+    r.heap_limit = sp_limit;
+    return r;
+}
+
+#ifdef __cplusplus
+}
+#endif 

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_GCC_ARM/MKL26Z4.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_GCC_ARM/MKL26Z4.ld
@@ -1,0 +1,163 @@
+/*
+ * KL25Z ARM GCC linker script file
+ */
+
+MEMORY
+{
+  VECTORS (rx) : ORIGIN = 0x00000000, LENGTH = 0x00000400
+  FLASH_PROTECTION	(rx) : ORIGIN = 0x00000400, LENGTH = 0x00000010
+  FLASH (rx) : ORIGIN = 0x00000410, LENGTH = 128K - 0x00000410
+  RAM (rwx) : ORIGIN = 0x1FFFF0C0, LENGTH = 16K - 0xC0
+}
+
+/* Linker script to place sections and symbol values. Should be used together
+ * with other linker script that defines memory regions FLASH and RAM.
+ * It references following symbols, which must be defined in code:
+ * _reset_init : Entry of reset handler
+ *
+ * It defines following symbols, which code can use without definition:
+ * __exidx_start
+ * __exidx_end
+ * __etext
+ * __data_start__
+ * __preinit_array_start
+ * __preinit_array_end
+ * __init_array_start
+ * __init_array_end
+ * __fini_array_start
+ * __fini_array_end
+ * __data_end__
+ * __bss_start__
+ * __bss_end__
+ * __end__
+ * end
+ * __HeapLimit
+ * __StackLimit
+ * __StackTop
+ * __stack
+ */
+ENTRY(Reset_Handler)
+
+SECTIONS
+{
+    .isr_vector :
+    {
+        __vector_table = .;
+        KEEP(*(.vector_table))
+        *(.text.Reset_Handler)
+        *(.text.System_Init)
+         . = ALIGN(4);
+    } > VECTORS
+
+    .flash_protect :
+    {
+        KEEP(*(.kinetis_flash_config_field))
+         . = ALIGN(4);
+    } > FLASH_PROTECTION
+
+    .text :
+    {
+        *(.text*)
+
+        KEEP(*(.init))
+        KEEP(*(.fini))
+
+        /* .ctors */
+        *crtbegin.o(.ctors)
+        *crtbegin?.o(.ctors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .ctors)
+        *(SORT(.ctors.*))
+        *(.ctors)
+
+        /* .dtors */
+        *crtbegin.o(.dtors)
+        *crtbegin?.o(.dtors)
+        *(EXCLUDE_FILE(*crtend?.o *crtend.o) .dtors)
+        *(SORT(.dtors.*))
+        *(.dtors)
+
+        *(.rodata*)
+
+        KEEP(*(.eh_frame*))
+    } > FLASH
+
+    .ARM.extab :
+    {
+        *(.ARM.extab* .gnu.linkonce.armextab.*)
+    } > FLASH
+
+    __exidx_start = .;
+    .ARM.exidx :
+    {
+        *(.ARM.exidx* .gnu.linkonce.armexidx.*)
+    } > FLASH
+    __exidx_end = .;
+
+    __etext = .;
+
+    .data : AT (__etext)
+    {
+        __data_start__ = .;
+        *(vtable)
+        *(.data*)
+
+        . = ALIGN(4);
+        /* preinit data */
+        PROVIDE_HIDDEN (__preinit_array_start = .);
+        KEEP(*(.preinit_array))
+        PROVIDE_HIDDEN (__preinit_array_end = .);
+
+        . = ALIGN(4);
+        /* init data */
+        PROVIDE_HIDDEN (__init_array_start = .);
+        KEEP(*(SORT(.init_array.*)))
+        KEEP(*(.init_array))
+        PROVIDE_HIDDEN (__init_array_end = .);
+
+
+        . = ALIGN(4);
+        /* finit data */
+        PROVIDE_HIDDEN (__fini_array_start = .);
+        KEEP(*(SORT(.fini_array.*)))
+        KEEP(*(.fini_array))
+        PROVIDE_HIDDEN (__fini_array_end = .);
+
+        . = ALIGN(4);
+        /* All data end */
+        __data_end__ = .;
+
+    } > RAM
+
+    .bss :
+    {
+        __bss_start__ = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end__ = .;
+    } > RAM
+
+    .heap :
+    {
+        __end__ = .;
+        end = __end__;
+        *(.heap*)
+        __HeapLimit = .;
+    } > RAM
+
+    /* .stack_dummy section doesn't contains any symbols. It is only
+     * used for linker to calculate size of stack sections, and assign
+     * values to stack symbols later */
+    .stack_dummy :
+    {
+        *(.stack)
+    } > RAM
+
+    /* Set stack top to end of RAM, and stack limit move down by
+     * size of stack_dummy section */
+    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackLimit = __StackTop - SIZEOF(.stack_dummy);
+    PROVIDE(__stack = __StackTop);
+
+    /* Check if data + heap + stack exceeds RAM limit */
+    ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
+}

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_GCC_ARM/startup_MKL26Z4.S
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_GCC_ARM/startup_MKL26Z4.S
@@ -1,0 +1,192 @@
+/* ---------------------------------------------------------------------------------------*/
+/*  @file:    startup_MKL26Z4.s                                                           */
+/*  @purpose: CMSIS Cortex-M0P Core Device Startup File                                   */
+/*            MKL26Z4                                                                     */
+/*  @version: 1.7                                                                         */
+/*  @date:    2015-2-18                                                                   */
+/*  @build:   b150218                                                                     */
+/* ---------------------------------------------------------------------------------------*/
+/*                                                                                        */
+/* Copyright (c) 1997 - 2015 , Freescale Semiconductor, Inc.                              */
+/* All rights reserved.                                                                   */
+/*                                                                                        */
+/* Redistribution and use in source and binary forms, with or without modification,       */
+/* are permitted provided that the following conditions are met:                          */
+/*                                                                                        */
+/* o Redistributions of source code must retain the above copyright notice, this list     */
+/*   of conditions and the following disclaimer.                                          */
+/*                                                                                        */
+/* o Redistributions in binary form must reproduce the above copyright notice, this       */
+/*   list of conditions and the following disclaimer in the documentation and/or          */
+/*   other materials provided with the distribution.                                      */
+/*                                                                                        */
+/* o Neither the name of Freescale Semiconductor, Inc. nor the names of its               */
+/*   contributors may be used to endorse or promote products derived from this            */
+/*   software without specific prior written permission.                                  */
+/*                                                                                        */
+/* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND        */
+/* ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED          */
+/* WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE                 */
+/* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR       */
+/* ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES         */
+/* (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;           */
+/* LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON         */
+/* ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT                */
+/* (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS          */
+/* SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.                           */
+/*****************************************************************************/
+/* Version: GCC for ARM Embedded Processors                                  */
+/*****************************************************************************/
+    .syntax unified
+    .arch armv6-m
+
+    .section .isr_vector, "a"
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long   __StackTop                                      /* Top of Stack */
+    .long   Reset_Handler                                   /* Reset Handler */
+    .long   NMI_Handler                                     /* NMI Handler*/
+    .long   HardFault_Handler                               /* Hard Fault Handler*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   SVC_Handler                                     /* SVCall Handler*/
+    .long   0                                               /* Reserved*/
+    .long   0                                               /* Reserved*/
+    .long   PendSV_Handler                                  /* PendSV Handler*/
+    .long   SysTick_Handler                                 /* SysTick Handler*/
+
+                                                            /* External Interrupts*/
+    .long   DMA0_IRQHandler                                 /* DMA channel 0 transfer complete and error interrupt*/
+    .long   DMA1_IRQHandler                                 /* DMA channel 1 transfer complete and error interrupt*/
+    .long   DMA2_IRQHandler                                 /* DMA channel 2 transfer complete and error interrupt*/
+    .long   DMA3_IRQHandler                                 /* DMA channel 3 transfer complete and error interrupt*/
+    .long   Reserved20_IRQHandler                           /* Reserved interrupt*/
+    .long   FTFA_IRQHandler                                 /* FTFA command complete and read collision*/
+    .long   LVD_LVW_IRQHandler                              /* Low-voltage detect, low-voltage warning*/
+    .long   LLWU_IRQHandler                                 /* Low Leakage Wakeup*/
+    .long   I2C0_IRQHandler                                 /* I2C0 interrupt*/
+    .long   I2C1_IRQHandler                                 /* I2C1 interrupt*/
+    .long   SPI0_IRQHandler                                 /* SPI0 single interrupt vector for all sources*/
+    .long   SPI1_IRQHandler                                 /* SPI1 single interrupt vector for all sources*/
+    .long   UART0_IRQHandler                                /* UART0 status and error*/
+    .long   UART1_IRQHandler                                /* UART1 status and error*/
+    .long   UART2_IRQHandler                                /* UART2 status and error*/
+    .long   ADC0_IRQHandler                                 /* ADC0 interrupt*/
+    .long   CMP0_IRQHandler                                 /* CMP0 interrupt*/
+    .long   TPM0_IRQHandler                                 /* TPM0 single interrupt vector for all sources*/
+    .long   TPM1_IRQHandler                                 /* TPM1 single interrupt vector for all sources*/
+    .long   TPM2_IRQHandler                                 /* TPM2 single interrupt vector for all sources*/
+    .long   RTC_IRQHandler                                  /* RTC alarm interrupt*/
+    .long   RTC_Seconds_IRQHandler                          /* RTC seconds interrupt*/
+    .long   PIT_IRQHandler                                  /* PIT single interrupt vector for all channels*/
+    .long   I2S0_IRQHandler                                 /* I2S0 Single interrupt vector for all sources*/
+    .long   USB0_IRQHandler                                 /* USB0 OTG*/
+    .long   DAC0_IRQHandler                                 /* DAC0 interrupt*/
+    .long   TSI0_IRQHandler                                 /* TSI0 interrupt*/
+    .long   MCG_IRQHandler                                  /* MCG interrupt*/
+    .long   LPTMR0_IRQHandler                               /* LPTMR0 interrupt*/
+    .long   Reserved45_IRQHandler                           /* Reserved interrupt*/
+    .long   PORTA_IRQHandler                                /* PORTA pin detect*/
+    .long   PORTC_PORTD_IRQHandler                          /* Single interrupt vector for PORTC and PORTD pin detect*/
+
+    .size    __isr_vector, . - __isr_vector
+
+/* Flash Configuration */
+    .section .FlashConfig, "a"
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFF
+    .long 0xFFFFFFFE
+
+    .text
+    .thumb
+
+/* Reset Handler */
+
+    .thumb_func
+    .align 2
+    .globl   Reset_Handler
+    .weak    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+    cpsid   i               /* Mask interrupts */
+#ifndef __NO_SYSTEM_INIT
+    bl SystemInit
+#endif
+    bl init_data_bss
+    cpsie   i               /* Unmask interrupts */
+#ifndef __START
+#define __START _start
+#endif
+#ifndef __ATOLLIC__
+    bl    __START
+#else
+    bl    __libc_init_array
+    bl    main
+#endif
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .align	1
+    .thumb_func
+    .weak DefaultISR
+    .type DefaultISR, %function
+DefaultISR:
+    ldr	r0, =DefaultISR
+    bx r0
+    .size DefaultISR, . - DefaultISR
+
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro def_irq_handler	handler_name
+    .weak \handler_name
+    .set  \handler_name, DefaultISR
+    .endm
+
+/* Exception Handlers */
+    def_irq_handler    NMI_Handler
+    def_irq_handler    HardFault_Handler
+    def_irq_handler    SVC_Handler
+    def_irq_handler    PendSV_Handler
+    def_irq_handler    SysTick_Handler
+    def_irq_handler    DMA0_IRQHandler
+    def_irq_handler    DMA1_IRQHandler
+    def_irq_handler    DMA2_IRQHandler
+    def_irq_handler    DMA3_IRQHandler
+    def_irq_handler    Reserved20_IRQHandler
+    def_irq_handler    FTFA_IRQHandler
+    def_irq_handler    LVD_LVW_IRQHandler
+    def_irq_handler    LLWU_IRQHandler
+    def_irq_handler    I2C0_IRQHandler
+    def_irq_handler    I2C1_IRQHandler
+    def_irq_handler    SPI0_IRQHandler
+    def_irq_handler    SPI1_IRQHandler
+    def_irq_handler    UART0_IRQHandler
+    def_irq_handler    UART1_IRQHandler
+    def_irq_handler    UART2_IRQHandler
+    def_irq_handler    ADC0_IRQHandler
+    def_irq_handler    CMP0_IRQHandler
+    def_irq_handler    TPM0_IRQHandler
+    def_irq_handler    TPM1_IRQHandler
+    def_irq_handler    TPM2_IRQHandler
+    def_irq_handler    RTC_IRQHandler
+    def_irq_handler    RTC_Seconds_IRQHandler
+    def_irq_handler    PIT_IRQHandler
+    def_irq_handler    I2S0_IRQHandler
+    def_irq_handler    USB0_IRQHandler
+    def_irq_handler    DAC0_IRQHandler
+    def_irq_handler    TSI0_IRQHandler
+    def_irq_handler    MCG_IRQHandler
+    def_irq_handler    LPTMR0_IRQHandler
+    def_irq_handler    Reserved45_IRQHandler
+    def_irq_handler    PORTA_IRQHandler
+    def_irq_handler    PORTC_PORTD_IRQHandler
+
+    .end

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_IAR/MKL26Z4.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_IAR/MKL26Z4.icf
@@ -1,0 +1,43 @@
+/*###ICF### Section handled by ICF editor, don't touch! ****/
+/*-Editor annotation file-*/
+/* IcfEditorFile="$TOOLKIT_DIR$\config\ide\IcfEditor\cortex_v1_0.xml" */
+/*-Specials-*/
+define symbol __ICFEDIT_intvec_start__ = 0x00000000;
+/*-Memory Regions-*/
+define symbol __ICFEDIT_region_ROM_start__ = 0x00000000;
+define symbol __ICFEDIT_region_ROM_end__   = 0x0001ffff;
+define symbol __ICFEDIT_region_NVIC_start__   = 0x1ffff000;
+define symbol __ICFEDIT_region_NVIC_end__   = 0x1ffff0bf;
+define symbol __ICFEDIT_region_RAM_start__ = 0x1ffff0c0;
+define symbol __ICFEDIT_region_RAM_end__   = 0x1fffffff;
+/*-Sizes-*/
+/*Heap 1/4 of ram and stack 1/8*/
+define symbol __ICFEDIT_size_cstack__ = 0x800;
+define symbol __ICFEDIT_size_heap__   = 0x1000;
+/**** End of ICF editor section. ###ICF###*/
+
+define symbol __region_RAM2_start__ 		= 0x20000000;
+define symbol __region_RAM2_end__ 			= 0x20002fff;
+
+define symbol __FlashConfig_start__			= 0x00000400;
+define symbol __FlashConfig_end__   		= 0x0000040f;
+
+define memory mem with size = 4G;
+define region ROM_region = mem:[from __ICFEDIT_region_ROM_start__ to (__FlashConfig_start__ - 1)] | mem:[from (__FlashConfig_end__+1)  to __ICFEDIT_region_ROM_end__];
+define region RAM_region = mem:[from __ICFEDIT_region_RAM_start__ to __ICFEDIT_region_RAM_end__] | mem:[from __region_RAM2_start__ to __region_RAM2_end__];
+
+define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
+define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
+
+define region FlashConfig_region = mem:[from __FlashConfig_start__ to __FlashConfig_end__];
+
+initialize by copy { readwrite };
+do not initialize  { section .noinit };
+
+place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
+
+place in FlashConfig_region {section FlashConfig};
+
+place in ROM_region   { readonly };
+
+place in RAM_region   { readwrite, block HEAP, block CSTACK };

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_IAR/startup_MKL26Z4.s
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/TOOLCHAIN_IAR/startup_MKL26Z4.s
@@ -1,0 +1,251 @@
+; ---------------------------------------------------------------------------------------
+;  @file:    startup_MKL26Z4.s
+;  @purpose: CMSIS Cortex-M0P Core Device Startup File
+;            MKL26Z4
+;  @version: 1.7
+;  @date:    2015-2-18
+;  @build:   b150218
+; ---------------------------------------------------------------------------------------
+;
+; Copyright (c) 1997 - 2015 , Freescale Semiconductor, Inc.
+; All rights reserved.
+;
+; Redistribution and use in source and binary forms, with or without modification,
+; are permitted provided that the following conditions are met:
+;
+; o Redistributions of source code must retain the above copyright notice, this list
+;   of conditions and the following disclaimer.
+;
+; o Redistributions in binary form must reproduce the above copyright notice, this
+;   list of conditions and the following disclaimer in the documentation and/or
+;   other materials provided with the distribution.
+;
+; o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+;   contributors may be used to endorse or promote products derived from this
+;   software without specific prior written permission.
+;
+; THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+; ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+; WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+; DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+; ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+; (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+; ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+; (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+;
+; The modules in this file are included in the libraries, and may be replaced
+; by any user-defined modules that define the PUBLIC symbol _program_start or
+; a user defined start symbol.
+; To override the cstartup defined in the library, simply add your modified
+; version to the workbench project.
+;
+; The vector table is normally located at address 0.
+; When debugging in RAM, it can be located in RAM, aligned to at least 2^6.
+; The name "__vector_table" has special meaning for C-SPY:
+; it is where the SP start value is found, and the NVIC vector
+; table register (VTOR) is initialized to this address if != 0.
+;
+; Cortex-M version
+;
+
+        MODULE  ?cstartup
+
+        ;; Forward declaration of sections.
+        SECTION CSTACK:DATA:NOROOT(3)
+
+        SECTION .intvec:CODE:NOROOT(2)
+
+        EXTERN  __iar_program_start
+        EXTERN  SystemInit
+        EXTERN  init_data_bss
+        PUBLIC  __vector_table
+        PUBLIC  __vector_table_0x1c
+        PUBLIC  __Vectors
+        PUBLIC  __Vectors_End
+        PUBLIC  __Vectors_Size
+
+        DATA
+
+__vector_table
+        DCD     sfe(CSTACK)
+        DCD     Reset_Handler
+
+        DCD     NMI_Handler                                   ;NMI Handler
+        DCD     HardFault_Handler                             ;Hard Fault Handler
+        DCD     0                                             ;Reserved
+        DCD     0                                             ;Reserved
+        DCD     0                                             ;Reserved
+__vector_table_0x1c
+        DCD     0                                             ;Reserved
+        DCD     0                                             ;Reserved
+        DCD     0                                             ;Reserved
+        DCD     0                                             ;Reserved
+        DCD     SVC_Handler                                   ;SVCall Handler
+        DCD     0                                             ;Reserved
+        DCD     0                                             ;Reserved
+        DCD     PendSV_Handler                                ;PendSV Handler
+        DCD     SysTick_Handler                               ;SysTick Handler
+
+                                                              ;External Interrupts
+        DCD     DMA0_IRQHandler                               ;DMA channel 0 transfer complete and error interrupt
+        DCD     DMA1_IRQHandler                               ;DMA channel 1 transfer complete and error interrupt
+        DCD     DMA2_IRQHandler                               ;DMA channel 2 transfer complete and error interrupt
+        DCD     DMA3_IRQHandler                               ;DMA channel 3 transfer complete and error interrupt
+        DCD     Reserved20_IRQHandler                         ;Reserved interrupt
+        DCD     FTFA_IRQHandler                               ;FTFA command complete and read collision
+        DCD     LVD_LVW_IRQHandler                            ;Low-voltage detect, low-voltage warning
+        DCD     LLWU_IRQHandler                               ;Low Leakage Wakeup
+        DCD     I2C0_IRQHandler                               ;I2C0 interrupt
+        DCD     I2C1_IRQHandler                               ;I2C1 interrupt
+        DCD     SPI0_IRQHandler                               ;SPI0 single interrupt vector for all sources
+        DCD     SPI1_IRQHandler                               ;SPI1 single interrupt vector for all sources
+        DCD     UART0_IRQHandler                              ;UART0 status and error
+        DCD     UART1_IRQHandler                              ;UART1 status and error
+        DCD     UART2_IRQHandler                              ;UART2 status and error
+        DCD     ADC0_IRQHandler                               ;ADC0 interrupt
+        DCD     CMP0_IRQHandler                               ;CMP0 interrupt
+        DCD     TPM0_IRQHandler                               ;TPM0 single interrupt vector for all sources
+        DCD     TPM1_IRQHandler                               ;TPM1 single interrupt vector for all sources
+        DCD     TPM2_IRQHandler                               ;TPM2 single interrupt vector for all sources
+        DCD     RTC_IRQHandler                                ;RTC alarm interrupt
+        DCD     RTC_Seconds_IRQHandler                        ;RTC seconds interrupt
+        DCD     PIT_IRQHandler                                ;PIT single interrupt vector for all channels
+        DCD     I2S0_IRQHandler                               ;I2S0 Single interrupt vector for all sources
+        DCD     USB0_IRQHandler                               ;USB0 OTG
+        DCD     DAC0_IRQHandler                               ;DAC0 interrupt
+        DCD     TSI0_IRQHandler                               ;TSI0 interrupt
+        DCD     MCG_IRQHandler                                ;MCG interrupt
+        DCD     LPTMR0_IRQHandler                             ;LPTMR0 interrupt
+        DCD     Reserved45_IRQHandler                         ;Reserved interrupt
+        DCD     PORTA_IRQHandler                              ;PORTA pin detect
+        DCD     PORTC_PORTD_IRQHandler                        ;Single interrupt vector for PORTC and PORTD pin detect
+__Vectors_End
+
+        SECTION FlashConfig:CODE
+__FlashConfig
+      	DCD	0xFFFFFFFF
+      	DCD	0xFFFFFFFF
+      	DCD	0xFFFFFFFF
+      	DCD	0xFFFFFFFE
+__FlashConfig_End
+
+__Vectors       EQU   __vector_table
+__Vectors_Size 	EQU   __Vectors_End - __Vectors
+
+
+;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
+;;
+;; Default interrupt handlers.
+;;
+        THUMB
+
+        PUBWEAK Reset_Handler
+        SECTION .text:CODE:REORDER:NOROOT(2)
+Reset_Handler
+        CPSID   I               ; Mask interrupts
+        LDR     R0, =SystemInit
+        BLX     R0
+        LDR     R0, =init_data_bss
+        BLX     R0
+        CPSIE   I               ; Unmask interrupts
+        LDR     R0, =__iar_program_start
+        BX      R0
+
+        PUBWEAK NMI_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+NMI_Handler
+        B .
+
+        PUBWEAK HardFault_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+HardFault_Handler
+        B .
+
+        PUBWEAK SVC_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SVC_Handler
+        B .
+
+        PUBWEAK PendSV_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+PendSV_Handler
+        B .
+
+        PUBWEAK SysTick_Handler
+        SECTION .text:CODE:REORDER:NOROOT(1)
+SysTick_Handler
+        B .
+
+        PUBWEAK DMA0_IRQHandler
+        PUBWEAK DMA1_IRQHandler
+        PUBWEAK DMA2_IRQHandler
+        PUBWEAK DMA3_IRQHandler
+        PUBWEAK Reserved20_IRQHandler
+        PUBWEAK FTFA_IRQHandler
+        PUBWEAK LVD_LVW_IRQHandler
+        PUBWEAK LLWU_IRQHandler
+        PUBWEAK I2C0_IRQHandler
+        PUBWEAK I2C1_IRQHandler
+        PUBWEAK SPI0_IRQHandler
+        PUBWEAK SPI1_IRQHandler
+        PUBWEAK UART0_IRQHandler
+        PUBWEAK UART1_IRQHandler
+        PUBWEAK UART2_IRQHandler
+        PUBWEAK ADC0_IRQHandler
+        PUBWEAK CMP0_IRQHandler
+        PUBWEAK TPM0_IRQHandler
+        PUBWEAK TPM1_IRQHandler
+        PUBWEAK TPM2_IRQHandler
+        PUBWEAK RTC_IRQHandler
+        PUBWEAK RTC_Seconds_IRQHandler
+        PUBWEAK PIT_IRQHandler
+        PUBWEAK I2S0_IRQHandler
+        PUBWEAK USB0_IRQHandler
+        PUBWEAK DAC0_IRQHandler
+        PUBWEAK TSI0_IRQHandler
+        PUBWEAK MCG_IRQHandler
+        PUBWEAK LPTMR0_IRQHandler
+        PUBWEAK Reserved45_IRQHandler
+        PUBWEAK PORTA_IRQHandler
+        PUBWEAK PORTC_PORTD_IRQHandler
+        PUBWEAK DefaultISR
+        SECTION .text:CODE:REORDER:NOROOT(2)
+DMA0_IRQHandler
+DMA1_IRQHandler
+DMA2_IRQHandler
+DMA3_IRQHandler
+Reserved20_IRQHandler
+FTFA_IRQHandler
+LVD_LVW_IRQHandler
+LLWU_IRQHandler
+I2C0_IRQHandler
+I2C1_IRQHandler
+SPI0_IRQHandler
+SPI1_IRQHandler
+UART0_IRQHandler
+UART1_IRQHandler
+UART2_IRQHandler
+ADC0_IRQHandler
+CMP0_IRQHandler
+TPM0_IRQHandler
+TPM1_IRQHandler
+TPM2_IRQHandler
+RTC_IRQHandler
+RTC_Seconds_IRQHandler
+PIT_IRQHandler
+I2S0_IRQHandler
+USB0_IRQHandler
+DAC0_IRQHandler
+TSI0_IRQHandler
+MCG_IRQHandler
+LPTMR0_IRQHandler
+Reserved45_IRQHandler
+PORTA_IRQHandler
+PORTC_PORTD_IRQHandler
+DefaultISR
+        LDR R0, =DefaultISR
+        BX R0
+
+        END

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/cmsis.h
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/cmsis.h
@@ -1,0 +1,13 @@
+/* mbed Microcontroller Library - CMSIS
+ * Copyright (C) 2009-2011 ARM Limited. All rights reserved.
+ * 
+ * A generic CMSIS include header, pulling in LPC11U24 specifics
+ */
+
+#ifndef MBED_CMSIS_H
+#define MBED_CMSIS_H
+
+#include "MKL26Z4.h"
+#include "cmsis_nvic.h"
+
+#endif

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/cmsis_nvic.c
@@ -1,0 +1,55 @@
+/* mbed Microcontroller Library
+ * CMSIS-style functionality to support dynamic vectors
+ *******************************************************************************
+ * Copyright (c) 2011 ARM Limited. All rights reserved.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of ARM Limited nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "cmsis_nvic.h"
+
+#define NVIC_RAM_VECTOR_ADDRESS (0x1FFFF000)  // Vectors positioned at start of RAM
+#define NVIC_FLASH_VECTOR_ADDRESS (0x0)       // Initial vector position in flash
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
+    uint32_t *vectors = (uint32_t*)SCB->VTOR;
+    uint32_t i;
+
+    // Copy and switch to dynamic vectors if the first time called
+    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+        uint32_t *old_vectors = vectors;
+        vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
+        for (i=0; i<NVIC_NUM_VECTORS; i++) {
+            vectors[i] = old_vectors[i];
+        }
+        SCB->VTOR = (uint32_t)NVIC_RAM_VECTOR_ADDRESS;
+    }
+    vectors[IRQn + 16] = vector;
+}
+
+uint32_t NVIC_GetVector(IRQn_Type IRQn) {
+    uint32_t *vectors = (uint32_t*)SCB->VTOR;
+    return vectors[IRQn + 16];
+}

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/cmsis_nvic.h
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/cmsis_nvic.h
@@ -1,0 +1,51 @@
+/* mbed Microcontroller Library
+ * CMSIS-style functionality to support dynamic vectors
+ *******************************************************************************
+ * Copyright (c) 2011 ARM Limited. All rights reserved.
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of ARM Limited nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+
+#ifndef MBED_CMSIS_NVIC_H
+#define MBED_CMSIS_NVIC_H
+
+#define NVIC_NUM_VECTORS      (16 + 32)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t NVIC_GetVector(IRQn_Type IRQn);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/system_MKL26Z4.c
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/system_MKL26Z4.c
@@ -1,0 +1,406 @@
+/*
+** ###################################################################
+**     Processors:          MKL26Z128CAL4
+**                          MKL26Z128VFM4
+**                          MKL26Z64VFM4
+**                          MKL26Z32VM4
+**                          MKL26Z128VFT4
+**                          MKL26Z64VFT4
+**                          MKL26Z32VFT4
+**                          MKL26Z128VLH4
+**                          MKL26Z64VLH4
+**                          MKL26Z32VLH4
+**                          MKL26Z256VLH4
+**                          MKL26Z256VLL4
+**                          MKL26Z128VLL4
+**                          MKL26Z256VMC4
+**                          MKL26Z128VMC4
+**                          MKL26Z256VMP4
+**
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          GNU C Compiler - CodeSourcery Sourcery G++
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manuals:   KL26P121M48SF4RM Rev. 3.2, October 2013
+**                          KL26P121M48SF4RM, Rev.2, Dec 2012
+**
+**     Version:             rev. 1.7, 2015-01-13
+**     Build:               b150129
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright (c) 2015 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2012-12-12)
+**         Initial version.
+**     - rev. 1.1 (2013-04-05)
+**         Changed start of doxygen comment.
+**     - rev. 1.2 (2013-04-12)
+**         SystemInit function fixed for clock configuration 1.
+**         Name of the interrupt num. 31 updated to reflect proper function.
+**     - rev. 1.3 (2014-05-27)
+**         Updated to Kinetis SDK support standard.
+**         MCG OSC clock select supported (MCG_C7[OSCSEL]).
+**     - rev. 1.4 (2014-07-25)
+**         System initialization updated:
+**         - Prefix added to the system initialization parameterization constants to avoid name conflicts..
+**         - VLLSx wake-up recovery added.
+**         - Delay of 1 ms added to SystemInit() to ensure stable FLL output in FEI and FEE MCG modes.
+**     - rev. 1.5 (2014-08-28)
+**         Update of system files - default clock configuration changed, fix of OSC initialization.
+**         Update of startup files - possibility to override DefaultISR added.
+**     - rev. 1.6 (2014-10-14)
+**         Renamed interrupt vector LPTimer to LPTMR0
+**     - rev. 1.7 (2015-01-13)
+**         Update of the copyright.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MKL26Z4
+ * @version 1.7
+ * @date 2015-01-13
+ * @brief Device specific configuration file for MKL26Z4 (implementation file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#include <stdint.h>
+#include "MKL26Z4.h"
+
+
+
+/* ----------------------------------------------------------------------------
+   -- Core clock
+   ---------------------------------------------------------------------------- */
+
+uint32_t SystemCoreClock = DEFAULT_SYSTEM_CLOCK;
+
+/* ----------------------------------------------------------------------------
+   -- SystemInit()
+   ---------------------------------------------------------------------------- */
+
+void SystemInit (void) {
+
+#if (ACK_ISOLATION)
+  if(PMC->REGSC &  PMC_REGSC_ACKISO_MASK) {
+    PMC->REGSC |= PMC_REGSC_ACKISO_MASK; /* VLLSx recovery */
+  }
+#endif
+
+  /* Watchdog disable */
+#if (DISABLE_WDOG)
+  /* SIM_COPC: COPT=0,COPCLKS=0,COPW=0 */
+  SIM->COPC = (uint32_t)0x00u;
+#endif /* (DISABLE_WDOG) */
+
+#ifdef CLOCK_SETUP
+  /* RTC_CLKIN route */
+#if (RTC_CLKIN_USED)
+  /* SIM_SCGC5: PORTC=1 */
+  SIM->SCGC5 |= SIM_SCGC5_PORTC_MASK;
+  /* PORTC_PCR1: ISF=0,MUX=1 */
+  PORTC->PCR[1] = (uint32_t)((PORTC->PCR[1] & (uint32_t)~(uint32_t)(
+                PORT_PCR_ISF_MASK |
+                PORT_PCR_MUX(0x06)
+               )) | (uint32_t)(
+                PORT_PCR_MUX(0x01)
+               ));
+#endif /* (RTC_CLKIN_USED) */
+
+  /* Wake-up from VLLSx? */
+  if((RCM->SRS0 & RCM_SRS0_WAKEUP_MASK) != 0x00U)
+  {
+    /* VLLSx recovery */
+    if((PMC->REGSC & PMC_REGSC_ACKISO_MASK) != 0x00U)
+    {
+       PMC->REGSC |= PMC_REGSC_ACKISO_MASK; /* Release hold with ACKISO: Only has an effect if recovering from VLLSx.*/
+    }
+  }
+
+  /* Power mode protection initialization */
+#ifdef SYSTEM_SMC_PMPROT_VALUE
+  SMC->PMPROT = SYSTEM_SMC_PMPROT_VALUE;
+#endif
+
+  /* System clock initialization */
+  /* Internal reference clock trim initialization */
+#if defined(SLOW_TRIM_ADDRESS)
+  if ( *((uint8_t*)SLOW_TRIM_ADDRESS) != 0xFFU) {                              /* Skip if non-volatile flash memory is erased */
+    MCG->C3 = *((uint8_t*)SLOW_TRIM_ADDRESS);
+#endif /* defined(SLOW_TRIM_ADDRESS) */
+#if defined(SLOW_FINE_TRIM_ADDRESS)
+    MCG->C4 = (MCG->C4 & ~(MCG_C4_SCFTRIM_MASK)) | ((*((uint8_t*) SLOW_FINE_TRIM_ADDRESS)) & MCG_C4_SCFTRIM_MASK);
+#endif
+#if defined(FAST_TRIM_ADDRESS)
+    MCG->C4 = (MCG->C4 & ~(MCG_C4_FCTRIM_MASK)) |((*((uint8_t*) FAST_TRIM_ADDRESS)) & MCG_C4_FCTRIM_MASK);
+#endif
+#if defined(FAST_FINE_TRIM_ADDRESS)
+    MCG->C2 = (MCG->C2 & ~(MCG_C2_FCFTRIM_MASK)) | ((*((uint8_t*)FAST_TRIM_ADDRESS)) & MCG_C2_FCFTRIM_MASK);
+#endif /* defined(FAST_FINE_TRIM_ADDRESS) */
+#if defined(SLOW_TRIM_ADDRESS)
+  }
+#endif /* defined(SLOW_TRIM_ADDRESS) */
+
+  /* Set system prescalers and clock sources */
+  SIM->CLKDIV1 = SYSTEM_SIM_CLKDIV1_VALUE; /* Set system prescalers */
+  SIM->SOPT1 = ((SIM->SOPT1) & (uint32_t)(~(SIM_SOPT1_OSC32KSEL_MASK))) | ((SYSTEM_SIM_SOPT1_VALUE) & (SIM_SOPT1_OSC32KSEL_MASK)); /* Set 32 kHz clock source (ERCLK32K) */
+  SIM->SOPT2 = ((SIM->SOPT2) & (uint32_t)(~(
+                 SIM_SOPT2_TPMSRC_MASK |
+                 SIM_SOPT2_UART0SRC_MASK |
+                 SIM_SOPT2_PLLFLLSEL_MASK |
+                 SIM_SOPT2_USBSRC_MASK
+                 ))) | ((SYSTEM_SIM_SOPT2_VALUE) & (
+                 SIM_SOPT2_TPMSRC_MASK |
+                 SIM_SOPT2_UART0SRC_MASK |
+                 SIM_SOPT2_PLLFLLSEL_MASK |
+                 SIM_SOPT2_USBSRC_MASK
+                 ));   /* Select TPM, LPUARTs, USB clock sources. */
+#if ((MCG_MODE == MCG_MODE_FEI) || (MCG_MODE == MCG_MODE_FBI) || (MCG_MODE == MCG_MODE_BLPI))
+  /* Set MCG and OSC */
+#if  ((((SYSTEM_OSC0_CR_VALUE) & OSC_CR_ERCLKEN_MASK) != 0x00U) || (((SYSTEM_MCG_C5_VALUE) & MCG_C5_PLLCLKEN0_MASK) != 0x00U))
+  /* SIM_SCGC5: PORTA=1 */
+  SIM->SCGC5 |= SIM_SCGC5_PORTA_MASK;
+  /* PORTA_PCR18: ISF=0,MUX=0 */
+  PORTA->PCR[18] &= (uint32_t)~(uint32_t)((PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07)));
+  if (((SYSTEM_MCG_C2_VALUE) & MCG_C2_EREFS0_MASK) != 0x00U) {
+    /* PORTA_PCR19: ISF=0,MUX=0 */
+    PORTA->PCR[19] &= (uint32_t)~(uint32_t)((PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07)));
+  }
+#endif
+  MCG->SC = SYSTEM_MCG_SC_VALUE;       /* Set SC (fast clock internal reference divider) */
+  MCG->C1 = SYSTEM_MCG_C1_VALUE;       /* Set C1 (clock source selection, FLL ext. reference divider, int. reference enable etc.) */
+  /* Check that the source of the FLL reference clock is the requested one. */
+  if (((SYSTEM_MCG_C1_VALUE) & MCG_C1_IREFS_MASK) != 0x00U) {
+    while((MCG->S & MCG_S_IREFST_MASK) == 0x00U) {
+    }
+  } else {
+    while((MCG->S & MCG_S_IREFST_MASK) != 0x00U) {
+    }
+  }
+  MCG->C2 = (MCG->C2 & (uint8_t)(~(MCG_C2_FCFTRIM_MASK))) | (SYSTEM_MCG_C2_VALUE & (uint8_t)(~(MCG_C2_LP_MASK))); /* Set C2 (freq. range, ext. and int. reference selection etc. excluding trim bits; low power bit is set later) */
+  MCG->C4 = ((SYSTEM_MCG_C4_VALUE) & (uint8_t)(~(MCG_C4_FCTRIM_MASK | MCG_C4_SCFTRIM_MASK))) | (MCG->C4 & (MCG_C4_FCTRIM_MASK | MCG_C4_SCFTRIM_MASK)); /* Set C4 (FLL output; trim values not changed) */
+  OSC0->CR = SYSTEM_OSC0_CR_VALUE;     /* Set OSC_CR (OSCERCLK enable, oscillator capacitor load) */
+
+#else /* MCG_MODE */
+  /* Set MCG and OSC */
+  /* SIM_SCGC5: PORTA=1 */
+  SIM->SCGC5 |= SIM_SCGC5_PORTA_MASK;
+  /* PORTA_PCR18: ISF=0,MUX=0 */
+  PORTA->PCR[18] &= (uint32_t)~(uint32_t)((PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07)));
+  if (((SYSTEM_MCG_C2_VALUE) & MCG_C2_EREFS0_MASK) != 0x00U) {
+    /* PORTA_PCR19: ISF=0,MUX=0 */
+    PORTA->PCR[19] &= (uint32_t)~(uint32_t)((PORT_PCR_ISF_MASK | PORT_PCR_MUX(0x07)));
+  }
+  MCG->SC = SYSTEM_MCG_SC_VALUE;       /* Set SC (fast clock internal reference divider) */
+  MCG->C2 = (MCG->C2 & (uint8_t)(~(MCG_C2_FCFTRIM_MASK))) | (SYSTEM_MCG_C2_VALUE & (uint8_t)(~(MCG_C2_LP_MASK))); /* Set C2 (freq. range, ext. and int. reference selection etc. excluding trim bits; low power bit is set later) */
+  OSC0->CR = SYSTEM_OSC0_CR_VALUE;     /* Set OSC_CR (OSCERCLK enable, oscillator capacitor load) */
+  #if (MCG_MODE == MCG_MODE_PEE)
+  MCG->C1 = (SYSTEM_MCG_C1_VALUE) | MCG_C1_CLKS(0x02); /* Set C1 (clock source selection, FLL ext. reference divider, int. reference enable etc.) - PBE mode*/
+  #else
+  MCG->C1 = SYSTEM_MCG_C1_VALUE;       /* Set C1 (clock source selection, FLL ext. reference divider, int. reference enable etc.) */
+  #endif
+  if (((SYSTEM_MCG_C2_VALUE) & MCG_C2_EREFS0_MASK) != 0x00U) {
+    while((MCG->S & MCG_S_OSCINIT0_MASK) == 0x00U) { /* Check that the oscillator is running */
+    }
+  }
+  /* Check that the source of the FLL reference clock is the requested one. */
+  if (((SYSTEM_MCG_C1_VALUE) & MCG_C1_IREFS_MASK) != 0x00U) {
+    while((MCG->S & MCG_S_IREFST_MASK) == 0x00U) {
+    }
+  } else {
+    while((MCG->S & MCG_S_IREFST_MASK) != 0x00U) {
+    }
+  }
+  MCG->C4 = ((SYSTEM_MCG_C4_VALUE)  & (uint8_t)(~(MCG_C4_FCTRIM_MASK | MCG_C4_SCFTRIM_MASK))) | (MCG->C4 & (MCG_C4_FCTRIM_MASK | MCG_C4_SCFTRIM_MASK)); /* Set C4 (FLL output; trim values not changed) */
+#endif /* MCG_MODE */
+
+  /* Common for all MCG modes */
+
+  /* PLL clock can be used to generate clock for some devices regardless of clock generator (MCGOUTCLK) mode. */
+  MCG->C5 = (SYSTEM_MCG_C5_VALUE) & (uint8_t)(~(MCG_C5_PLLCLKEN0_MASK)); /* Set C5 (PLL settings, PLL reference divider etc.) */
+  MCG->C6 = (SYSTEM_MCG_C6_VALUE) & (uint8_t)~(MCG_C6_PLLS_MASK); /* Set C6 (PLL select, VCO divider etc.) */
+  if ((SYSTEM_MCG_C5_VALUE) & MCG_C5_PLLCLKEN0_MASK) {
+    MCG->C5 |= MCG_C5_PLLCLKEN0_MASK;  /* PLL clock enable in mode other than PEE or PBE */
+  }
+
+  /* BLPI and BLPE MCG mode specific */
+#if ((MCG_MODE == MCG_MODE_BLPI) || (MCG_MODE == MCG_MODE_BLPE))
+  MCG->C2 |= (MCG_C2_LP_MASK);         /* Disable FLL and PLL in bypass mode */
+  /* PEE and PBE MCG mode specific */
+#elif ((MCG_MODE == MCG_MODE_PBE) || (MCG_MODE == MCG_MODE_PEE))
+  MCG->C6 |= (MCG_C6_PLLS_MASK);       /* Set C6 (PLL select, VCO divider etc.) */
+  while((MCG->S & MCG_S_LOCK0_MASK) == 0x00U) { /* Wait until PLL is locked*/
+  }
+  #if (MCG_MODE == MCG_MODE_PEE)
+  MCG->C1 &= (uint8_t)~(MCG_C1_CLKS_MASK);
+  #endif
+#endif
+
+  /* Clock mode status check */
+#if ((MCG_MODE == MCG_MODE_FEI) || (MCG_MODE == MCG_MODE_FEE))
+  while((MCG->S & MCG_S_CLKST_MASK) != 0x00U) { /* Wait until output of the FLL is selected */
+  }
+  /* Use LPTMR to wait for 1ms for FLL clock stabilization */
+  SIM->SCGC5 |= SIM_SCGC5_LPTMR_MASK;  /* Allow software control of LPMTR */
+  LPTMR0->CMR = LPTMR_CMR_COMPARE(0);  /* Default 1 LPO tick */
+  LPTMR0->CSR = (LPTMR_CSR_TCF_MASK | LPTMR_CSR_TPS(0x00));
+  LPTMR0->PSR = (LPTMR_PSR_PCS(0x01) | LPTMR_PSR_PBYP_MASK); /* Clock source: LPO, Prescaler bypass enable */
+  LPTMR0->CSR = LPTMR_CSR_TEN_MASK;    /* LPMTR enable */
+  while((LPTMR0->CSR & LPTMR_CSR_TCF_MASK) == 0u) {
+  }
+  LPTMR0->CSR = 0x00;                  /* Disable LPTMR */
+  SIM->SCGC5 &= (uint32_t)~(uint32_t)SIM_SCGC5_LPTMR_MASK;
+#elif ((MCG_MODE == MCG_MODE_FBI) || (MCG_MODE == MCG_MODE_BLPI))
+  while((MCG->S & MCG_S_CLKST_MASK) != 0x04U) { /* Wait until internal reference clock is selected as MCG output */
+  }
+#elif ((MCG_MODE == MCG_MODE_FBE) || (MCG_MODE == MCG_MODE_PBE) || (MCG_MODE == MCG_MODE_BLPE))
+  while((MCG->S & MCG_S_CLKST_MASK) != 0x08U) { /* Wait until external reference clock is selected as MCG output */
+  }
+#elif (MCG_MODE == MCG_MODE_PEE)
+  while((MCG->S & MCG_S_CLKST_MASK) != 0x0CU) { /* Wait until output of the PLL is selected */
+  }
+#endif
+
+  /* Very-low-power run mode enable */
+#if (((SYSTEM_SMC_PMCTRL_VALUE) & SMC_PMCTRL_RUNM_MASK) == (0x02U << SMC_PMCTRL_RUNM_SHIFT))
+  SMC->PMCTRL = (uint8_t)((SYSTEM_SMC_PMCTRL_VALUE) & (SMC_PMCTRL_RUNM_MASK)); /* Enable VLPR mode */
+  while(SMC->PMSTAT != 0x04U) {        /* Wait until the system is in VLPR mode */
+  }
+#endif
+
+  /* PLL loss of lock interrupt request initialization */
+  if (((SYSTEM_MCG_C6_VALUE) & MCG_C6_LOLIE0_MASK) != 0U) {
+    NVIC_EnableIRQ(MCG_IRQn);          /* Enable PLL loss of lock interrupt request */
+  }
+#endif //#ifdef CLOCK_SETUP
+
+}
+
+/* ----------------------------------------------------------------------------
+   -- SystemCoreClockUpdate()
+   ---------------------------------------------------------------------------- */
+
+void SystemCoreClockUpdate (void) {
+
+    uint32_t MCGOUTClock;                /* Variable to store output clock frequency of the MCG module */
+  uint16_t Divider;
+
+  if ((MCG->C1 & MCG_C1_CLKS_MASK) == 0x00U) {
+    /* Output of FLL or PLL is selected */
+    if ((MCG->C6 & MCG_C6_PLLS_MASK) == 0x00U) {
+      /* FLL is selected */
+      if ((MCG->C1 & MCG_C1_IREFS_MASK) == 0x00U) {
+        /* External reference clock is selected */
+        MCGOUTClock = CPU_XTAL_CLK_HZ; /* System oscillator drives MCG clock */
+        if ((MCG->C2 & MCG_C2_RANGE0_MASK) != 0x00U) {
+          switch (MCG->C1 & MCG_C1_FRDIV_MASK) {
+          case 0x38U:
+            Divider = 1536U;
+            break;
+          case 0x30U:
+            Divider = 1280U;
+            break;
+          default:
+            Divider = (uint16_t)(32LU << ((MCG->C1 & MCG_C1_FRDIV_MASK) >> MCG_C1_FRDIV_SHIFT));
+            break;
+          }
+        } else {/* ((MCG->C2 & MCG_C2_RANGE_MASK) != 0x00U) */
+          Divider = (uint16_t)(1LU << ((MCG->C1 & MCG_C1_FRDIV_MASK) >> MCG_C1_FRDIV_SHIFT));
+        }
+        MCGOUTClock = (MCGOUTClock / Divider); /* Calculate the divided FLL reference clock */
+      } else { /* (!((MCG->C1 & MCG_C1_IREFS_MASK) == 0x00U)) */
+        MCGOUTClock = CPU_INT_SLOW_CLK_HZ; /* The slow internal reference clock is selected */
+      } /* (!((MCG->C1 & MCG_C1_IREFS_MASK) == 0x00U)) */
+      /* Select correct multiplier to calculate the MCG output clock  */
+      switch (MCG->C4 & (MCG_C4_DMX32_MASK | MCG_C4_DRST_DRS_MASK)) {
+        case 0x00U:
+          MCGOUTClock *= 640U;
+          break;
+        case 0x20U:
+          MCGOUTClock *= 1280U;
+          break;
+        case 0x40U:
+          MCGOUTClock *= 1920U;
+          break;
+        case 0x60U:
+          MCGOUTClock *= 2560U;
+          break;
+        case 0x80U:
+          MCGOUTClock *= 732U;
+          break;
+        case 0xA0U:
+          MCGOUTClock *= 1464U;
+          break;
+        case 0xC0U:
+          MCGOUTClock *= 2197U;
+          break;
+        case 0xE0U:
+          MCGOUTClock *= 2929U;
+          break;
+        default:
+          break;
+      }
+    } else { /* (!((MCG->C6 & MCG_C6_PLLS_MASK) == 0x00U)) */
+      /* PLL is selected */
+      Divider = (((uint16_t)MCG->C5 & MCG_C5_PRDIV0_MASK) + 0x01U);
+      MCGOUTClock = (uint32_t)(CPU_XTAL_CLK_HZ / Divider); /* Calculate the PLL reference clock */
+      Divider = (((uint16_t)MCG->C6 & MCG_C6_VDIV0_MASK) + 24U);
+      MCGOUTClock *= Divider;          /* Calculate the MCG output clock */
+    } /* (!((MCG->C6 & MCG_C6_PLLS_MASK) == 0x00U)) */
+  } else if ((MCG->C1 & MCG_C1_CLKS_MASK) == 0x40U) {
+    /* Internal reference clock is selected */
+    if ((MCG->C2 & MCG_C2_IRCS_MASK) == 0x00U) {
+      MCGOUTClock = CPU_INT_SLOW_CLK_HZ; /* Slow internal reference clock selected */
+    } else { /* (!((MCG->C2 & MCG_C2_IRCS_MASK) == 0x00U)) */
+      Divider = (uint16_t)(0x01LU << ((MCG->SC & MCG_SC_FCRDIV_MASK) >> MCG_SC_FCRDIV_SHIFT));
+      MCGOUTClock = (uint32_t) (CPU_INT_FAST_CLK_HZ / Divider); /* Fast internal reference clock selected */
+    } /* (!((MCG->C2 & MCG_C2_IRCS_MASK) == 0x00U)) */
+  } else if ((MCG->C1 & MCG_C1_CLKS_MASK) == 0x80U) {
+    /* External reference clock is selected */
+    MCGOUTClock = CPU_XTAL_CLK_HZ;   /* System oscillator drives MCG clock */
+  } else { /* (!((MCG->C1 & MCG_C1_CLKS_MASK) == 0x80U)) */
+    /* Reserved value */
+    return;
+  } /* (!((MCG->C1 & MCG_C1_CLKS_MASK) == 0x80U)) */
+  SystemCoreClock = (MCGOUTClock / (0x01U + ((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV1_MASK) >> SIM_CLKDIV1_OUTDIV1_SHIFT)));
+
+}

--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/system_MKL26Z4.h
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/system_MKL26Z4.h
@@ -1,0 +1,351 @@
+/*
+** ###################################################################
+**     Processors:          MKL26Z128CAL4
+**                          MKL26Z128VFM4
+**                          MKL26Z64VFM4
+**                          MKL26Z32VM4
+**                          MKL26Z128VFT4
+**                          MKL26Z64VFT4
+**                          MKL26Z32VFT4
+**                          MKL26Z128VLH4
+**                          MKL26Z64VLH4
+**                          MKL26Z32VLH4
+**                          MKL26Z256VLH4
+**                          MKL26Z256VLL4
+**                          MKL26Z128VLL4
+**                          MKL26Z256VMC4
+**                          MKL26Z128VMC4
+**                          MKL26Z256VMP4
+**
+**     Compilers:           Keil ARM C/C++ Compiler
+**                          Freescale C/C++ for Embedded ARM
+**                          GNU C Compiler
+**                          GNU C Compiler - CodeSourcery Sourcery G++
+**                          IAR ANSI C/C++ Compiler for ARM
+**
+**     Reference manuals:   KL26P121M48SF4RM Rev. 3.2, October 2013
+**                          KL26P121M48SF4RM, Rev.2, Dec 2012
+**
+**     Version:             rev. 1.7, 2015-01-13
+**     Build:               b150129
+**
+**     Abstract:
+**         Provides a system configuration function and a global variable that
+**         contains the system frequency. It configures the device and initializes
+**         the oscillator (PLL) that is part of the microcontroller device.
+**
+**     Copyright (c) 2015 Freescale Semiconductor, Inc.
+**     All rights reserved.
+**
+**     Redistribution and use in source and binary forms, with or without modification,
+**     are permitted provided that the following conditions are met:
+**
+**     o Redistributions of source code must retain the above copyright notice, this list
+**       of conditions and the following disclaimer.
+**
+**     o Redistributions in binary form must reproduce the above copyright notice, this
+**       list of conditions and the following disclaimer in the documentation and/or
+**       other materials provided with the distribution.
+**
+**     o Neither the name of Freescale Semiconductor, Inc. nor the names of its
+**       contributors may be used to endorse or promote products derived from this
+**       software without specific prior written permission.
+**
+**     THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+**     ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+**     WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+**     DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+**     ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+**     (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+**     LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+**     ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+**     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+**     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+**
+**     http:                 www.freescale.com
+**     mail:                 support@freescale.com
+**
+**     Revisions:
+**     - rev. 1.0 (2012-12-12)
+**         Initial version.
+**     - rev. 1.1 (2013-04-05)
+**         Changed start of doxygen comment.
+**     - rev. 1.2 (2013-04-12)
+**         SystemInit function fixed for clock configuration 1.
+**         Name of the interrupt num. 31 updated to reflect proper function.
+**     - rev. 1.3 (2014-05-27)
+**         Updated to Kinetis SDK support standard.
+**         MCG OSC clock select supported (MCG_C7[OSCSEL]).
+**     - rev. 1.4 (2014-07-25)
+**         System initialization updated:
+**         - Prefix added to the system initialization parameterization constants to avoid name conflicts..
+**         - VLLSx wake-up recovery added.
+**         - Delay of 1 ms added to SystemInit() to ensure stable FLL output in FEI and FEE MCG modes.
+**     - rev. 1.5 (2014-08-28)
+**         Update of system files - default clock configuration changed, fix of OSC initialization.
+**         Update of startup files - possibility to override DefaultISR added.
+**     - rev. 1.6 (2014-10-14)
+**         Renamed interrupt vector LPTimer to LPTMR0
+**     - rev. 1.7 (2015-01-13)
+**         Update of the copyright.
+**
+** ###################################################################
+*/
+
+/*!
+ * @file MKL26Z4
+ * @version 1.7
+ * @date 2015-01-13
+ * @brief Device specific configuration file for MKL26Z4 (header file)
+ *
+ * Provides a system configuration function and a global variable that contains
+ * the system frequency. It configures the device and initializes the oscillator
+ * (PLL) that is part of the microcontroller device.
+ */
+
+#ifndef SYSTEM_MKL26Z4_H_
+#define SYSTEM_MKL26Z4_H_                        /**< Symbol preventing repeated inclusion */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+
+#ifndef DISABLE_WDOG
+  #define DISABLE_WDOG                 1
+#endif
+
+#define ACK_ISOLATION                  1
+
+#ifndef RTC_CLKIN_USED
+  #define RTC_CLKIN_USED               1
+#endif
+
+
+/* MCG mode constants */
+
+#define MCG_MODE_FEI                   0U
+#define MCG_MODE_FBI                   1U
+#define MCG_MODE_BLPI                  2U
+#define MCG_MODE_FEE                   3U
+#define MCG_MODE_FBE                   4U
+#define MCG_MODE_BLPE                  5U
+#define MCG_MODE_PBE                   6U
+#define MCG_MODE_PEE                   7U
+
+/* Predefined clock setups
+   0 ... Default part configuration
+         Multipurpose Clock Generator (MCG) in FEI mode.
+         Reference clock source for MCG module: Slow internal reference clock
+         Core clock = 20.97152MHz
+         Bus clock  = 20.97152MHz
+   1 ... Maximum achievable clock frequency configuration
+         Multipurpose Clock Generator (MCG) in PEE mode.
+         Reference clock source for MCG module: System oscillator reference clock
+         Core clock = 48MHz
+         Bus clock  = 24MHz
+   2 ... Chip internally clocked, ready for Very Low Power Run mode
+         Multipurpose Clock Generator (MCG) in BLPI mode.
+         Reference clock source for MCG module: Fast internal reference clock
+         Core clock = 4MHz
+         Bus clock  = 0.8MHz
+   3 ... Chip externally clocked, ready for Very Low Power Run mode
+         Multipurpose Clock Generator (MCG) in BLPE mode.
+         Reference clock source for MCG module: System oscillator reference clock
+         Core clock = 4MHz
+         Bus clock  = 1MHz
+   4 ... USB clock setup
+         Multipurpose Clock Generator (MCG) in PEE mode.
+         Reference clock source for MCG module: System oscillator reference clock
+         Core clock = 48MHz
+         Bus clock  = 24MHz
+*/
+
+/* Define clock source values */
+
+#define CPU_XTAL_CLK_HZ                8000000U            /* Value of the external crystal or oscillator clock frequency of the system oscillator (OSC) in Hz */
+#define CPU_INT_SLOW_CLK_HZ            32768U              /* Value of the slow internal oscillator clock frequency in Hz */
+#define CPU_INT_FAST_CLK_HZ            4000000U            /* Value of the fast internal oscillator clock frequency in Hz */
+
+/* RTC oscillator setting */
+
+/* Low power mode enable */
+/* SMC_PMPROT: AVLP=1,ALLS=1,AVLLS=1 */
+#define SYSTEM_SMC_PMPROT_VALUE        0x2AU               /* SMC_PMPROT */
+
+/* Internal reference clock trim */
+/* #undef SLOW_TRIM_ADDRESS */                             /* Slow oscillator not trimmed. Commented out for MISRA compliance. */
+/* #undef SLOW_FINE_TRIM_ADDRESS */                        /* Slow oscillator not trimmed. Commented out for MISRA compliance. */
+/* #undef FAST_TRIM_ADDRESS */                             /* Fast oscillator not trimmed. Commented out for MISRA compliance. */
+/* #undef FAST_FINE_TRIM_ADDRESS */                        /* Fast oscillator not trimmed. Commented out for MISRA compliance. */
+
+#ifdef CLOCK_SETUP
+#if (CLOCK_SETUP == 0)
+  #define DEFAULT_SYSTEM_CLOCK         20971520U           /* Default System clock value */
+  #define MCG_MODE                     MCG_MODE_FEI /* Clock generator mode */
+  /* MCG_C1: CLKS=0,FRDIV=0,IREFS=1,IRCLKEN=1,IREFSTEN=0 */
+  #define SYSTEM_MCG_C1_VALUE          0x06U               /* MCG_C1 */
+  /* MCG_C2: LOCRE0=0,FCFTRIM=0,RANGE0=2,HGO0=0,EREFS0=1,LP=0,IRCS=0 */
+  #define SYSTEM_MCG_C2_VALUE          0x24U               /* MCG_C2 */
+  /* MCG_C4: DMX32=0,DRST_DRS=0,FCTRIM=0,SCFTRIM=0 */
+  #define SYSTEM_MCG_C4_VALUE          0x00U               /* MCG_C4 */
+  /* MCG_SC: ATME=0,ATMS=0,ATMF=0,FLTPRSRV=0,FCRDIV=0,LOCS0=0 */
+  #define SYSTEM_MCG_SC_VALUE          0x00U               /* MCG_SC */
+  /* MCG_C5: PLLCLKEN0=0,PLLSTEN0=0,PRDIV0=0 */
+  #define SYSTEM_MCG_C5_VALUE          0x00U               /* MCG_C5 */
+  /* MCG_C6: LOLIE0=0,PLLS=0,CME0=0,VDIV0=0 */
+  #define SYSTEM_MCG_C6_VALUE          0x00U               /* MCG_C6 */
+  /* OSC0_CR: ERCLKEN=1,EREFSTEN=0,SC2P=0,SC4P=0,SC8P=0,SC16P=0 */
+  #define SYSTEM_OSC0_CR_VALUE         0x80U               /* OSC0_CR */
+  /* SMC_PMCTRL: RUNM=0,STOPA=0,STOPM=0 */
+  #define SYSTEM_SMC_PMCTRL_VALUE      0x00U               /* SMC_PMCTRL */
+  /* SIM_CLKDIV1: OUTDIV1=0,OUTDIV4=0 */
+  #define SYSTEM_SIM_CLKDIV1_VALUE     0x00U               /* SIM_CLKDIV1 */
+  /* SIM_SOPT1: USBREGEN=0,USBSSTBY=0,USBVSTBY=0,OSC32KSEL=3 */
+  #define SYSTEM_SIM_SOPT1_VALUE       0x000C0000U         /* SIM_SOPT1 */
+  /* SIM_SOPT2: UART0SRC=0,TPMSRC=1,USBSRC=0,PLLFLLSEL=0,CLKOUTSEL=0,RTCCLKOUTSEL=0 */
+  #define SYSTEM_SIM_SOPT2_VALUE       0x01000000U         /* SIM_SOPT2 */
+#elif (CLOCK_SETUP == 1)
+  #define DEFAULT_SYSTEM_CLOCK         48000000U           /* Default System clock value */
+  #define MCG_MODE                     MCG_MODE_PEE /* Clock generator mode */
+  /* MCG_C1: CLKS=0,FRDIV=3,IREFS=0,IRCLKEN=1,IREFSTEN=0 */
+  #define SYSTEM_MCG_C1_VALUE          0x1AU               /* MCG_C1 */
+  /* MCG_C2: LOCRE0=0,FCFTRIM=0,RANGE0=2,HGO0=0,EREFS0=1,LP=0,IRCS=0 */
+  #define SYSTEM_MCG_C2_VALUE          0x24U               /* MCG_C2 */
+  /* MCG_C4: DMX32=0,DRST_DRS=0,FCTRIM=0,SCFTRIM=0 */
+  #define SYSTEM_MCG_C4_VALUE          0x00U               /* MCG_C4 */
+  /* MCG_SC: ATME=0,ATMS=0,ATMF=0,FLTPRSRV=0,FCRDIV=0,LOCS0=0 */
+  #define SYSTEM_MCG_SC_VALUE          0x00U               /* MCG_SC */
+  /* MCG_C5: PLLCLKEN0=0,PLLSTEN0=0,PRDIV0=3 */
+  #define SYSTEM_MCG_C5_VALUE          0x03U               /* MCG_C5 */
+  /* MCG_C6: LOLIE0=0,PLLS=1,CME0=0,VDIV0=0 */
+  #define SYSTEM_MCG_C6_VALUE          0x40U               /* MCG_C6 */
+  /* OSC0_CR: ERCLKEN=1,EREFSTEN=0,SC2P=0,SC4P=0,SC8P=0,SC16P=0 */
+  #define SYSTEM_OSC0_CR_VALUE         0x80U               /* OSC0_CR */
+  /* SMC_PMCTRL: RUNM=0,STOPA=0,STOPM=0 */
+  #define SYSTEM_SMC_PMCTRL_VALUE      0x00U               /* SMC_PMCTRL */
+  /* SIM_CLKDIV1: OUTDIV1=0,OUTDIV4=1 */
+  #define SYSTEM_SIM_CLKDIV1_VALUE     0x00010000U         /* SIM_CLKDIV1 */
+  /* SIM_SOPT1: USBREGEN=0,USBSSTBY=0,USBVSTBY=0,OSC32KSEL=3 */
+  #define SYSTEM_SIM_SOPT1_VALUE       0x000C0000U         /* SIM_SOPT1 */
+  /* SIM_SOPT2: UART0SRC=0,TPMSRC=1,USBSRC=0,PLLFLLSEL=1,CLKOUTSEL=0,RTCCLKOUTSEL=0 */
+  #define SYSTEM_SIM_SOPT2_VALUE       0x01010000U         /* SIM_SOPT2 */
+#elif (CLOCK_SETUP == 2)
+  #define DEFAULT_SYSTEM_CLOCK         4000000U            /* Default System clock value */
+  #define MCG_MODE                     MCG_MODE_BLPI /* Clock generator mode */
+  /* MCG_C1: CLKS=1,FRDIV=0,IREFS=1,IRCLKEN=1,IREFSTEN=0 */
+  #define SYSTEM_MCG_C1_VALUE          0x46U               /* MCG_C1 */
+  /* MCG_C2: LOCRE0=0,FCFTRIM=0,RANGE0=2,HGO0=0,EREFS0=1,LP=1,IRCS=1 */
+  #define SYSTEM_MCG_C2_VALUE          0x27U               /* MCG_C2 */
+  /* MCG_C4: DMX32=0,DRST_DRS=0,FCTRIM=0,SCFTRIM=0 */
+  #define SYSTEM_MCG_C4_VALUE          0x00U               /* MCG_C4 */
+  /* MCG_SC: ATME=0,ATMS=0,ATMF=0,FLTPRSRV=0,FCRDIV=0,LOCS0=0 */
+  #define SYSTEM_MCG_SC_VALUE          0x00U               /* MCG_SC */
+  /* MCG_C5: PLLCLKEN0=0,PLLSTEN0=0,PRDIV0=0 */
+  #define SYSTEM_MCG_C5_VALUE          0x00U               /* MCG_C5 */
+  /* MCG_C6: LOLIE0=0,PLLS=0,CME0=0,VDIV0=0 */
+  #define SYSTEM_MCG_C6_VALUE          0x00U               /* MCG_C6 */
+  /* OSC0_CR: ERCLKEN=1,EREFSTEN=0,SC2P=0,SC4P=0,SC8P=0,SC16P=0 */
+  #define SYSTEM_OSC0_CR_VALUE         0x80U               /* OSC0_CR */
+  /* SMC_PMCTRL: RUNM=0,STOPA=0,STOPM=0 */
+  #define SYSTEM_SMC_PMCTRL_VALUE      0x00U               /* SMC_PMCTRL */
+  /* SIM_CLKDIV1: OUTDIV1=0,OUTDIV4=4 */
+  #define SYSTEM_SIM_CLKDIV1_VALUE     0x00040000U         /* SIM_CLKDIV1 */
+  /* SIM_SOPT1: USBREGEN=0,USBSSTBY=0,USBVSTBY=0,OSC32KSEL=3 */
+  #define SYSTEM_SIM_SOPT1_VALUE       0x000C0000U         /* SIM_SOPT1 */
+  /* SIM_SOPT2: UART0SRC=0,TPMSRC=2,USBSRC=0,PLLFLLSEL=0,CLKOUTSEL=0,RTCCLKOUTSEL=0 */
+  #define SYSTEM_SIM_SOPT2_VALUE       0x02000000U         /* SIM_SOPT2 */
+#elif (CLOCK_SETUP == 3)
+  #define DEFAULT_SYSTEM_CLOCK         4000000U            /* Default System clock value */
+  #define MCG_MODE                     MCG_MODE_BLPE /* Clock generator mode */
+  /* MCG_C1: CLKS=2,FRDIV=3,IREFS=0,IRCLKEN=1,IREFSTEN=0 */
+  #define SYSTEM_MCG_C1_VALUE          0x9AU               /* MCG_C1 */
+  /* MCG_C2: LOCRE0=0,FCFTRIM=0,RANGE0=2,HGO0=0,EREFS0=1,LP=1,IRCS=1 */
+  #define SYSTEM_MCG_C2_VALUE          0x27U               /* MCG_C2 */
+  /* MCG_C4: DMX32=0,DRST_DRS=0,FCTRIM=0,SCFTRIM=0 */
+  #define SYSTEM_MCG_C4_VALUE          0x00U               /* MCG_C4 */
+  /* MCG_SC: ATME=0,ATMS=0,ATMF=0,FLTPRSRV=0,FCRDIV=0,LOCS0=0 */
+  #define SYSTEM_MCG_SC_VALUE          0x00U               /* MCG_SC */
+  /* MCG_C5: PLLCLKEN0=0,PLLSTEN0=0,PRDIV0=0 */
+  #define SYSTEM_MCG_C5_VALUE          0x00U               /* MCG_C5 */
+  /* MCG_C6: LOLIE0=0,PLLS=0,CME0=0,VDIV0=0 */
+  #define SYSTEM_MCG_C6_VALUE          0x00U               /* MCG_C6 */
+  /* OSC0_CR: ERCLKEN=1,EREFSTEN=0,SC2P=0,SC4P=0,SC8P=0,SC16P=0 */
+  #define SYSTEM_OSC0_CR_VALUE         0x80U               /* OSC0_CR */
+  /* SMC_PMCTRL: RUNM=0,STOPA=0,STOPM=0 */
+  #define SYSTEM_SMC_PMCTRL_VALUE      0x00U               /* SMC_PMCTRL */
+  /* SIM_CLKDIV1: OUTDIV1=1,OUTDIV4=3 */
+  #define SYSTEM_SIM_CLKDIV1_VALUE     0x10030000U         /* SIM_CLKDIV1 */
+  /* SIM_SOPT1: USBREGEN=0,USBSSTBY=0,USBVSTBY=0,OSC32KSEL=3 */
+  #define SYSTEM_SIM_SOPT1_VALUE       0x000C0000U         /* SIM_SOPT1 */
+  /* SIM_SOPT2: UART0SRC=0,TPMSRC=2,USBSRC=0,PLLFLLSEL=0,CLKOUTSEL=0,RTCCLKOUTSEL=0 */
+  #define SYSTEM_SIM_SOPT2_VALUE       0x02000000U         /* SIM_SOPT2 */
+#elif (CLOCK_SETUP == 4)
+  #define DEFAULT_SYSTEM_CLOCK         48000000U           /* Default System clock value */
+  #define MCG_MODE                     MCG_MODE_PEE /* Clock generator mode */
+  /* MCG_C1: CLKS=0,FRDIV=3,IREFS=0,IRCLKEN=1,IREFSTEN=0 */
+  #define SYSTEM_MCG_C1_VALUE          0x1AU               /* MCG_C1 */
+  /* MCG_C2: LOCRE0=0,FCFTRIM=0,RANGE0=2,HGO0=0,EREFS0=1,LP=0,IRCS=0 */
+  #define SYSTEM_MCG_C2_VALUE          0x24U               /* MCG_C2 */
+  /* MCG_C4: DMX32=0,DRST_DRS=0,FCTRIM=0,SCFTRIM=0 */
+  #define SYSTEM_MCG_C4_VALUE          0x00U               /* MCG_C4 */
+  /* MCG_SC: ATME=0,ATMS=0,ATMF=0,FLTPRSRV=0,FCRDIV=0,LOCS0=0 */
+  #define SYSTEM_MCG_SC_VALUE          0x00U               /* MCG_SC */
+  /* MCG_C5: PLLCLKEN0=0,PLLSTEN0=0,PRDIV0=3 */
+  #define SYSTEM_MCG_C5_VALUE          0x03U               /* MCG_C5 */
+  /* MCG_C6: LOLIE0=0,PLLS=1,CME0=0,VDIV0=24 */
+  #define SYSTEM_MCG_C6_VALUE          0x58U               /* MCG_C6 */
+  /* OSC0_CR: ERCLKEN=1,EREFSTEN=0,SC2P=0,SC4P=0,SC8P=0,SC16P=0 */
+  #define SYSTEM_OSC0_CR_VALUE         0x80U               /* OSC0_CR */
+  /* SMC_PMCTRL: RUNM=0,STOPA=0,STOPM=0 */
+  #define SYSTEM_SMC_PMCTRL_VALUE      0x00U               /* SMC_PMCTRL */
+  /* SIM_CLKDIV1: OUTDIV1=1,OUTDIV4=1 */
+  #define SYSTEM_SIM_CLKDIV1_VALUE     0x10010000U         /* SIM_CLKDIV1 */
+  /* SIM_SOPT1: USBREGEN=0,USBSSTBY=0,USBVSTBY=0,OSC32KSEL=3 */
+  #define SYSTEM_SIM_SOPT1_VALUE       0x000C0000U         /* SIM_SOPT1 */
+  /* SIM_SOPT2: UART0SRC=0,TPMSRC=1,USBSRC=0,PLLFLLSEL=1,CLKOUTSEL=0,RTCCLKOUTSEL=0 */
+  #define SYSTEM_SIM_SOPT2_VALUE       0x01010000U         /* SIM_SOPT2 */
+#else
+  #error The selected clock setup is not supported.
+#endif
+#else //#ifdef CLOCK_SETUP
+  #define DEFAULT_SYSTEM_CLOCK         20971520U           /* Default System clock value */
+#endif //#ifdef CLOCK_SETUP
+
+
+/**
+ * @brief System clock frequency (core clock)
+ *
+ * The system clock frequency supplied to the SysTick timer and the processor
+ * core clock. This variable can be used by the user application to setup the
+ * SysTick timer or configure other parameters. It may also be used by debugger to
+ * query the frequency of the debug timer or configure the trace clock speed
+ * SystemCoreClock is initialized with a correct predefined value.
+ */
+extern uint32_t SystemCoreClock;
+
+/**
+ * @brief Setup the microcontroller system.
+ *
+ * Typically this function configures the oscillator (PLL) that is part of the
+ * microcontroller device. For systems with variable clock speed it also updates
+ * the variable SystemCoreClock. SystemInit is called from startup_device file.
+ */
+void SystemInit (void);
+
+/**
+ * @brief Updates the SystemCoreClock variable.
+ *
+ * It must be called whenever the core clock is changed during program
+ * execution. SystemCoreClockUpdate() evaluates the clock register settings and calculates
+ * the current core clock.
+ */
+void SystemCoreClockUpdate (void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  /* #if !defined(SYSTEM_MKL26Z4_H_) */

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/PeripheralNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/PeripheralNames.h
@@ -1,0 +1,95 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PERIPHERALNAMES_H
+#define MBED_PERIPHERALNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    OSC32KCLK = 0,
+    RTC_CLKIN = 2
+} RTCName;
+
+typedef enum {
+    UART_0 = (int)UART0_BASE,
+    UART_1 = (int)UART1_BASE,
+    UART_2 = (int)UART2_BASE
+} UARTName;
+#define STDIO_UART_TX     USBTX
+#define STDIO_UART_RX     USBRX
+#define STDIO_UART        UART_0
+
+typedef enum {
+    I2C_0 = (int)I2C0_BASE,
+    I2C_1 = (int)I2C1_BASE,
+} I2CName;
+
+#define TPM_SHIFT   8
+typedef enum {
+    PWM_1  = (0 << TPM_SHIFT) | (0),  // TPM0 CH0
+    PWM_2  = (0 << TPM_SHIFT) | (1),  // TPM0 CH1
+    PWM_3  = (0 << TPM_SHIFT) | (2),  // TPM0 CH2
+    PWM_4  = (0 << TPM_SHIFT) | (3),  // TPM0 CH3
+    PWM_5  = (0 << TPM_SHIFT) | (4),  // TPM0 CH4
+    PWM_6  = (0 << TPM_SHIFT) | (5),  // TPM0 CH5
+
+    PWM_7  = (1 << TPM_SHIFT) | (0),  // TPM1 CH0
+    PWM_8  = (1 << TPM_SHIFT) | (1),  // TPM1 CH1
+
+    PWM_9  = (2 << TPM_SHIFT) | (0),  // TPM2 CH0
+    PWM_10 = (2 << TPM_SHIFT) | (1)   // TPM2 CH1
+} PWMName;
+
+#define CHANNELS_A_SHIFT    5
+typedef enum {
+    ADC0_SE0  =  0,
+    ADC0_SE3  =  3,
+    ADC0_SE4a =  (1 << CHANNELS_A_SHIFT) | (4),
+    ADC0_SE4b =  4,
+    ADC0_SE5b =  5,
+    ADC0_SE6b =  6,
+    ADC0_SE7a =  (1 << CHANNELS_A_SHIFT) | (7),
+    ADC0_SE7b =  7,
+    ADC0_SE8  =  8,
+    ADC0_SE9  =  9,
+    ADC0_SE11 = 11,
+    ADC0_SE12 = 12,
+    ADC0_SE13 = 13,
+    ADC0_SE14 = 14,
+    ADC0_SE15 = 15,
+    ADC0_SE23 = 23
+} ADCName;
+
+typedef enum {
+    DAC_0 = 0
+} DACName;
+
+
+typedef enum {
+    SPI_0 = (int)SPI0_BASE,
+    SPI_1 = (int)SPI1_BASE,
+} SPIName;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/PeripheralPins.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/PeripheralPins.c
@@ -1,0 +1,197 @@
+
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+ 
+#include "PeripheralPins.h"
+
+/************RTC***************/
+const PinMap PinMap_RTC[] = {
+    {PTC1, RTC_CLKIN, 1},
+};
+
+/************ADC***************/
+const PinMap PinMap_ADC[] = {
+    {PTE20, ADC0_SE0,  0},
+    {PTE22, ADC0_SE3,  0},
+    {PTE21, ADC0_SE4a, 0},
+    {PTE29, ADC0_SE4b, 0},
+    {PTE30, ADC0_SE23, 0},
+    {PTE23, ADC0_SE7a, 0},
+    {PTB0,  ADC0_SE8,  0},
+    {PTB1,  ADC0_SE9,  0},
+    {PTB2,  ADC0_SE12, 0},
+    {PTB3,  ADC0_SE13, 0},
+    {PTC0,  ADC0_SE14, 0},
+    {PTC1,  ADC0_SE15, 0},
+    {PTC2,  ADC0_SE11, 0},
+    {PTD1,  ADC0_SE5b, 0},
+    {PTD5,  ADC0_SE6b, 0},
+    {PTD6,  ADC0_SE7b, 0},
+    {NC,    NC,        0}
+};
+
+/************DAC***************/
+const PinMap PinMap_DAC[] = {
+    {PTE30, DAC_0, 0},
+    {NC   , NC   , 0}
+};
+
+/************I2C***************/
+const PinMap PinMap_I2C_SDA[] = {
+    {PTE25, I2C_0, 5},
+    {PTC9,  I2C_0, 2},
+    {PTE0,  I2C_1, 6},
+    {PTB1,  I2C_0, 2},
+    {PTB3,  I2C_0, 2},
+    {PTC11, I2C_1, 2},
+    {PTC2,  I2C_1, 2},
+    {PTA4,  I2C_1, 2},
+    {NC  ,  NC   , 0}
+};
+
+const PinMap PinMap_I2C_SCL[] = {
+    {PTE24, I2C_0, 5},
+    {PTC8,  I2C_0, 2},
+    {PTE1,  I2C_1, 6},
+    {PTB0,  I2C_0, 2},
+    {PTB2,  I2C_0, 2},
+    {PTC10, I2C_1, 2},
+    {PTC1,  I2C_1, 2},
+    {NC  ,  NC,    0}
+};
+
+/************UART***************/
+const PinMap PinMap_UART_TX[] = {
+    {PTC4,  UART_1, 3},
+    {PTA2,  UART_0, 2},
+    {PTD5,  UART_2, 3},
+    {PTD3,  UART_2, 3},
+    {PTD7,  UART_0, 3},
+    {PTE20, UART_0, 4},
+    {PTE22, UART_2, 4},
+    {PTE0,  UART_1, 3},
+    {NC  ,  NC    , 0}
+};
+
+const PinMap PinMap_UART_RX[] = {
+    {PTC3,  UART_1, 3},
+    {PTA1,  UART_0, 2},
+    {PTD4,  UART_2, 3},
+    {PTD2,  UART_2, 3},
+    {PTD6,  UART_0, 3},
+    {PTE23, UART_2, 4},
+    {PTE21, UART_0, 4},
+    {PTE1,  UART_1, 3},
+    {NC  ,  NC    , 0}
+};
+
+/************SPI***************/
+const PinMap PinMap_SPI_SCLK[] = {
+    {PTA15, SPI_0, 2},
+    {PTB11, SPI_1, 2},
+    {PTC5,  SPI_0, 2},
+    {PTD1,  SPI_0, 2},
+    {PTD5,  SPI_1, 2},
+    {PTE2,  SPI_1, 2},
+    {NC  ,  NC   , 0}
+};
+
+const PinMap PinMap_SPI_MOSI[] = {
+    {PTA16, SPI_0, 2},
+    {PTA17, SPI_0, 5},
+    {PTB16, SPI_1, 2},
+    {PTB17, SPI_1, 5},
+    {PTC6,  SPI_0, 2},
+    {PTC7,  SPI_0, 5},
+    {PTD2,  SPI_0, 2},
+    {PTD3,  SPI_0, 5},
+    {PTD6,  SPI_1, 2},
+    {PTD7,  SPI_1, 5},
+    {PTE1,  SPI_1, 2},
+    {PTE3,  SPI_1, 5},
+    {NC  ,  NC   , 0}
+};
+
+const PinMap PinMap_SPI_MISO[] = {
+    {PTA16, SPI_0, 5},
+    {PTA17, SPI_0, 2},
+    {PTB16, SPI_1, 5},
+    {PTB17, SPI_1, 2},
+    {PTC6,  SPI_0, 5},
+    {PTC7,  SPI_0, 2},
+    {PTD2,  SPI_0, 5},
+    {PTD3,  SPI_0, 2},
+    {PTD6,  SPI_1, 5},
+    {PTD7,  SPI_1, 2},
+    {PTE1,  SPI_1, 5},
+    {PTE3,  SPI_1, 2},
+    {NC   , NC   , 0}
+};
+
+const PinMap PinMap_SPI_SSEL[] = {
+    {PTA14, SPI_0, 2},
+    {PTB10, SPI_1, 2},
+    {PTC4,  SPI_0, 2},
+    {PTD0,  SPI_0, 2},
+    {PTD4,  SPI_1, 2},
+    {PTE4,  SPI_1, 2},
+    {NC  ,  NC   , 0}
+};
+
+/************PWM***************/
+const PinMap PinMap_PWM[] = {
+    {PTA0,  PWM_6,  3}, // PTA0 , TPM0 CH5    
+    {PTA1,  PWM_9 , 3}, // PTA1 , TPM2 CH0
+    {PTA2,  PWM_10, 3}, // PTA2 , TPM2 CH1
+    {PTA3,  PWM_1,  3}, // PTA3 , TPM0 CH0
+    {PTA4,  PWM_2 , 3}, // PTA4 , TPM0 CH1
+    {PTA5,  PWM_3 , 3}, // PTA5 , TPM0 CH2
+    {PTA12, PWM_7 , 3}, // PTA12, TPM1 CH0
+    {PTA13, PWM_8 , 3}, // PTA13, TPM1 CH1  
+    
+    {PTB0,  PWM_7,  3}, // PTB0 , TPM1 CH0
+    {PTB1,  PWM_8,  3}, // PTB1 , TPM1 CH1
+    {PTB2,  PWM_9,  3}, // PTB2 , TPM2 CH0
+    {PTB3,  PWM_10, 3}, // PTB3 , TPM2 CH1
+    {PTB18, PWM_9,  3}, // PTB18, TPM2 CH0
+    {PTB19, PWM_10, 3}, // PTB18, TPM2 CH1
+
+    {PTC1,  PWM_1,  4}, // PTC1 , TPM0 CH0
+    {PTC2,  PWM_2,  4}, // PTC2 , TPM0 CH1
+    {PTC3,  PWM_3,  4}, // PTC3 , TPM0 CH2
+    {PTC4,  PWM_4,  4}, // PTC4 , TPM0 CH3
+    {PTC8,  PWM_5 , 3}, // PTC8 , TPM0 CH4
+    {PTC9,  PWM_6 , 3}, // PTC9 , TPM0 CH5    
+    
+    {PTD0,  PWM_1 , 4}, // PTD0 , TPM0 CH0
+    {PTD1,  PWM_2 , 4}, // PTD0 , TPM0 CH1
+    {PTD2,  PWM_3 , 4}, // PTD2 , TPM0 CH2
+    {PTD3,  PWM_4 , 4}, // PTD3 , TPM0 CH3    
+    {PTD4,  PWM_5 , 4}, // PTD4 , TPM0 CH4
+    {PTD5,  PWM_6 , 4}, // PTD5 , TPM0 CH5
+
+    {PTE20, PWM_7,  3}, // PTE20, TPM1 CH0
+    {PTE21, PWM_8,  3}, // PTE21, TPM1 CH1
+    {PTE22, PWM_9,  3}, // PTE22, TPM2 CH0
+    {PTE23, PWM_10, 3}, // PTE23, TPM2 CH1
+    {PTE24, PWM_1,  3}, // PTE24, TPM0 CH0
+    {PTE25, PWM_2,  3}, // PTE25, TPM0 CH1
+    {PTE26, PWM_6,  3}, // PTE26, TPM0 CH5
+    {PTE29, PWM_3,  3}, // PTE29, TPM0 CH2
+    {PTE30, PWM_4,  3}, // PTE30, TPM0 CH3
+    {PTE31, PWM_5,  3}, // PTE31, TPM0 CH4
+    {NC   , NC,     0}
+};

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/PinNames.h
@@ -1,0 +1,254 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  12
+
+typedef enum {
+    PTA0 = 0x0,
+    PTA1 = 0x4,
+    PTA2 = 0x8,
+    PTA3 = 0xc,
+    PTA4 = 0x10,
+    PTA5 = 0x14,
+    PTA6 = 0x18,
+    PTA7 = 0x1c,
+    PTA8 = 0x20,
+    PTA9 = 0x24,
+    PTA10 = 0x28,
+    PTA11 = 0x2c,
+    PTA12 = 0x30,
+    PTA13 = 0x34,
+    PTA14 = 0x38,
+    PTA15 = 0x3c,
+    PTA16 = 0x40,
+    PTA17 = 0x44,
+    PTA18 = 0x48,
+    PTA19 = 0x4c,
+    PTA20 = 0x50,
+    PTA21 = 0x54,
+    PTA22 = 0x58,
+    PTA23 = 0x5c,
+    PTA24 = 0x60,
+    PTA25 = 0x64,
+    PTA26 = 0x68,
+    PTA27 = 0x6c,
+    PTA28 = 0x70,
+    PTA29 = 0x74,
+    PTA30 = 0x78,
+    PTA31 = 0x7c,
+    PTB0 = 0x1000,
+    PTB1 = 0x1004,
+    PTB2 = 0x1008,
+    PTB3 = 0x100c,
+    PTB4 = 0x1010,
+    PTB5 = 0x1014,
+    PTB6 = 0x1018,
+    PTB7 = 0x101c,
+    PTB8 = 0x1020,
+    PTB9 = 0x1024,
+    PTB10 = 0x1028,
+    PTB11 = 0x102c,
+    PTB12 = 0x1030,
+    PTB13 = 0x1034,
+    PTB14 = 0x1038,
+    PTB15 = 0x103c,
+    PTB16 = 0x1040,
+    PTB17 = 0x1044,
+    PTB18 = 0x1048,
+    PTB19 = 0x104c,
+    PTB20 = 0x1050,
+    PTB21 = 0x1054,
+    PTB22 = 0x1058,
+    PTB23 = 0x105c,
+    PTB24 = 0x1060,
+    PTB25 = 0x1064,
+    PTB26 = 0x1068,
+    PTB27 = 0x106c,
+    PTB28 = 0x1070,
+    PTB29 = 0x1074,
+    PTB30 = 0x1078,
+    PTB31 = 0x107c,
+    PTC0 = 0x2000,
+    PTC1 = 0x2004,
+    PTC2 = 0x2008,
+    PTC3 = 0x200c,
+    PTC4 = 0x2010,
+    PTC5 = 0x2014,
+    PTC6 = 0x2018,
+    PTC7 = 0x201c,
+    PTC8 = 0x2020,
+    PTC9 = 0x2024,
+    PTC10 = 0x2028,
+    PTC11 = 0x202c,
+    PTC12 = 0x2030,
+    PTC13 = 0x2034,
+    PTC14 = 0x2038,
+    PTC15 = 0x203c,
+    PTC16 = 0x2040,
+    PTC17 = 0x2044,
+    PTC18 = 0x2048,
+    PTC19 = 0x204c,
+    PTC20 = 0x2050,
+    PTC21 = 0x2054,
+    PTC22 = 0x2058,
+    PTC23 = 0x205c,
+    PTC24 = 0x2060,
+    PTC25 = 0x2064,
+    PTC26 = 0x2068,
+    PTC27 = 0x206c,
+    PTC28 = 0x2070,
+    PTC29 = 0x2074,
+    PTC30 = 0x2078,
+    PTC31 = 0x207c,
+    PTD0 = 0x3000,
+    PTD1 = 0x3004,
+    PTD2 = 0x3008,
+    PTD3 = 0x300c,
+    PTD4 = 0x3010,
+    PTD5 = 0x3014,
+    PTD6 = 0x3018,
+    PTD7 = 0x301c,
+    PTD8 = 0x3020,
+    PTD9 = 0x3024,
+    PTD10 = 0x3028,
+    PTD11 = 0x302c,
+    PTD12 = 0x3030,
+    PTD13 = 0x3034,
+    PTD14 = 0x3038,
+    PTD15 = 0x303c,
+    PTD16 = 0x3040,
+    PTD17 = 0x3044,
+    PTD18 = 0x3048,
+    PTD19 = 0x304c,
+    PTD20 = 0x3050,
+    PTD21 = 0x3054,
+    PTD22 = 0x3058,
+    PTD23 = 0x305c,
+    PTD24 = 0x3060,
+    PTD25 = 0x3064,
+    PTD26 = 0x3068,
+    PTD27 = 0x306c,
+    PTD28 = 0x3070,
+    PTD29 = 0x3074,
+    PTD30 = 0x3078,
+    PTD31 = 0x307c,
+    PTE0 = 0x4000,
+    PTE1 = 0x4004,
+    PTE2 = 0x4008,
+    PTE3 = 0x400c,
+    PTE4 = 0x4010,
+    PTE5 = 0x4014,
+    PTE6 = 0x4018,
+    PTE7 = 0x401c,
+    PTE8 = 0x4020,
+    PTE9 = 0x4024,
+    PTE10 = 0x4028,
+    PTE11 = 0x402c,
+    PTE12 = 0x4030,
+    PTE13 = 0x4034,
+    PTE14 = 0x4038,
+    PTE15 = 0x403c,
+    PTE16 = 0x4040,
+    PTE17 = 0x4044,
+    PTE18 = 0x4048,
+    PTE19 = 0x404c,
+    PTE20 = 0x4050,
+    PTE21 = 0x4054,
+    PTE22 = 0x4058,
+    PTE23 = 0x405c,
+    PTE24 = 0x4060,
+    PTE25 = 0x4064,
+    PTE26 = 0x4068,
+    PTE27 = 0x406c,
+    PTE28 = 0x4070,
+    PTE29 = 0x4074,
+    PTE30 = 0x4078,
+    PTE31 = 0x407c,
+
+    LED_RED = PTE29,
+    LED_GREEN = PTE31,
+    LED_BLUE = PTD5,
+
+    // mbed original LED naming
+    LED1 = LED_RED,
+    LED2 = LED_GREEN,
+    LED3 = LED_BLUE,
+    LED4 = LED_BLUE,
+
+    // USB Pins
+    USBTX = PTA2,
+    USBRX = PTA1,
+
+    // Arduino Headers
+    D0 = PTA1,
+    D1 = PTA2,
+    D2 = PTD3,
+    D3 = PTA12,
+    D4 = PTA4,
+    D5 = PTA5,
+    D6 = PTC8,
+    D7 = PTC9,
+    D8 = PTA13,
+    D9 = PTD2,
+    D10 = PTD4,
+    D11 = PTD6,
+    D12 = PTD7,
+    D13 = PTD5,
+    D14 = PTE0,
+    D15 = PTE1,
+
+    A0 = PTB0,
+    A1 = PTB1,
+    A2 = PTB2,
+    A3 = PTB3,
+    A4 = PTC2,
+    A5 = PTC1,
+
+    I2C_SCL = D15,
+    I2C_SDA = D14,
+
+    TSI_ELEC0 = PTB16,
+    TSI_ELEC1 = PTB17,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+/* PullDown not available for KL25 */
+typedef enum {
+    PullNone = 0,
+    PullUp = 2,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/device.h
@@ -1,0 +1,58 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#define DEVICE_PORTIN           1
+#define DEVICE_PORTOUT          1
+#define DEVICE_PORTINOUT        1
+
+#define DEVICE_INTERRUPTIN      1
+
+#define DEVICE_ANALOGIN         1
+#define DEVICE_ANALOGOUT        1
+
+#define DEVICE_SERIAL           1
+
+#define DEVICE_I2C              1
+#define DEVICE_I2CSLAVE         1
+
+#define DEVICE_SPI              1
+#define DEVICE_SPISLAVE         1
+
+#define DEVICE_CAN              0
+
+#define DEVICE_RTC              1
+
+#define DEVICE_ETHERNET         0
+
+#define DEVICE_PWMOUT           1
+
+#define DEVICE_SEMIHOST         1
+#define DEVICE_LOCALFILESYSTEM  0
+#define DEVICE_ID_LENGTH       24
+
+#define DEVICE_SLEEP            1
+
+#define DEVICE_DEBUG_AWARENESS  0
+
+#define DEVICE_STDIO_MESSAGES   1
+
+#define DEVICE_ERROR_RED        1
+
+#include "objects.h"
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/gpio_irq_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/gpio_irq_api.c
@@ -1,0 +1,170 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <stddef.h>
+#include "cmsis.h"
+
+#include "gpio_irq_api.h"
+#include "gpio_api.h"
+#include "mbed_error.h"
+
+#define CHANNEL_NUM    64
+
+static uint32_t channel_ids[CHANNEL_NUM] = {0};
+static gpio_irq_handler irq_handler;
+
+#define IRQ_DISABLED        (0)
+#define IRQ_RAISING_EDGE    PORT_PCR_IRQC(9)
+#define IRQ_FALLING_EDGE    PORT_PCR_IRQC(10)
+#define IRQ_EITHER_EDGE     PORT_PCR_IRQC(11)
+
+const uint32_t search_bits[] = {0x0000FFFF, 0x000000FF, 0x0000000F, 0x00000003, 0x00000001};
+
+static void handle_interrupt_in(PORT_Type *port, int ch_base) {
+    uint32_t isfr;
+    uint8_t location;
+
+    while((isfr = port->ISFR) != 0) {
+        location = 0;
+        for (int i = 0; i < 5; i++) {
+            if (!(isfr & (search_bits[i] << location)))
+                location += 1 << (4 - i);
+        }
+        
+        uint32_t id = channel_ids[ch_base + location];
+        if (id == 0) {
+            continue;
+        }
+
+        FGPIO_Type *gpio;
+        gpio_irq_event event = IRQ_NONE;
+        switch (port->PCR[location] & PORT_PCR_IRQC_MASK) {
+            case IRQ_RAISING_EDGE:
+                event = IRQ_RISE;
+                break;
+
+            case IRQ_FALLING_EDGE:
+                event = IRQ_FALL;
+                break;
+
+            case IRQ_EITHER_EDGE:
+                gpio = (port == PORTA) ? (FPTA) : (FPTD);
+                event = (gpio->PDIR & (1 << location)) ? (IRQ_RISE) : (IRQ_FALL);
+                break;
+        }
+        if (event != IRQ_NONE) {
+            irq_handler(id, event);
+        }
+        port->ISFR = 1 << location;
+    }
+}
+
+void gpio_irqA(void) {handle_interrupt_in(PORTA, 0);}
+void gpio_irqD(void) {handle_interrupt_in(PORTD, 32);}
+
+int gpio_irq_init(gpio_irq_t *obj, PinName pin, gpio_irq_handler handler, uint32_t id) {
+    if (pin == NC) return -1;
+
+    irq_handler = handler;
+
+    obj->port = pin >> PORT_SHIFT;
+    obj->pin = (pin & 0x7F) >> 2;
+
+    uint32_t ch_base, vector;
+    IRQn_Type irq_n;
+    switch (obj->port) {
+            case PortA:
+                ch_base = 0;  irq_n = PORTA_IRQn; vector = (uint32_t)gpio_irqA;
+                break;
+
+            case PortD:
+                ch_base = 32; irq_n = PORTD_IRQn; vector = (uint32_t)gpio_irqD;
+                break;
+
+            default:
+                error("gpio_irq only supported on port A and D");
+                break;
+    }
+    NVIC_SetVector(irq_n, vector);
+    NVIC_EnableIRQ(irq_n);
+
+    obj->ch = ch_base + obj->pin;
+    channel_ids[obj->ch] = id;
+
+    return 0;
+}
+
+void gpio_irq_free(gpio_irq_t *obj) {
+    channel_ids[obj->ch] = 0;
+}
+
+void gpio_irq_set(gpio_irq_t *obj, gpio_irq_event event, uint32_t enable) {
+    PORT_Type *port = (PORT_Type *)(PORTA_BASE + 0x1000 * obj->port);
+
+    uint32_t irq_settings = IRQ_DISABLED;
+
+    switch (port->PCR[obj->pin] & PORT_PCR_IRQC_MASK) {
+        case IRQ_DISABLED:
+            if (enable) {
+                irq_settings = (event == IRQ_RISE) ? (IRQ_RAISING_EDGE) : (IRQ_FALLING_EDGE);
+            }
+            break;
+
+        case IRQ_RAISING_EDGE:
+            if (enable) {
+                irq_settings = (event == IRQ_RISE) ? (IRQ_RAISING_EDGE) : (IRQ_EITHER_EDGE);
+            } else {
+                if (event == IRQ_FALL)
+                    irq_settings = IRQ_RAISING_EDGE;
+            }
+            break;
+
+        case IRQ_FALLING_EDGE:
+            if (enable) {
+                irq_settings = (event == IRQ_FALL) ? (IRQ_FALLING_EDGE) : (IRQ_EITHER_EDGE);
+            } else {
+                if (event == IRQ_RISE)
+                    irq_settings = IRQ_FALLING_EDGE;
+            }
+            break;
+
+        case IRQ_EITHER_EDGE:
+            if (enable) {
+                irq_settings = IRQ_EITHER_EDGE;
+            } else {
+                irq_settings = (event == IRQ_RISE) ? (IRQ_FALLING_EDGE) : (IRQ_RAISING_EDGE);
+            }
+            break;
+    }
+
+    // Interrupt configuration and clear interrupt
+    port->PCR[obj->pin] = (port->PCR[obj->pin] & ~PORT_PCR_IRQC_MASK) | irq_settings | PORT_PCR_ISF_MASK;
+}
+
+void gpio_irq_enable(gpio_irq_t *obj) {
+    if (obj->port == PortA) {
+        NVIC_EnableIRQ(PORTA_IRQn);
+    } else if (obj->port == PortD) {
+        NVIC_EnableIRQ(PORTD_IRQn);
+    }
+}
+
+void gpio_irq_disable(gpio_irq_t *obj) {
+    if (obj->port == PortA) {
+        NVIC_DisableIRQ(PORTA_IRQn);
+    } else if (obj->port == PortD) {
+        NVIC_DisableIRQ(PORTD_IRQn);
+    }
+}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/mbed_overrides.c
@@ -1,0 +1,32 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "gpio_api.h"
+
+// called before main - implement here if board needs it ortherwise, let
+//  the application override this if necessary
+//void mbed_sdk_init()
+//{
+//
+//}
+
+// Change the NMI pin to an input. This allows NMI pin to 
+//  be used as a low power mode wakeup.  The application will
+//  need to change the pin back to NMI_b or wakeup only occurs once!
+void NMI_Handler(void)
+{
+    gpio_t gpio;
+    gpio_init_in(&gpio, PTA4);
+}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/serial_api.c
@@ -1,0 +1,305 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed_assert.h"
+#include "serial_api.h"
+
+// math.h required for floating point operations for baud rate calculation
+#include <math.h>
+
+#include <string.h>
+
+#include "cmsis.h"
+#include "pinmap.h"
+#include "clk_freqs.h"
+#include "PeripheralPins.h"
+
+//Devices either user UART0 or UARTLP
+#ifndef UARTLP_BASES
+    #define UARTLP_C2_RE_MASK       UART0_C2_RE_MASK
+    #define UARTLP_C2_TE_MASK       UART0_C2_TE_MASK
+    #define UARTLP_BDH_SBNS_MASK    UART0_BDH_SBNS_MASK
+    #define UARTLP_BDH_SBNS_SHIFT   UART0_BDH_SBNS_SHIFT
+    #define UARTLP_S1_TDRE_MASK     UART0_S1_TDRE_MASK
+    #define UARTLP_S1_TC_MASK        UART0_S1_TC_MASK
+    #define UARTLP_S1_OR_MASK       UART0_S1_OR_MASK
+    #define UARTLP_C2_RIE_MASK      UART0_C2_RIE_MASK
+    #define UARTLP_C2_TIE_MASK      UART0_C2_TIE_MASK
+    #define UARTLP_C2_SBK_MASK      UART0_C2_SBK_MASK
+    #define UARTLP_S1_RDRF_MASK     UART0_S1_RDRF_MASK
+#endif
+
+#ifdef UART2
+    #define UART_NUM        3
+#else
+    #define UART_NUM        1
+#endif
+
+/******************************************************************************
+ * INITIALIZATION
+ ******************************************************************************/
+
+static uint32_t serial_irq_ids[UART_NUM] = {0};
+static uart_irq_handler irq_handler;
+
+int stdio_uart_inited = 0;
+serial_t stdio_uart;
+
+void serial_init(serial_t *obj, PinName tx, PinName rx) {
+    // determine the UART to use
+    UARTName uart_tx = (UARTName)pinmap_peripheral(tx, PinMap_UART_TX);
+    UARTName uart_rx = (UARTName)pinmap_peripheral(rx, PinMap_UART_RX);
+    UARTName uart = (UARTName)pinmap_merge(uart_tx, uart_rx);
+    MBED_ASSERT((int)uart != NC);
+
+    obj->uart = (UARTLP_Type *)uart;
+    // enable clk
+    switch (uart) {
+        case UART_0: if (mcgpllfll_frequency() != 0)                    //PLL/FLL is selected
+                        SIM->SOPT2 |= (1<<SIM_SOPT2_UART0SRC_SHIFT);
+                     else
+                        SIM->SOPT2 |= (2<<SIM_SOPT2_UART0SRC_SHIFT);
+                     SIM->SCGC4 |= SIM_SCGC4_UART0_MASK; break;
+    #if UART_NUM > 1
+        case UART_1: SIM->SCGC4 |= SIM_SCGC4_UART1_MASK; break;
+        case UART_2: SIM->SCGC4 |= SIM_SCGC4_UART2_MASK; break;
+    #endif
+    }
+    // Disable UART before changing registers
+    obj->uart->C2 &= ~(UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK);
+
+    // Enable UART transmitter to ensure TX activity is finished
+    obj->uart->C2 |= UARTLP_C2_TE_MASK;
+
+    // Wait for TX activity to finish
+    while(!(obj->uart->S1 & UARTLP_S1_TC_MASK));
+
+    // Disbale UARTs again
+    obj->uart->C2 &= ~(UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK);
+
+
+    switch (uart) {
+        case UART_0: obj->index = 0; break;
+    #if UART_NUM > 1
+        case UART_1: obj->index = 1; break;
+        case UART_2: obj->index = 2; break;
+    #endif
+    }
+
+    // set default baud rate and format
+    serial_baud  (obj, 9600);
+    serial_format(obj, 8, ParityNone, 1);
+
+    // pinout the chosen uart
+    pinmap_pinout(tx, PinMap_UART_TX);
+    pinmap_pinout(rx, PinMap_UART_RX);
+
+    // set rx/tx pins in PullUp mode and enable TX/RX
+    if (tx != NC) {
+        obj->uart->C2 |= UARTLP_C2_TE_MASK;
+        pin_mode(tx, PullUp);
+    }
+    if (rx != NC) {
+        obj->uart->C2 |= UARTLP_C2_RE_MASK;
+        pin_mode(rx, PullUp);
+    }
+
+    if (uart == STDIO_UART) {
+        stdio_uart_inited = 1;
+        memcpy(&stdio_uart, obj, sizeof(serial_t));
+    }
+}
+
+void serial_free(serial_t *obj) {
+    serial_irq_ids[obj->index] = 0;
+}
+
+// serial_baud
+//
+// set the baud rate, taking in to account the current SystemFrequency
+void serial_baud(serial_t *obj, int baudrate) {
+
+    // save C2 state
+    uint8_t c2_state = (obj->uart->C2 & (UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK));
+
+    // Disable UART before changing registers
+    obj->uart->C2 &= ~(UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK);
+
+    uint32_t PCLK;
+    if (obj->uart == UART0) {
+        if (mcgpllfll_frequency() != 0)
+            PCLK = mcgpllfll_frequency();
+        else
+            PCLK = extosc_frequency();
+    } else
+        PCLK = bus_frequency();
+
+    // First we check to see if the basic divide with no DivAddVal/MulVal
+    // ratio gives us an integer result. If it does, we set DivAddVal = 0,
+    // MulVal = 1. Otherwise, we search the valid ratio value range to find
+    // the closest match. This could be more elegant, using search methods
+    // and/or lookup tables, but the brute force method is not that much
+    // slower, and is more maintainable.
+    uint16_t DL = PCLK / (16 * baudrate);
+
+    // set BDH and BDL
+    obj->uart->BDH = (obj->uart->BDH & ~(0x1f)) | ((DL >> 8) & 0x1f);
+    obj->uart->BDL = (obj->uart->BDL & ~(0xff)) | ((DL >> 0) & 0xff);
+
+    // restore C2 state
+    obj->uart->C2 |= c2_state;
+}
+
+void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_bits) {
+    MBED_ASSERT((stop_bits == 1) || (stop_bits == 2));
+    MBED_ASSERT((parity == ParityNone) || (parity == ParityOdd) || (parity == ParityEven));
+    MBED_ASSERT(data_bits == 8); // TODO: Support other number of data bits (also in the write method!)
+
+    // save C2 state
+    uint8_t c2_state = (obj->uart->C2 & (UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK));
+
+    // Disable UART before changing registers
+    obj->uart->C2 &= ~(UARTLP_C2_RE_MASK | UARTLP_C2_TE_MASK);
+
+
+    uint8_t parity_enable, parity_select;
+    switch (parity) {
+        case ParityNone: parity_enable = 0; parity_select = 0; break;
+        case ParityOdd : parity_enable = 1; parity_select = 1; data_bits++; break;
+        case ParityEven: parity_enable = 1; parity_select = 0; data_bits++; break;
+        default:
+            break;
+    }
+
+    stop_bits -= 1;
+
+    // data bits, parity and parity mode
+    obj->uart->C1 = ((parity_enable << 1)
+                  |  (parity_select << 0));
+
+    // stop bits
+    obj->uart->BDH &= ~UARTLP_BDH_SBNS_MASK;
+    obj->uart->BDH |= (stop_bits << UARTLP_BDH_SBNS_SHIFT);
+
+    // restore C2 state
+    obj->uart->C2 |= c2_state;
+}
+
+/******************************************************************************
+ * INTERRUPTS HANDLING
+ ******************************************************************************/
+static inline void uart_irq(uint8_t status, uint32_t index) {
+    if (serial_irq_ids[index] != 0) {
+        if (status & UARTLP_S1_TDRE_MASK)
+            irq_handler(serial_irq_ids[index], TxIrq);
+
+        if (status & UARTLP_S1_RDRF_MASK)
+            irq_handler(serial_irq_ids[index], RxIrq);
+    }
+}
+
+void uart0_irq() {
+    uart_irq(UART0->S1, 0);
+    if (UART0->S1 & UARTLP_S1_OR_MASK)
+        UART0->S1 |= UARTLP_S1_OR_MASK;
+}
+#if UART_NUM > 1
+void uart1_irq() {uart_irq(UART1->S1, 1);}
+void uart2_irq() {uart_irq(UART2->S1, 2);}
+#endif
+
+void serial_irq_handler(serial_t *obj, uart_irq_handler handler, uint32_t id) {
+    irq_handler = handler;
+    serial_irq_ids[obj->index] = id;
+}
+
+void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable) {
+    IRQn_Type irq_n = (IRQn_Type)0;
+    uint32_t vector = 0;
+    switch ((int)obj->uart) {
+        case UART_0: irq_n=UART0_IRQn; vector = (uint32_t)&uart0_irq; break;
+        #if UART_NUM > 1
+        case UART_1: irq_n=UART1_IRQn; vector = (uint32_t)&uart1_irq; break;
+        case UART_2: irq_n=UART2_IRQn; vector = (uint32_t)&uart2_irq; break;
+        #endif
+    }
+
+    if (enable) {
+        switch (irq) {
+            case RxIrq: obj->uart->C2 |= (UARTLP_C2_RIE_MASK); break;
+            case TxIrq: obj->uart->C2 |= (UARTLP_C2_TIE_MASK); break;
+        }
+        NVIC_SetVector(irq_n, vector);
+        NVIC_EnableIRQ(irq_n);
+
+    } else { // disable
+        int all_disabled = 0;
+        SerialIrq other_irq = (irq == RxIrq) ? (TxIrq) : (RxIrq);
+        switch (irq) {
+            case RxIrq: obj->uart->C2 &= ~(UARTLP_C2_RIE_MASK); break;
+            case TxIrq: obj->uart->C2 &= ~(UARTLP_C2_TIE_MASK); break;
+        }
+        switch (other_irq) {
+            case RxIrq: all_disabled = (obj->uart->C2 & (UARTLP_C2_RIE_MASK)) == 0; break;
+            case TxIrq: all_disabled = (obj->uart->C2 & (UARTLP_C2_TIE_MASK)) == 0; break;
+        }
+        if (all_disabled)
+            NVIC_DisableIRQ(irq_n);
+    }
+}
+
+/******************************************************************************
+ * READ/WRITE
+ ******************************************************************************/
+int serial_getc(serial_t *obj) {
+    while (!serial_readable(obj));
+    return obj->uart->D;
+}
+
+void serial_putc(serial_t *obj, int c) {
+    while (!serial_writable(obj));
+    obj->uart->D = c;
+}
+
+int serial_readable(serial_t *obj) {
+    // check overrun
+    if (obj->uart->S1 &  UARTLP_S1_OR_MASK) {
+        obj->uart->S1 |= UARTLP_S1_OR_MASK;
+    }
+    return (obj->uart->S1 & UARTLP_S1_RDRF_MASK);
+}
+
+int serial_writable(serial_t *obj) {
+    // check overrun
+    if (obj->uart->S1 &  UARTLP_S1_OR_MASK) {
+        obj->uart->S1 |= UARTLP_S1_OR_MASK;
+    }
+    return (obj->uart->S1 & UARTLP_S1_TDRE_MASK);
+}
+
+void serial_clear(serial_t *obj) {
+}
+
+void serial_pinout_tx(PinName tx) {
+    pinmap_pinout(tx, PinMap_UART_TX);
+}
+
+void serial_break_set(serial_t *obj) {
+    obj->uart->C2 |= UARTLP_C2_SBK_MASK;
+}
+
+void serial_break_clear(serial_t *obj) {
+    obj->uart->C2 &= ~UARTLP_C2_SBK_MASK;
+}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/TARGET_KL26Z/spi_api.c
@@ -1,0 +1,226 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "mbed_assert.h"
+#include "spi_api.h"
+
+#include <math.h>
+
+#include "cmsis.h"
+#include "pinmap.h"
+
+static const PinMap PinMap_SPI_SCLK[] = {
+    {PTA15, SPI_0, 2},
+    {PTB9,  SPI_1, 2},
+    {PTB11, SPI_1, 2},
+    {PTC5,  SPI_0, 2},
+    {PTD1,  SPI_0, 2},
+    {PTD5,  SPI_1, 2},
+    {PTE2,  SPI_1, 2},
+    {PTE17, SPI_0, 2},
+    {NC  ,  NC   , 0}
+};
+
+static const PinMap PinMap_SPI_MOSI[] = {
+    {PTA16, SPI_0, 2},
+    {PTA17, SPI_0, 5},
+    {PTB16, SPI_1, 2},
+    {PTB17, SPI_1, 5},
+    {PTC6,  SPI_0, 2},
+    {PTC7,  SPI_0, 5},
+    {PTD2,  SPI_0, 2},
+    {PTD3,  SPI_0, 5},
+    {PTD6,  SPI_1, 2},
+    {PTD7,  SPI_1, 5},
+    {PTE1,  SPI_1, 2},
+    {PTE3,  SPI_1, 5},
+    {PTE18, SPI_0, 2},
+    {PTE19, SPI_0, 5},
+    {NC  ,  NC   , 0}
+};
+
+static const PinMap PinMap_SPI_MISO[] = {
+    {PTA16, SPI_0, 5},
+    {PTA17, SPI_0, 2},
+    {PTB16, SPI_1, 5},
+    {PTB17, SPI_1, 2},
+    {PTC6,  SPI_0, 5},
+    {PTC7,  SPI_0, 2},
+    {PTD2,  SPI_0, 5},
+    {PTD3,  SPI_0, 2},
+    {PTD6,  SPI_1, 5},
+    {PTD7,  SPI_1, 2},
+    {PTE1,  SPI_1, 5},
+    {PTE3,  SPI_1, 2},
+    {PTE18, SPI_0, 5},
+    {PTE19, SPI_0, 2},
+    {NC   , NC   , 0}
+};
+
+static const PinMap PinMap_SPI_SSEL[] = {
+    {PTA14, SPI_0, 2},
+    {PTB10, SPI_1, 2},
+    {PTC4,  SPI_0, 2},
+    {PTD0,  SPI_0, 2},
+    {PTD4,  SPI_1, 2},
+    {PTE4,  SPI_1, 2},
+    {PTE16, SPI_0, 2},
+    {NC  ,  NC   , 0}
+};
+
+void spi_init(spi_t *obj, PinName mosi, PinName miso, PinName sclk, PinName ssel) {
+    // determine the SPI to use
+    SPIName spi_mosi = (SPIName)pinmap_peripheral(mosi, PinMap_SPI_MOSI);
+    SPIName spi_miso = (SPIName)pinmap_peripheral(miso, PinMap_SPI_MISO);
+    SPIName spi_sclk = (SPIName)pinmap_peripheral(sclk, PinMap_SPI_SCLK);
+    SPIName spi_ssel = (SPIName)pinmap_peripheral(ssel, PinMap_SPI_SSEL);
+    SPIName spi_data = (SPIName)pinmap_merge(spi_mosi, spi_miso);
+    SPIName spi_cntl = (SPIName)pinmap_merge(spi_sclk, spi_ssel);
+
+    obj->spi = (SPI_Type*)pinmap_merge(spi_data, spi_cntl);
+    MBED_ASSERT((int)obj->spi != NC);
+
+    // enable power and clocking
+    switch ((int)obj->spi) {
+        case SPI_0: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 22; break;
+        case SPI_1: SIM->SCGC5 |= 1 << 13; SIM->SCGC4 |= 1 << 23; break;
+    }
+
+    // enable SPI
+    obj->spi->C1 |= SPI_C1_SPE_MASK;
+    obj->spi->C2 &= ~SPI_C2_SPIMODE_MASK; //8bit
+
+    // pin out the spi pins
+    pinmap_pinout(mosi, PinMap_SPI_MOSI);
+    pinmap_pinout(miso, PinMap_SPI_MISO);
+    pinmap_pinout(sclk, PinMap_SPI_SCLK);
+    if (ssel != NC) {
+        pinmap_pinout(ssel, PinMap_SPI_SSEL);
+    }
+}
+
+void spi_free(spi_t *obj) {
+    // [TODO]
+}
+void spi_format(spi_t *obj, int bits, int mode, int slave) {
+    MBED_ASSERT((bits == 8) || (bits == 16));
+    MBED_ASSERT((mode >= 0) && (mode <= 3));
+
+    uint8_t polarity = (mode & 0x2) ? 1 : 0;
+    uint8_t phase = (mode & 0x1) ? 1 : 0;
+    uint8_t c1_data = ((!slave) << 4) | (polarity << 3) | (phase << 2);
+
+    // clear MSTR, CPOL and CPHA bits
+    obj->spi->C1 &= ~(0x7 << 2);
+
+    // write new value
+    obj->spi->C1 |= c1_data;
+    if (bits == 8) {
+        obj->spi->C2 &= ~SPI_C2_SPIMODE_MASK;
+    } else {
+        obj->spi->C2 |= SPI_C2_SPIMODE_MASK;
+    }
+}
+
+void spi_frequency(spi_t *obj, int hz) {
+    uint32_t error = 0;
+    uint32_t p_error = 0xffffffff;
+    uint32_t ref = 0;
+    uint8_t  spr = 0;
+    uint8_t  ref_spr = 0;
+    uint8_t  ref_prescaler = 0;
+
+    // bus clk
+    uint32_t PCLK = SystemCoreClock / (((SIM->CLKDIV1 & SIM_CLKDIV1_OUTDIV4_MASK) >> SIM_CLKDIV1_OUTDIV4_SHIFT) + 1);
+    uint8_t prescaler = 1;
+    uint8_t divisor = 2;
+
+    for (prescaler = 1; prescaler <= 8; prescaler++) {
+        divisor = 2;
+        for (spr = 0; spr <= 8; spr++, divisor *= 2) {
+            ref = PCLK / (prescaler*divisor);
+            if (ref > (uint32_t)hz)
+                continue;
+            error = hz - ref;
+            if (error < p_error) {
+                ref_spr = spr;
+                ref_prescaler = prescaler - 1;
+                p_error = error;
+            }
+        }
+    }
+
+    // set SPPR and SPR
+    obj->spi->BR = ((ref_prescaler & 0x7) << 4) | (ref_spr & 0xf);
+}
+
+static inline int spi_writeable(spi_t * obj) {
+    return (obj->spi->S & SPI_S_SPTEF_MASK) ? 1 : 0;
+}
+
+static inline int spi_readable(spi_t * obj) {
+    return (obj->spi->S & SPI_S_SPRF_MASK) ? 1 : 0;
+}
+
+int spi_master_write(spi_t *obj, int value) {
+    int ret;
+    if (obj->spi->C2 & SPI_C2_SPIMODE_MASK) {
+        // 16bit
+        while(!spi_writeable(obj));
+        obj->spi->DL = (value & 0xff);
+        obj->spi->DH = ((value >> 8) & 0xff);
+
+        // wait rx buffer full
+        while (!spi_readable(obj));
+        ret = obj->spi->DH;
+        ret = (ret << 8) | obj->spi->DL;
+    } else {
+        //8bit
+        while(!spi_writeable(obj));
+        obj->spi->DL = (value & 0xff);
+
+        // wait rx buffer full
+        while (!spi_readable(obj));
+        ret = (obj->spi->DL & 0xff);
+    }
+
+    return ret;
+}
+
+int spi_slave_receive(spi_t *obj) {
+    return spi_readable(obj);
+}
+
+int spi_slave_read(spi_t *obj) {
+    int ret;
+    if (obj->spi->C2 & SPI_C2_SPIMODE_MASK) {
+        ret = obj->spi->DH;
+        ret = ((ret << 8) | obj->spi->DL);
+    } else {
+        ret = obj->spi->DL;
+    }
+    return ret;
+}
+
+void spi_slave_write(spi_t *obj, int value) {
+    while (!spi_writeable(obj));
+    if (obj->spi->C2 & SPI_C2_SPIMODE_MASK) {
+        obj->spi->DL = (value & 0xff);
+        obj->spi->DH = ((value >> 8) & 0xff);
+    } else {
+        obj->spi->DL = value;
+    }
+
+}

--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/objects.h
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/objects.h
@@ -29,6 +29,8 @@ extern "C" {
 #define UARTLP_Type UART0_Type
 #elif defined(TARGET_KL43Z)
 #define UARTLP_Type LPUART_Type
+#elif defined(TARGET_KL26Z)
+	#define UARTLP_Type UART0_Type
 #endif
 
 struct gpio_irq_s {

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -220,6 +220,9 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #elif defined(TARGET_KL25Z)
 #define INITIAL_SP            (0x20003000UL)
 
+#elif defined(TARGET_KL26Z)
+#define INITIAL_SP            (0x20003000UL)
+
 #elif defined(TARGET_K64F)
 #define INITIAL_SP            (0x20030000UL)
 

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -55,7 +55,7 @@
    || defined(TARGET_STM32L152RE) || defined(TARGET_STM32F446RE)
 #    define OS_TASKCNT         14
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_STM32F303RE) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO) || defined(TARGET_LPC1114) \
-   || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
+   || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL26Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
    || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824) || defined(TARGET_STM32F302R8) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) \
    || defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F091RC) || defined(TARGET_NZ32SC151) \
    || defined(TARGET_SSCI824)
@@ -73,7 +73,7 @@
    || defined(TARGET_STM32L152RE) || defined(TARGET_STM32F446RE)
 #      define OS_SCHEDULERSTKSIZE    256
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) \
-   || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
+   || defined(TARGET_LPC812)   || defined(TARGET_KL25Z)         || defined(TARGET_KL26Z)        || defined(TARGET_KL05Z)        || defined(TARGET_STM32F100RB)  || defined(TARGET_STM32F051R8) \
    || defined(TARGET_STM32F103RB) || defined(TARGET_LPC824) || defined(TARGET_STM32F302R8) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F091RC) || defined(TARGET_NZ32SC151) \
    || defined(TARGET_SSCI824)
 #      define OS_SCHEDULERSTKSIZE    128
@@ -127,7 +127,7 @@
 #    define OS_CLOCK       72000000
 
 #  elif defined(TARGET_LPC11U24) || defined(TARGET_LPC11U35_401)  || defined(TARGET_LPC11U35_501) || defined(TARGET_LPCCAPPUCCINO)  || defined(TARGET_LPC1114) || defined(TARGET_KL25Z) \
-     || defined(TARGET_KL05Z) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z) || defined(TARGET_STM32F051R8) || defined(TARGET_LPC11U68) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F091RC)
+     || defined(TARGET_KL26Z) || defined(TARGET_KL05Z) || defined(TARGET_KL46Z) || defined(TARGET_KL43Z) || defined(TARGET_STM32F051R8) || defined(TARGET_LPC11U68) || defined(TARGET_STM32F072RB) || defined(TARGET_STM32F091RC)
 #    define OS_CLOCK       48000000
 
 #  elif defined(TARGET_LPC812)

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -438,6 +438,15 @@ class KL25Z(Target):
         self.is_disk_virtual = True
         self.detect_code = ["0200"]
 
+class KL26Z(Target):
+    def __init__(self):
+        Target.__init__(self)
+        self.core = "Cortex-M0+"
+        self.extra_labels = ['Freescale', 'KLXX']
+        self.supported_toolchains = ["ARM","GCC_ARM","IAR"]
+        self.supported_form_factors = ["ARDUINO"]
+        self.is_disk_virtual = True
+
 class KL43Z(Target):
     def __init__(self):
         Target.__init__(self)
@@ -1338,6 +1347,7 @@ TARGETS = [
     ### Freescale ###
     KL05Z(),
     KL25Z(),
+    KL26Z(),
     KL43Z(),
     KL46Z(),
     K20D50M(),


### PR DESCRIPTION
Added KL26Z as a target.
HAL and CMSIS modules added for the KL26Z 
Added KL26Z to Targets.py

Edited USBEndpoints.h to add KL26 Target
Edited RTX_CONF_CM.c and RTX_CM_Lib.h to add KL26 target - Unsure of how many concurrent threads to add, so defined 6 as is with the KL25, however the KL46 has 14 defined so unsure what makes the difference here

Compiled Libraries successfully : MBED,CMSIS,USBHost, USBDevice, RTOS, DSP, FAT

Unable to currently test all changes on hardware due to a lack of having a FRDM-KL26Z board currently, any testing anyone could complete would be appreciated. 