### PR TITLE
[mbed] Modified MBED_ASSERT to use error()

### DIFF
--- a/libraries/mbed/api/mbed_assert.h
+++ b/libraries/mbed/api/mbed_assert.h
@@ -23,8 +23,7 @@ extern "C" {
 /** Internal mbed assert function which is invoked when MBED_ASSERT macro failes.
  *  This function is active only if NDEBUG is not defined prior to including this
  *  assert header file.
- *  In case of MBED_ASSERT failing condition, the assertation message is printed
- *  to stderr and mbed_die() is called.
+ *  In case of MBED_ASSERT failing condition, error() is called with the assertation message.
  *  @param expr Expresion to be checked.
  *  @param file File where assertation failed.
  *  @param line Failing assertation line number.

--- a/libraries/mbed/common/assert.c
+++ b/libraries/mbed/common/assert.c
@@ -14,19 +14,9 @@
  * limitations under the License.
  */
 #include "mbed_assert.h"
-#include "device.h"
-
-#if DEVICE_STDIO_MESSAGES
-#include <stdio.h>
-#endif
-
-#include <stdlib.h>
-#include "mbed_interface.h"
+#include "mbed_error.h"
 
 void mbed_assert_internal(const char *expr, const char *file, int line)
 {
-#if DEVICE_STDIO_MESSAGES
-    fprintf(stderr, "mbed assertation failed: %s, file: %s, line %d \n", expr, file, line);
-#endif
-    mbed_die();
+    error("mbed assertation failed: %s, file: %s, line %d \n", expr, file, line);
 }


### PR DESCRIPTION
Modified `mbed_assert_internal()` to call `error()` with the assertation message instead of `fprintf()` followed by `mbed_die()`. This allows assertation failures to be caught by custom `error()` functions that replace the default weak definition.