### PR TITLE
[11U68]Fixed P0_11 for GPIO

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/gpio_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/gpio_api.c
@@ -33,6 +33,7 @@ uint32_t gpio_set(PinName pin) {
     
     int func = ((pin == P0_0)  || // reset
                 (pin == P0_10) || // SWCLK
+                (pin == P0_11) || // TDI
                 (pin == P0_12) || // TMS
                 (pin == P0_13) || // TDO
                 (pin == P0_14) || // TRST


### PR DESCRIPTION
Hello All
Change P0_11 to use GPIO(DigitalOut) from TDI.

I accepted Contributor Agreement.
My nickname on mbed is "Hapi_Tech"

Best regards.