### PR TITLE
add IBDAP-LPC11U35 platform

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_MCU_LPC11U35_501/TARGET_LPC11U35_501_IBDAP/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_MCU_LPC11U35_501/TARGET_LPC11U35_501_IBDAP/PinNames.h
@@ -1,0 +1,184 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2014 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  5
+
+typedef enum {
+    // LPC11U Pin Names
+    P0_0 = 0,
+    P0_1 = 1,
+    P0_2 = 2,
+    P0_3 = 3,
+    P0_4 = 4,
+    P0_5 = 5,
+    P0_6 = 6,
+    P0_7 = 7,
+    P0_8 = 8,
+    P0_9 = 9,
+    P0_10 = 10,
+    P0_11 = 11,
+    P0_12 = 12,
+    P0_13 = 13,
+    P0_14 = 14,
+    P0_15 = 15,
+    P0_16 = 16,
+    P0_17 = 17,
+    P0_18 = 18,
+    P0_19 = 19,
+    P0_20 = 20,
+    P0_21 = 21,
+    P0_22 = 22,
+    P0_23 = 23,
+    P0_24 = 24,
+    P0_25 = 25,
+    P0_26 = 26,
+    P0_27 = 27,
+
+    P1_0 = 32,
+    P1_1 = 33,
+    P1_2 = 34,
+    P1_3 = 35,
+    P1_4 = 36,
+    P1_5 = 37,
+    P1_6 = 38,
+    P1_7 = 39,
+    P1_8 = 40,
+    P1_9 = 41,
+    P1_10 = 42,
+    P1_11 = 43,
+    P1_12 = 44,
+    P1_13 = 45,
+    P1_14 = 46,
+    P1_15 = 47,
+    P1_16 = 48,
+    P1_17 = 49,
+    P1_18 = 50,
+    P1_19 = 51,
+    P1_20 = 52,
+    P1_21 = 53,
+    P1_22 = 54,
+    P1_23 = 55,
+    P1_24 = 56,
+    P1_25 = 57,
+    P1_26 = 58,
+    P1_27 = 59,
+    P1_28 = 60,
+    P1_29 = 61,
+
+    P1_31 = 63,
+
+    // mbed DIP Pin Names
+                    // CN1-1  (GND)
+                    // CN1-2  (EXTPOWER)
+                    // CN1-3  (NC)
+    p4 = P0_0,      // CN1-4
+    p5 = P0_9,      // CN1-5
+    p6 = P0_8,      // CN1-6
+    p7 = P0_10,     // CN1-7
+    p8 = P0_7,      // CN1-8
+    p9 = P0_19,     // CN1-9
+    p10 = P0_18,    // CN1-10
+    p11 = P0_21,    // CN1-11
+    p12 = P0_22,    // CN1-12
+    p13 = P1_15,    // CN1-13
+    p14 = P0_6,     // CN1-14
+    p15 = P0_11,    // CN1-15
+    p16 = P0_12,    // CN1-16
+    p17 = P0_13,    // CN1-17
+    p18 = P0_14,    // CN1-18
+    p19 = P0_15,    // CN1-19
+    p20 = P0_16,    // CN1-20
+
+    p21 = P0_14,    // CN2-20
+    p22 = P0_2,     // CN2-19
+    p23 = P0_23,    // CN2-18
+    p24 = P0_17,    // CN2-17
+    p25 = P0_20,    // CN2-16
+    p26 = P1_15,    // CN2-15
+    p27 = P0_4,     // CN2-14
+    p28 = P0_5,     // CN2-13
+    p29 = P1_19,    // CN2-12
+    p30 = P0_1,     // CN2-11
+                    // CN2-10 (D+USB)
+                    // CN2-9  (D-USB)
+    p33 = P0_3,     // CN2-8  (USB-VBUS)
+                    // CN2-7  (NC)
+                    // CN2-6  (NC)
+                    // CN2-5  (NC)
+                    // CN2-4  (NC)
+                    // CN2-3  (NC)
+                    // CN2-2  (VDD)
+                    // CN2-1  (VDD)
+
+    // Other mbed Pin Names
+    LED1 = P0_20,   // GREEN LED
+    LED2 = P0_11,   // RED LED
+    LED3 = P0_21,   // BLUE LED
+    LED4 = P0_20,   // repeat LED1
+
+    UART_TX = P0_19,
+    UART_RX = P0_18,
+
+    I2C_SCL = P0_4,
+    I2C_SDA = P0_5,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF,
+
+    // Standard but not supported pins
+    USBTX = NC,
+    USBRX = NC,
+
+} PinName;
+
+typedef enum {
+    CHANNEL0 = FLEX_INT0_IRQn,
+    CHANNEL1 = FLEX_INT1_IRQn,
+    CHANNEL2 = FLEX_INT2_IRQn,
+    CHANNEL3 = FLEX_INT3_IRQn,
+    CHANNEL4 = FLEX_INT4_IRQn,
+    CHANNEL5 = FLEX_INT5_IRQn,
+    CHANNEL6 = FLEX_INT6_IRQn,
+    CHANNEL7 = FLEX_INT7_IRQn
+} Channel;
+
+typedef enum {
+    PullUp = 2,
+    PullDown = 1,
+    PullNone = 0,
+    Repeater = 3,
+    OpenDrain = 4,
+    PullDefault = PullDown
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_MCU_LPC11U35_501/TARGET_LPC11U35_501_IBDAP/device.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11UXX/TARGET_MCU_LPC11U35_501/TARGET_LPC11U35_501_IBDAP/device.h
@@ -1,0 +1,59 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#define DEVICE_PORTIN           1
+#define DEVICE_PORTOUT          1
+#define DEVICE_PORTINOUT        1
+
+#define DEVICE_INTERRUPTIN      1
+
+#define DEVICE_ANALOGIN         1
+#define DEVICE_ANALOGOUT        0
+
+#define DEVICE_SERIAL           1
+
+#define DEVICE_I2C              1
+#define DEVICE_I2CSLAVE         1
+
+#define DEVICE_SPI              1
+#define DEVICE_SPISLAVE         1
+
+#define DEVICE_CAN              0
+
+#define DEVICE_RTC              0
+
+#define DEVICE_ETHERNET         0
+
+#define DEVICE_PWMOUT           1
+
+#define DEVICE_SEMIHOST         0
+#define DEVICE_LOCALFILESYSTEM  0
+#define DEVICE_ID_LENGTH       32
+#define DEVICE_MAC_OFFSET      20
+
+#define DEVICE_SLEEP            1
+
+#define DEVICE_DEBUG_AWARENESS  0
+
+#define DEVICE_STDIO_MESSAGES   0
+
+#define DEVICE_ERROR_PATTERN    1
+
+#include "objects.h"
+
+#endif

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -189,6 +189,14 @@ class LPC11U35_501(LPCTarget):
         self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR" , "IAR"]
         self.default_toolchain = "uARM"
 
+class LPC11U35_501_IBDAP(LPCTarget):
+    def __init__(self):
+        LPCTarget.__init__(self)
+        self.core = "Cortex-M0"
+        self.extra_labels = ['NXP', 'LPC11UXX', 'MCU_LPC11U35_501']
+        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR" , "IAR"]
+        self.default_toolchain = "uARM"
+
 class LPC11U35_Y5_MBUG(LPCTarget):
     def __init__(self):
         LPCTarget.__init__(self)
@@ -1335,6 +1343,7 @@ TARGETS = [
     MICRONFCBOARD(), # LPC11U34_421
     LPC11U35_401(),
     LPC11U35_501(),
+    LPC11U35_501_IBDAP(),
     XADOW_M0(),     # LPC11U35_501
     LPC11U35_Y5_MBUG(),
     LPC11U37_501(),


### PR DESCRIPTION
This pull request is for adding Armstart IBDAP-LPC11U35 board to the mbed supported platforms.

-----------------------------------

# IBDAP 

IBDAP is a fully CMSIS-DAP compatible debug adapter. It provides vendor independent debug interface between your PC over USB and target ARM device over JTAG/SWD pins. You can do debugging functions like stepping, breakpoints, watch points and firmware download etc. It's fully supported by Keil, OpenOCD, GNU GDB, IAR and other commonly used debugging tools.

# Why IBDAP?

Debug adapters are expensive, some could cost thousands of dollars, some may not be compatible among different vendors. Luckily, ARM standardized the debugging interface which is called CMSIS-DAP and released the firmware implementation on some processors, however, you still need a Keil MDK Professional edition software in order to build the firmware, even the open source one provided by mbed and the price for Keil Professional is intimidating. All these barriers has become the first issue that every inventor is facing, and we need a solution!

IBDAP's objective is to become an affordable open source & open hardware CMSIS-DAP JTAG/SWD debug probe implementation using gcc & makefile. Anyone can modify and embed a debug probe on its own device easily with everything under its control.

# mbed enabled

Besides being functioning as a JTAG/SWD debug probe, IBDAP could also be used as a general mbed development board. It has an ARM Cortex M0 processor  running at 48Mhz and has peripherals like UART, I2C, SPI, USB. It can be used in many applications like USB audio devices, USB mouse/keyboards, USB mass storage devices, USB-TTL adapter device and many many more. Moreover, the 10-bit high precision ADC peripheral also makes IBDAP an ideal device for any sensor projects. 

![IBDAP pinout](https://s3.amazonaws.com/armstart/Debug+Tools/IBDAP-LPC11U35/7.jpg)

# Schematic and Source Codes

Schematic: [https://s3.amazonaws.com/armstart/Debug+Tools/IBDAP-LPC11U35/IBDAP-LPC11U35_SCH.pdf](https://s3.amazonaws.com/armstart/Debug+Tools/IBDAP-LPC11U35/IBDAP-LPC11U35_SCH.pdf)

Source code: [https://github.com/Armstart-com/IBDAP-CMSIS-DAP](https://github.com/Armstart-com/IBDAP-CMSIS-DAP)

# How to use IBDAP to debug target board

Connect IBDAP's TGT_DBG 10-pin header to the target board (note, VTREF pin at TGT_DBG provides 3.3V for the target board, but you can switch off by removing the corresponding jumper), connect IBDAP and PC via USB cable.

If your system is Windows, you should be able to see a USB HID device called "IBDAP-LPC11U35 CMSIS-DAP" in your control panel.

## If you are using Keil

From your Keil project, click on "Options for Target" button just besides the target, choose "Debug" tab, select use: "CMSIS-DAP Debugger", then click "settings", you should be able to see the "IBDAP-LPC11U35 CMSIS-DAP" device with any error, if yes, then we are all set.

![Keil options](https://s3.amazonaws.com/armstart/Debug+Tools/IBDAP-LPC11U35/howtos/keil-cmsis-dap-setting-1.JPG)
