### PR TITLE
Make it possible to build the core mbed library with yotta

### DIFF
--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -6,7 +6,15 @@ set(MBED_LEGACY_TOOLCHAIN "GCC_ARM")
 add_definitions("-DNRF51")
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 
-# mbed-2 yotta-compatible build system:
+#
+# mbed-2 yotta-compatible build system
+#
+
+# make sure necessary features are enabled:
+project(mbed)
+enable_language(ASM)
+
+
 # the mbed.a library is built from two sets of source files + include
 # directories:
 #
@@ -26,7 +34,7 @@ macro(mbed_find_target_dirs PARENT_DIRECTORY SOURCES_LIST INCLUDES_LIST)
     # append this directory to the search path:
     list(APPEND ${INCLUDES_LIST} "${PARENT_DIRECTORY}")
     # add all source files in this directory to the sources list:
-    file(GLOB sources "${PARENT_DIRECTORY}/*.cpp" "${PARENT_DIRECTORY}/*.c")
+    file(GLOB sources "${PARENT_DIRECTORY}/*.cpp" "${PARENT_DIRECTORY}/*.c" "${PARENT_DIRECTORY}/*.s" "${PARENT_DIRECTORY}/*.S" )
     list(APPEND ${SOURCES_LIST} ${sources})
     
     # get a list of all subdirectories that we want to recurse into:
@@ -47,9 +55,9 @@ macro(mbed_find_target_dirs PARENT_DIRECTORY SOURCES_LIST INCLUDES_LIST)
                   endif()
               endforeach()
           elseif(${child} MATCHES "^TOOLCHAIN_")
+              # toolchain-magic: (recurse if the MBED_LEGACY_TOOLCHAIN matches
+              # this name)
               if(${child} MATCHES "^TOOLCHAIN_${MBED_LEGACY_TOOLCHAIN}$")
-                  # toolchain-magic: (recurse if the MBED_LEGACY_TOOLCHAIN matches
-                  # this name)
                   list(APPEND matching_subdirs ${child})
               endif()
           else()

--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -76,6 +76,22 @@ mbed_find_target_dirs("${CMAKE_CURRENT_SOURCE_DIR}/targets" MBED_TARGET_SOURCES 
 #message("found target sources: ${MBED_TARGET_SOURCES}")
 #message("found target include dirs: ${MBED_TARGET_INCLUDE_DIRS}")
 
+# unfortunately, for ARMCC, the startup code needs to be provided as an object
+# on the command line (not as part of an archive). To do this we override the
+# CMake add_executable command.
+if(CMAKE_C_COMPILER_ID STREQUAL "ARMCC")
+    set(MBED_TARGET_STARTUP_CODE_SOURCES "")
+    foreach(src ${MBED_TARGET_SOURCES})
+        if("${src}" MATCHES .*startup_.*\\.[sS])
+            LIST(APPEND MBED_TARGET_STARTUP_CODE_SOURCES "${src}")
+        endif()
+    endforeach()
+    add_library(mbed_classic_startupcod OBJECT ${MBED_TARGET_STARTUP_CODE_SOURCES})
+    macro (add_executable _name)
+        _add_executable(${ARGV} $<TARGET_OBJECTS:mbed_classic_startupcod>)
+    endmacro()
+endif()
+
 # we have to append any target-specific include dirs to the global include dirs
 # list, so that any indirect includes (e.g. via mbed.h) of files in those
 # directories will work:

--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -3,7 +3,7 @@
 #
 
 # make sure necessary features are enabled:
-project(mbed)
+project(mbed-classic)
 enable_language(ASM)
 
 # override compilation flags:
@@ -74,13 +74,21 @@ mbed_find_target_dirs("${CMAKE_CURRENT_SOURCE_DIR}/targets" MBED_TARGET_SOURCES 
 #message("found target sources: ${MBED_TARGET_SOURCES}")
 #message("found target include dirs: ${MBED_TARGET_INCLUDE_DIRS}")
 
+# we have to append any target-specific include dirs to the global include dirs
+# list, so that any indirect includes (e.g. via mbed.h) of files in those
+# directories will work:
+# (non-target-specific include dirs are listed in extraIncludes in module.json)
+foreach(dir ${MBED_TARGET_INCLUDE_DIRS})
+    set_property(GLOBAL APPEND PROPERTY YOTTA_GLOBAL_INCLUDE_DIRS ${dir})
+endforeach()
+
 # finally, we can construct a library using the determined set of include paths
 # + source files. Note that the library name must match the name of the yotta
 # module (defined in module.json) for this module to link properly with other
 # yotta modules.
 include_directories(${MBED_COMMON_INCLUDE_DIRS})
 include_directories(${MBED_TARGET_INCLUDE_DIRS})
-add_library(mbed
+add_library(mbed-classic
     ${MBED_COMMON_SOURCES}
     ${MBED_TARGET_SOURCES}
 )

--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -1,0 +1,84 @@
+#!!! TODO stuff in this pre-amble will be defined by the target description,
+#hard-coding for now...
+
+set(MBED_LEGACY_TARGET_DEFINITIONS "NORDIC" "NRF51822_MKIT" "MCU_NRF51822" "MCU_NORDIC_16K")
+set(MBED_LEGACY_TOOLCHAIN "GCC_ARM")
+add_definitions("-DNRF51")
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+
+# mbed-2 yotta-compatible build system:
+# the mbed.a library is built from two sets of source files + include
+# directories:
+#
+# MBED_COMMON_SOURCES: the source files that are the same for all targets,
+# these are easily found by globbing:
+#
+file(GLOB MBED_COMMON_SOURCES "common/*.cpp" "common/*.c")
+#
+# (always include the hal header directory, too)
+set(MBED_COMMON_INCLUDE_DIRS "hal")
+
+# and MBED_TARGET_SOURCES: these depend on which target we are building for. To
+# find these we need to walk the directories in targets/, and wherever we see a
+# TARGET_<something> name, recurse only if <something> matches what we're
+# currently building for
+macro(mbed_find_target_dirs PARENT_DIRECTORY SOURCES_LIST INCLUDES_LIST)
+    # append this directory to the search path:
+    list(APPEND ${INCLUDES_LIST} "${PARENT_DIRECTORY}")
+    # add all source files in this directory to the sources list:
+    file(GLOB sources "${PARENT_DIRECTORY}/*.cpp" "${PARENT_DIRECTORY}/*.c")
+    list(APPEND ${SOURCES_LIST} ${sources})
+    
+    # get a list of all subdirectories that we want to recurse into:
+    file(GLOB dir_children RELATIVE "${PARENT_DIRECTORY}" "${PARENT_DIRECTORY}/*")
+    set(matching_subdirs "")
+    foreach(child ${dir_children})
+      if(IS_DIRECTORY "${PARENT_DIRECTORY}/${child}")
+          # is this directory name a magic one?
+          if(${child} MATCHES "^TARGET_")
+              # target-magic: recurse if the MBED_LEGACY_TARGET_DEFINITIONS **list**
+              # contains a matching value:
+              foreach(legacy_magic_def ${MBED_LEGACY_TARGET_DEFINITIONS})
+                  # we could probably unroll the list into a single regex if
+                  # this is a performance problem:
+                  if(${child} MATCHES "^TARGET_${legacy_magic_def}$")
+                      list(APPEND matching_subdirs ${child})
+                      break()
+                  endif()
+              endforeach()
+          elseif(${child} MATCHES "^TOOLCHAIN_")
+              if(${child} MATCHES "^TOOLCHAIN_${MBED_LEGACY_TOOLCHAIN}$")
+                  # toolchain-magic: (recurse if the MBED_LEGACY_TOOLCHAIN matches
+                  # this name)
+                  list(APPEND matching_subdirs ${child})
+              endif()
+          else()
+              # not special: always recurse into this directory
+              list(APPEND matching_subdirs ${child})
+          endif()
+      endif()
+    endforeach()
+    #message("matching_subdirs: ${matching_subdirs}")
+
+    # recurse:
+    foreach(subdir ${matching_subdirs})
+        mbed_find_target_dirs("${PARENT_DIRECTORY}/${subdir}" ${SOURCES_LIST} ${INCLUDES_LIST})
+    endforeach()
+endmacro()
+
+set(MBED_TARGET_SOURCES "")
+set(MBED_TARGET_INCLUDE_DIRS "")
+mbed_find_target_dirs("${CMAKE_CURRENT_SOURCE_DIR}/targets" MBED_TARGET_SOURCES MBED_TARGET_INCLUDE_DIRS)
+#message("found target sources: ${MBED_TARGET_SOURCES}")
+#message("found target include dirs: ${MBED_TARGET_INCLUDE_DIRS}")
+
+# finally, we can construct a library using the determined set of include paths
+# + source files. Note that the library name must match the name of the yotta
+# module (defined in module.json) for this module to link properly with other
+# yotta modules.
+include_directories(${MBED_COMMON_INCLUDE_DIRS})
+include_directories(${MBED_TARGET_INCLUDE_DIRS})
+add_library(mbed
+    ${MBED_COMMON_SOURCES}
+    ${MBED_TARGET_SOURCES}
+)

--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -43,26 +43,26 @@ macro(mbed_find_target_dirs PARENT_DIRECTORY SOURCES_LIST INCLUDES_LIST)
     foreach(child ${dir_children})
       if(IS_DIRECTORY "${PARENT_DIRECTORY}/${child}")
           # is this directory name a magic one?
-          if(${child} MATCHES "^TARGET_")
+          if("${child}" MATCHES "^TARGET_")
               # target-magic: recurse if the MBED_LEGACY_TARGET_DEFINITIONS **list**
               # contains a matching value:
               foreach(legacy_magic_def ${MBED_LEGACY_TARGET_DEFINITIONS})
                   # we could probably unroll the list into a single regex if
                   # this is a performance problem:
-                  if(${child} MATCHES "^TARGET_${legacy_magic_def}$")
+                  if("${child}" MATCHES "^TARGET_${legacy_magic_def}$")
                       list(APPEND matching_subdirs ${child})
                       break()
                   endif()
               endforeach()
-          elseif(${child} MATCHES "^TOOLCHAIN_")
+          elseif("${child}" MATCHES "^TOOLCHAIN_")
               # toolchain-magic: (recurse if the MBED_LEGACY_TOOLCHAIN matches
               # this name)
-              if(${child} MATCHES "^TOOLCHAIN_${MBED_LEGACY_TOOLCHAIN}$")
-                  list(APPEND matching_subdirs ${child})
+              if("${child}" MATCHES "^TOOLCHAIN_${MBED_LEGACY_TOOLCHAIN}$")
+                  list(APPEND matching_subdirs "${child}")
               endif()
           else()
               # not special: always recurse into this directory
-              list(APPEND matching_subdirs ${child})
+              list(APPEND matching_subdirs "${child}")
           endif()
       endif()
     endforeach()

--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -1,11 +1,3 @@
-#!!! TODO stuff in this pre-amble will be defined by the target description,
-#hard-coding for now...
-
-set(MBED_LEGACY_TARGET_DEFINITIONS "NORDIC" "NRF51822_MKIT" "MCU_NRF51822" "MCU_NORDIC_16K")
-set(MBED_LEGACY_TOOLCHAIN "GCC_ARM")
-add_definitions("-DNRF51")
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
-
 #
 # mbed-2 yotta-compatible build system
 #
@@ -14,6 +6,8 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 project(mbed)
 enable_language(ASM)
 
+# override compilation flags:
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
 
 # the mbed.a library is built from two sets of source files + include
 # directories:

--- a/libraries/mbed/CMakeLists.txt
+++ b/libraries/mbed/CMakeLists.txt
@@ -7,7 +7,9 @@ project(mbed-classic)
 enable_language(ASM)
 
 # override compilation flags:
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+if(CMAKE_C_COMPILER_ID MATCHES GNU)
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -std=gnu99")
+endif()
 
 # the mbed.a library is built from two sets of source files + include
 # directories:

--- a/libraries/mbed/module.json
+++ b/libraries/mbed/module.json
@@ -1,0 +1,27 @@
+{
+  "name": "mbed",
+  "version": "2.0.0-a0",
+  "description": "mbed SDK (for mbed 2.0)",
+  "keywords": [
+    "mbed"
+  ],
+  "author": "Bogdan Marinescu <bogdan.marinescu@arm.com>",
+  "repository": {
+    "url": "git@github.com:mbedmicro/mbed.git",
+    "type": "git"
+  },
+  "homepage": "https://github.com/mbedmicro/mbed",
+  "licenses": [
+    {
+      "url": "https://spdx.org/licenses/Apache-2.0",
+      "type": "Apache-2.0"
+    }
+  ],
+  "extraIncludes": [
+    "api"
+  ],
+  "dependencies": {
+  },
+  "targetDependencies": {
+  }
+}

--- a/libraries/mbed/module.json
+++ b/libraries/mbed/module.json
@@ -1,7 +1,7 @@
 {
-  "name": "mbed",
-  "version": "2.0.0-a0",
-  "description": "mbed SDK (for mbed 2.0)",
+  "name": "mbed-classic",
+  "version": "0.0.1",
+  "description": "mbed core SDK (for mbed 2.0, *not* mbedOS)",
   "keywords": [
     "mbed"
   ],

--- a/libraries/mbed/module.json
+++ b/libraries/mbed/module.json
@@ -18,7 +18,10 @@
     }
   ],
   "extraIncludes": [
-    "api"
+    "api",
+    "hal",
+    "targets/hal",
+    "targets/cmsis"
   ],
   "dependencies": {
   },


### PR DESCRIPTION
This builds with target descriptions derived from both mbed-gcc and mbed-armcc, requires yotta >= 0.4.4.

cc @jaustin @rgrover
