### PR TITLE
Update pwmout_api.c

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,3 @@
+general:
+  build_dir: api
+  

--- a/circle.yml
+++ b/circle.yml
@@ -1,3 +1,0 @@
-general:
-  build_dir: api
-  

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/pwmout_api.c
@@ -241,9 +241,9 @@ void pwmout_period_us(pwmout_t* obj, int us)
 
     TimHandle.Init.Period        = us - 1;
     if (APBxCLKDivider == RCC_HCLK_DIV1)
-      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq*2) / 1000000) - 1; // 1 µs tick
+      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq) / 1000000) - 1; // 1 Âµs tick
     else
-      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq) / 1000000) - 1; // 1 µs tick
+      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq)*2 / 1000000) - 1; // 1 Âµs tick
     TimHandle.Init.ClockDivision = 0;
     TimHandle.Init.CounterMode   = TIM_COUNTERMODE_UP;
     HAL_TIM_PWM_Init(&TimHandle);


### PR DESCRIPTION
Line 244 changed PclkFreq*2 to PcklFreq
Line 246 changed PclkFreq to PclkFreq*2

This is proposed as the current pwmout_api.c gives the wrong period/frequency when using e.g."mypwm.period_ms(1);"
For PWM1 1ms gave 500Hz and PWM2,3 and 4 gave 2KHz

Applied to source as above and re-compiled this gave 1KHz outputs for all PWM's selected
Tried on NUCLEO STM32F401RE will effect other NUCLEO-STM32F4 as above

HAL Clocks are as follows for the F401RE Board:  PCLK1=42000000 PCLK2=84000000 HCLK=84000000

Kind Regards

Martin