### PR TITLE
Blue Lights of Death fix for Silicon Labs boards

### DIFF
--- a/libraries/mbed/common/board.c
+++ b/libraries/mbed/common/board.c
@@ -19,7 +19,7 @@
 #include "mbed_interface.h"
 
 WEAK void mbed_die(void) {
-#ifndef NRF51_H
+#if !defined (NRF51_H) && !defined(TARGET_EFM32)
 	__disable_irq();	// dont allow interrupts to disturb the flash pattern
 #endif
 #if   (DEVICE_ERROR_RED == 1)

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device.h
@@ -50,6 +50,8 @@
 
 #define DEVICE_LOWPOWERTIMER    1
 
+#define DEVICE_ERROR_PATTERN    1
+
 #include "objects.h"
 #include "device_peripherals.h"
 

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG_STK3400/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG_STK3400/device.h
@@ -50,6 +50,8 @@
 
 #define DEVICE_LOWPOWERTIMER    1
 
+#define DEVICE_ERROR_PATTERN    1
+
 // Redefine OPEN_MAX from sys_limits.h to save on RAM.
 // Effect: maximum amount of file handlers = OPEN_MAX
 // This is not going to have an impact, since this is a RAM-limited part anyway.

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG_STK3600/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG_STK3600/device.h
@@ -50,6 +50,8 @@
 
 #define DEVICE_LOWPOWERTIMER    1
 
+#define DEVICE_ERROR_PATTERN    1
+
 #include "objects.h"
 #include "Modules.h"
 #include "device_peripherals.h"

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG_STK3800/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG_STK3800/device.h
@@ -50,6 +50,8 @@
 
 #define DEVICE_LOWPOWERTIMER    1
 
+#define DEVICE_ERROR_PATTERN    1
+
 #include "objects.h"
 #include "Modules.h"
 #include "device_peripherals.h"

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG_STK3200/device.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG_STK3200/device.h
@@ -50,6 +50,8 @@
 
 #define DEVICE_LOWPOWERTIMER    1
 
+#define DEVICE_ERROR_PATTERN    1
+
 // Redefine OPEN_MAX from sys_limits.h to save on RAM.
 // Effect: maximum amount of file handlers = OPEN_MAX
 // This is not going to have an impact, since this is a RAM-limited part anyway.


### PR DESCRIPTION
## Problem
the Silicon Labs boards do not exhibit proper siren lights when the error() function is called.

## Solution
This pull request adds the proper #defines to trigger siren lights on LED0 and LED1. Now the siren lights work correctly.

## Validate
Try running the following code before the PR and after. Prior it will hang and a single LED will light up, after the PR siren lights will flash and text will appear on the output terminal. 

```C
#include "mbed.h"

void
main(void){
    error("something went wrong...");
    // Siren lights should be flashing now and output should be on the terminal
}
```