### PR TITLE
Update cmsis_nvic.c

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/TARGET_Freescale/TARGET_KLXX/TARGET_KL46Z/cmsis_nvic.c
@@ -31,14 +31,14 @@
 #include "cmsis_nvic.h"
 
 #define NVIC_RAM_VECTOR_ADDRESS (0x1FFFE000)  // Vectors positioned at start of RAM
-#define NVIC_FLASH_VECTOR_ADDRESS (0x0)       // Initial vector position in flash
+#define NVIC_FLASH_VECTOR_ADDRESS (__vector_table)       // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     uint32_t *vectors = (uint32_t*)SCB->VTOR;
     uint32_t i;
 
     // Copy and switch to dynamic vectors if the first time called
-    if (SCB->VTOR == NVIC_FLASH_VECTOR_ADDRESS) {
+    if (SCB->VTOR < NVIC_RAM_VECTOR_ADDRESS) {
         uint32_t *old_vectors = vectors;
         vectors = (uint32_t*)NVIC_RAM_VECTOR_ADDRESS;
         for (i=0; i<NVIC_NUM_VECTORS; i++) {


### PR DESCRIPTION
Ensure the NVIC table gets copied to RAM even when it is not at 0x0000
Same as 152b58673f64d18174038282d90ca97e67d44ae2 for TARGET_LPC176X