### PR TITLE
ST BLoD Fix

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/device.h
@@ -63,7 +63,8 @@
 
 #define DEVICE_STDIO_MESSAGES   1
 
-#define DEVICE_ERROR_RED        0
+#define DEVICE_ERROR_RED        1
+#define LED_RED                 LED1
 
 #include "objects.h"
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/device.h
@@ -63,7 +63,8 @@
 
 #define DEVICE_STDIO_MESSAGES   1
 
-#define DEVICE_ERROR_RED        0
+#define DEVICE_ERROR_RED        1
+#define LED_RED                 LED1
 
 #include "objects.h"
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device.h
@@ -63,7 +63,8 @@
 
 #define DEVICE_STDIO_MESSAGES   1
 
-#define DEVICE_ERROR_RED        0
+#define DEVICE_ERROR_RED        1
+#define LED_RED                 LED1
 
 #include "objects.h"
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device.h
@@ -63,7 +63,8 @@
 
 #define DEVICE_STDIO_MESSAGES   1
 
-#define DEVICE_ERROR_RED        0
+#define DEVICE_ERROR_RED        1
+#define LED_RED                 LED1
 
 #include "objects.h"
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device.h
@@ -63,7 +63,8 @@
 
 #define DEVICE_STDIO_MESSAGES   1
 
-#define DEVICE_ERROR_RED        0
+#define DEVICE_ERROR_RED        1
+#define LED_RED                 LED1
 
 #include "objects.h"
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/device.h
@@ -63,7 +63,8 @@
 
 #define DEVICE_STDIO_MESSAGES   1
 
-#define DEVICE_ERROR_RED        0
+#define DEVICE_ERROR_RED        1
+#define LED_RED                 LED1
 
 #include "objects.h"
 


### PR DESCRIPTION
## Problem
All ST boards do not have the blue lights of death. on calling `error()` the message will print, but the led lights will not blink, this PR adds BLoD to all ST boards. 

## Solution
Add requisite lines to the device.h files to enable BLoD behavior (All ST Boards have a single led)

## Future Improvements
* improve the BLOD routine so its generic for one light (ie get change the ERROR_LED_RED to something like ERROR_LED_SINGLE) 
* change rate of blink to be random-ish like true siren lights are
* get partners to add this to all the ST Board derivitives (ublox, mdot, archmax)
