### PR TITLE
Tools: Added verbose mode to mbed library build when using singletest.py

### DIFF
--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -348,6 +348,7 @@ class SingleTestRunner(object):
                                                          toolchain,
                                                          options=build_mbed_libs_options,
                                                          clean=clean_mbed_libs_options,
+                                                         verbose=self.opts_verbose,
                                                          jobs=self.opts_jobs)
 
                 if not build_mbed_libs_result:


### PR DESCRIPTION
#　Description
This is a minor change but improves toolchain issues investigations and assigns proper behavior to verbose flag.

Added verbose mode to mbed library build when using ```singletest.py``` ```-v``` (verbose) switch
# Rationale
When using
```
$ cd mbed/workspace_tools
$ singletest.py ... -v
```
verbose prints from mbed SDK library build were not shown.
When debugging issues related to compiler flags etc. those verbose messages should be visible.

# Test and example output
```
$ singletest.py --auto -v
```
```make
[DEBUG] Command: c:/Keil/ARM/ARMCC\bin\armcc -c --cpu=Cortex-M4.fp --gnu -Otime --split_sections --apcs=interwork --brief_diagnostics --restrict --multibyte_chars -O3 -Ic:/Keil/ARM/ARMCC\include -DTARGET_KPSDK_MCUS -DTARGET_FF_ARDUINO -D__CORTEX_M4 -DCPU_MK64FN1M0VMD12 -DTARGET_FRDM -DTARGET_CORTEX_M -D__FPU_PRESENT=1 -DMBED_BUILD_TIMESTAMP=1439369410.9 -DTARGET_KPSDK_CODE -DTARGET_M4 -D__MBED__=1 -DARM_MATH_CM4 -DTARGET_K64F -DTARGET_Freescale -DFSL_RTOS_MBED -DTOOLCHAIN_ARM -DTARGET_MCU_K64F -DTOOLCHAIN_ARM_STD -IC:\Work\przemek2\mbed\libraries\mbed\targets\cmsis -IC:\Work\przemek2\mbed\libraries\mbed\targets\cmsis\TARGET_Freescale -IC:\Work\przemek2\mbed\libraries\mbed\targets\cmsis\TARGET_Freescale\TARGET_MCU_K64F -IC:\Work\przemek2\mbed\libraries\mbed\targets\cmsis\TARGET_Freescale\TARGET_MCU_K64F\TOOLCHAIN_ARM_STD -E -o C:\Work\przemek2\mbed\build\mbed\.temp\TARGET_K64F\TOOLCHAIN_ARM_STD\TARGET_Freescale\TARGET_MCU_K64F\TOOLCHAIN_ARM_STD\startup_MK64F12.o.E.s C:\Work\przemek2\mbed\libraries\mbed\targets\cmsis\TARGET_Freescale\TARGET_MCU_K64F\TOOLCHAIN_ARM_STD\startup_MK64F12.S
[DEBUG] Return: 0
[DEBUG] Output: "no source": Warning:  #3036-D: "c:/Keil/ARM/ARMCC\include" was specified as both a system and non-system include directory -- the non-system entry will be ignored
[DEBUG] Output: C:\Work\przemek2\mbed\libraries\mbed\targets\cmsis\TARGET_Freescale\TARGET_MCU_K64F\TOOLCHAIN_ARM_STD\startup_MK64F12.S: 1 warning, 0 errors
```