### PR TITLE
Nordic: add const qualifier to acceptedSpeeds in serial API

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -29,23 +29,25 @@
 
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
-static int acceptedSpeeds[17][2] = {{1200, UART_BAUDRATE_BAUDRATE_Baud1200},
-                                         {2400, UART_BAUDRATE_BAUDRATE_Baud2400},
-                                         {4800, UART_BAUDRATE_BAUDRATE_Baud4800},
-                                         {9600, UART_BAUDRATE_BAUDRATE_Baud9600},
-                                         {14400, UART_BAUDRATE_BAUDRATE_Baud14400},
-                                         {19200, UART_BAUDRATE_BAUDRATE_Baud19200},
-                                         {28800, UART_BAUDRATE_BAUDRATE_Baud28800},
-                                         {31250, (0x00800000UL) /* 31250 baud */},
-                                         {38400, UART_BAUDRATE_BAUDRATE_Baud38400},
-                                         {57600, UART_BAUDRATE_BAUDRATE_Baud57600},
-                                         {76800, UART_BAUDRATE_BAUDRATE_Baud76800},
-                                         {115200, UART_BAUDRATE_BAUDRATE_Baud115200},
-                                         {230400, UART_BAUDRATE_BAUDRATE_Baud230400},
-                                         {250000, UART_BAUDRATE_BAUDRATE_Baud250000},
-                                         {460800, UART_BAUDRATE_BAUDRATE_Baud460800},
-                                         {921600, UART_BAUDRATE_BAUDRATE_Baud921600},
-                                         {1000000, UART_BAUDRATE_BAUDRATE_Baud1M}};
+static const int acceptedSpeeds[17][2] = {
+    {1200, UART_BAUDRATE_BAUDRATE_Baud1200},
+    {2400, UART_BAUDRATE_BAUDRATE_Baud2400},
+    {4800, UART_BAUDRATE_BAUDRATE_Baud4800},
+    {9600, UART_BAUDRATE_BAUDRATE_Baud9600},
+    {14400, UART_BAUDRATE_BAUDRATE_Baud14400},
+    {19200, UART_BAUDRATE_BAUDRATE_Baud19200},
+    {28800, UART_BAUDRATE_BAUDRATE_Baud28800},
+    {31250, (0x00800000UL) /* 31250 baud */},
+    {38400, UART_BAUDRATE_BAUDRATE_Baud38400},
+    {57600, UART_BAUDRATE_BAUDRATE_Baud57600},
+    {76800, UART_BAUDRATE_BAUDRATE_Baud76800},
+    {115200, UART_BAUDRATE_BAUDRATE_Baud115200},
+    {230400, UART_BAUDRATE_BAUDRATE_Baud230400},
+    {250000, UART_BAUDRATE_BAUDRATE_Baud250000},
+    {460800, UART_BAUDRATE_BAUDRATE_Baud460800},
+    {921600, UART_BAUDRATE_BAUDRATE_Baud921600},
+    {1000000, UART_BAUDRATE_BAUDRATE_Baud1M}
+};
 
 int stdio_uart_inited = 0;
 serial_t stdio_uart;


### PR DESCRIPTION
This is a small optimisation for ARM compiler toolchains: constant
arrays should be declared const explicitly, to let the compiler put them
into .rodata instead of .data. GCC automatically detects that the array
is read-only, and already puts it into flash.

This way, we free 136 bytes of RAM, which is nothing to sneeze at, given
that applications only get about 2048 bytes by default, on 16k targets.

Please note that you will need to disable data compression in armlink to
see the actual difference, using the "--datacompressor off" switch, for
example.