### PR TITLE
[RTOS] Fixed INITIAL_SP for LPC11U68

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -266,7 +266,7 @@ osThreadDef_t os_thread_def_main = {(os_pthread)main, osPriorityNormal, 0, NULL}
 #define INITIAL_SP            (0x02009000UL)
 
 #elif defined(TARGET_LPC11U68)
-#define INITIAL_SP            (0x10004000UL)
+#define INITIAL_SP            (0x10008000UL)
 
 #elif defined(TARGET_STM32F411RE)
 #define INITIAL_SP            (0x20020000UL)


### PR DESCRIPTION
According to the LPC11U68 datasheet, the top of SRAM0 occurs at 0x10008000, not 0x10004000.