### PR TITLE
[LPC15XX] Fix GPIO port word pin registers offset

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC15XX/LPC15xx.h
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC15XX/LPC15xx.h
@@ -159,9 +159,9 @@ typedef enum {
 
 typedef struct {                                    /*!< GPIO_PORT Structure                                                   */
   __IO uint8_t   B[76];                             /*!< Byte pin registers                                                    */
-  __I  uint32_t  RESERVED0[45];
+  __I  uint32_t  RESERVED0[1005];
   __IO uint32_t  W[76];                             /*!< Word pin registers                                                    */
-  __I  uint32_t  RESERVED1[1908];
+  __I  uint32_t  RESERVED1[948];
   __IO uint32_t  DIR[3];                            /*!< Port Direction registers                                              */
   __I  uint32_t  RESERVED2[29];
   __IO uint32_t  MASK[3];                           /*!< Port Mask register                                                    */


### PR DESCRIPTION
Adjust offset for GPIO port word pin registers from 0x100 to 0x1000.

The updated SVD file supporting this change can be found on the [lpcware](https://www.lpcware.com/content/nxpfile/lpc1500-svd-file) site.

I don't think any existing code makes use of the GPIO word pin registers, but I've manually verified that they work on an LPCXpresso 1549 board.