### PR TITLE
[LPC4337] fix PinNames.h for OM13070

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC43XX/TARGET_LPC4337/PinNames.h
@@ -14,8 +14,6 @@
  * limitations under the License.
  */
 
-#define BOARD_REV_B
-
 #ifndef MBED_PINNAMES_H
 #define MBED_PINNAMES_H
 
@@ -451,29 +449,6 @@ typedef enum {
     SFP_INS0  = MBED_PIN(0x1C, 0, 0, 0), // Interrupt select for pin interrupts 0 to 3
     SFP_INS1  = MBED_PIN(0x1C, 1, 0, 0), // Interrupt select for pin interrupts 4 to 7
 
-/*
-#define MBED_ADC_NUM(MBED_PIN)   ((MBED_PIN >> 5) & 0x0000000F)
-#define MBED_ADC_CHAN(MBED_PIN)  (MBED_PIN & 0x0000001F)
-
-    // Use pseudo-pin ID also for ADCs, although with special handling
-    SFP_ADC0_0 = MBED_PIN(0x19, 2, 0, 0), // ADC0_0
-    SFP_ADC0_1 = MBED_PIN(0x19, 2, 0, 1), // ADC0_1
-    SFP_ADC0_2 = MBED_PIN(0x19, 2, 0, 2), // ADC0_2
-    SFP_ADC0_3 = MBED_PIN(0x19, 2, 0, 3), // ADC0_3
-    SFP_ADC0_4 = MBED_PIN(0x19, 2, 0, 4), // ADC0_4
-    SFP_ADC0_5 = MBED_PIN(0x19, 2, 0, 5), // ADC0_5
-    SFP_ADC0_6 = MBED_PIN(0x19, 2, 0, 6), // ADC0_6
-
-    SFP_ADC1_0 = MBED_PIN(0x19, 3, 1, 0), // ADC1_0
-    SFP_ADC1_1 = MBED_PIN(0x19, 3, 1, 1), // ADC1_1
-    SFP_ADC1_2 = MBED_PIN(0x19, 3, 1, 2), // ADC1_2
-    SFP_ADC1_3 = MBED_PIN(0x19, 3, 1, 3), // ADC1_3
-    SFP_ADC1_4 = MBED_PIN(0x19, 3, 1, 4), // ADC1_4
-    SFP_ADC1_5 = MBED_PIN(0x19, 3, 1, 5), // ADC1_5
-    SFP_ADC1_6 = MBED_PIN(0x19, 3, 1, 6), // ADC1_6
-    SFP_ADC1_7 = MBED_PIN(0x19, 3, 1, 7), // ADC1_7
-*/
-
     // Dedicated pin (no GPIO)
     P_DED = MBED_PIN(0, 0, NO_GPIO, 0),
 
@@ -482,55 +457,23 @@ typedef enum {
 
     // ---------- LPCXpresso 4337 pins ----------
 
-#ifdef BOARD_REV_A // for Rev.A
-    D0  = P2_1,
-    D1  = P2_0,
-    D2  = P1_20,
-    D3  = P1_18,
-    D4  = P1_16,
-    D5  = P1_15,
-    D6  = P1_4,
-    D7  = P2_2,
-    D8  = P1_0,
-    D9  = P1_3,
-    D10 = P1_5,
-    D11 = P0_1,
-    D12 = P0_0,
-    D13 = P1_19,
-    SDA = P2_3,
-    SCL = P2_4,
-
-    A0  = P4_3,
-    A1  = P4_1,
-    A2  = PF_8,
-    A3  = P7_5,
-    A4  = P1_14,
-    A5  = P2_5,
-
-    LED_GREEN = GPIO0_14,
-    LED_RED   = GPIO3_7,
-    LED_BLUE  = GPIO3_5,
-
-    // Serial pins
-    UART0_TX = P2_0,
-    UART0_RX = P2_1,
-    USBTX = UART0_TX,
-    USBRX = UART0_RX,
-#else // for Rev.B
-    D0  = P1_14,
-    D1  = P3_4,
+    D0  = P2_11,
+    D1  = P2_10,
     D2  = P2_13,
     D3  = P1_8,
-    D4  = P2_6,
+    D4  = P2_2,
     D5  = P1_7,
     D6  = P2_9,
-    D7  = P2_2,
-    D8  = P3_5,
-    D9  = P1_2,
+    D7  = P2_12,
+
+    D8  = P2_6,
+    D9  = P6_5,
     D10 = P1_5,
     D11 = P1_4,
     D12 = P1_3,
     D13 = PF_4,
+    D14 = P2_3,
+    D15 = P2_4,
     SDA = P2_3,
     SCL = P2_4,
 
@@ -538,10 +481,10 @@ typedef enum {
     A1  = P4_1,
     A2  = PF_8,
     A3  = P7_5,
-    A4  = P2_11,
+    A4  = NC,
     A5  = P2_5,
 
-    LED_GREEN = P2_10,
+    LED_GREEN = P2_7,
     LED_RED   = P6_11,
     LED_BLUE  = P6_9,
 
@@ -552,7 +495,6 @@ typedef enum {
     UART1_RX = D0,
     USBTX = UART0_TX,
     USBRX = UART0_RX,
-#endif
 
     I2C_SDA = SDA,
     I2C_SDL = SCL,
@@ -561,46 +503,6 @@ typedef enum {
     LED2 = LED_BLUE,
     LED3 = LED_GREEN,
     LED4 = LED_RED,
-
-//    UART1_TX = P5_6,
-//    UART1_RX = P1_14,
-//    UART2_TX = P2_10,
-//    UART2_RX = P2_11,
-//    UART3_TX = P2_3,
-//    UART3_RX = P2_4,
-
-/*
-    // Analog pins
-    ADC4 = P4_3,
-    ADC2 = P4_1,
-    ADC0 = P7_4,
-    ADC1 = P7_5,
-    ADC3 = P7_7,
-    DAC0 = P4_4,
-*/
-
-    // USB pins
-    //P_USB0_TX = SFP_USB1,
-    //P_USB0_RX = SFP_USB1,
-
-
-/*
-    // PWM pins
-    //                   210E    210     200E    200
-    //                   ----    ----    ----    ----
-    PWM1 = P1_7,      // J9-3    J9-3    S2-3    S2-3
-    PWM2 = P7_6,      // J9-8    J9-8    S4-6    S4-6
-	PWM3 = P6_12,     // J10-1   J10-1   S10-3   n/p
-    PWM4 = P4_6,      // J10-3   J10-3   S2-6    S2-6
-    PWM5 = P7_5,      // J8-2    J8-2    S4-4    S4-4
-    PWM6 = P4_1,      // J8-3    J8-3    S3-4    S3-4
-    PWM7 = P7_7,      // J8-4    J8-4    S4-5    S4-5
-    PWM8 = P2_8,      // J12-4   n/p     S8-3    n/p
-    PWM9 = P2_9,      // J12-6   n/p     S9-3    n/p
-    PWM10 = P7_1,     // J13-5   n/p     S9-8    n/p
-    PWM11 = P7_0,     // J13-6   n/p     S9-9    n/p
-    PWM12 = P1_5,     // J14-7   n/p     S10-6   n/p
-*/
 
     // ---------- End of LPCXpresso 4337 pins ----------
 } PinName;


### PR DESCRIPTION
Please find test summary below. There are some errors but I think it's not critical problem.
* MBED_16 (RCT) failed by automated test, however the same test case works by manual test.
* MBED_37 and MBED_38 (Serial NC RX/TX) failed.  I saw same failure in other platform such as the LPC1768.
* MBED_A9 (Serial) timeout.  I saw same failure in other platform such as the LPC1768.

```
Test summary:
+---------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result  | Target  | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+---------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK      | LPC4337 | ARM       | DTCT_1      | Simple detect test                    |        0.52        |       10      |  1/1  |
| OK      | LPC4337 | ARM       | EXAMPLE_1   | /dev/null                             |        3.51        |       20      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_10     | Hello World                           |        0.39        |       5       |  1/1  |
| OK      | LPC4337 | ARM       | MBED_11     | Ticker Int                            |       11.39        |       15      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_12     | C++                                   |        1.42        |       10      |  1/1  |
| FAIL    | LPC4337 | ARM       | MBED_16     | RTC                                   |        5.47        |       20      |  0/1  |
| OK      | LPC4337 | ARM       | MBED_2      | stdio                                 |        0.78        |       20      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_23     | Ticker Int us                         |       11.39        |       15      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_24     | Timeout Int us                        |       11.42        |       15      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_25     | Time us                               |       11.37        |       15      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_26     | Integer constant division             |        1.4         |       20      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_34     | Ticker Two callbacks                  |       11.37        |       15      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_36     | WFI correct behavior                  |       10.39        |       15      |  1/1  |
| FAIL    | LPC4337 | ARM       | MBED_37     | Serial NC RX                          |        0.94        |       20      |  0/1  |
| FAIL    | LPC4337 | ARM       | MBED_38     | Serial NC TX                          |        0.44        |       20      |  0/1  |
| OK      | LPC4337 | ARM       | MBED_A1     | Basic                                 |        1.37        |       20      |  1/1  |
| OK      | LPC4337 | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.5         |       20      |  1/1  |
| TIMEOUT | LPC4337 | ARM       | MBED_A9     | Serial Echo at 115200                 |       40.47        |       20      |  0/1  |
| OK      | LPC4337 | ARM       | MBED_BUSOUT | BusOut                                |        2.33        |       15      |  1/1  |
+---------+---------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 3 FAIL / 15 OK / 1 TIMEOUT

Completed in 247.79 sec

Build successes:
  * ARM::LPC4337
```