### PR TITLE
Fixed name for MICRONFCBOARD in build_release.py

### DIFF
--- a/workspace_tools/build_release.py
+++ b/workspace_tools/build_release.py
@@ -49,7 +49,7 @@ OFFICIAL_MBED_LIBRARY_BUILD = (
     ('ARCH_GPRS',    ('ARM', 'uARM', 'GCC_ARM', 'GCC_CR', 'IAR')),
     ('LPC4337',      ('ARM',)),
     ('LPC11U37H_401', ('ARM', 'uARM','GCC_ARM','GCC_CR', 'IAR')),
-    ('APPNEARME_MICRONFCBOARD', ('ARM', 'uARM','GCC_ARM')),
+    ('MICRONFCBOARD', ('ARM', 'uARM','GCC_ARM')),
 
     ('KL05Z',        ('ARM', 'uARM', 'GCC_ARM', 'IAR')),
     ('KL25Z',        ('ARM', 'GCC_ARM', 'IAR')),


### PR DESCRIPTION
This fixes an issue where the MICRONFCBOARD does not compile when using the build_release.py script.