### PR TITLE
Enable LPC8xx usart when configuring it

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/serial_api.c
@@ -196,8 +196,18 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
         default:
             break;
     }
-    
-    obj->uart->CFG = (data_bits << 2)
+
+    // First disable the the usart as described in documentation and then enable while updating CFG
+
+    // 24.6.1 USART Configuration register
+    // Remark: If software needs to change configuration values, the following sequence should
+    // be used: 1) Make sure the USART is not currently sending or receiving data. 2) Disable
+    // the USART by writing a 0 to the Enable bit (0 may be written to the entire register). 3)
+    // Write the new configuration value, with the ENABLE bit set to 1.
+    obj->uart->CFG &= ~(1 << 0);
+
+    obj->uart->CFG = (1 << 0) // this will enable the usart
+                   | (data_bits << 2)
                    | (paritysel << 4)
                    | (stop_bits << 6);
 }

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC82X/serial_api.c
@@ -230,7 +230,17 @@ void serial_format(serial_t *obj, int data_bits, SerialParity parity, int stop_b
             break;
     }
 
-    obj->uart->CFG = (data_bits << 2)
+    // First disable the the usart as described in documentation and then enable while updating CFG
+
+    // 24.6.1 USART Configuration register
+    // Remark: If software needs to change configuration values, the following sequence should
+    // be used: 1) Make sure the USART is not currently sending or receiving data. 2) Disable
+    // the USART by writing a 0 to the Enable bit (0 may be written to the entire register). 3)
+    // Write the new configuration value, with the ENABLE bit set to 1.
+    obj->uart->CFG &= ~(1 << 0);
+
+    obj->uart->CFG = (1 << 0) // this will enable the usart
+                   | (data_bits << 2)
                    | (paritysel << 4)
                    | (stop_bits << 6);
 }


### PR DESCRIPTION
This is a pull request related to a similar issue to https://github.com/mbedmicro/mbed/issues/1011 for LPC8xx targets

This fix is a port of https://github.com/mbedmicro/mbed/pull/1012 to LPC81x/LPC82x
so credits go to @jurgis 