### PR TITLE
Fix compilation warning

### DIFF
--- a/libraries/rtos/rtos/Thread.cpp
+++ b/libraries/rtos/rtos/Thread.cpp
@@ -42,7 +42,7 @@ Thread::Thread(void (*task)(void const *argument), void *argument,
     }
     
     //Fill the stack with a magic word for maximum usage checking
-    for (int i = 0; i < (stack_size / sizeof(uint32_t)); i++) {
+    for (uint32_t i = 0; i < (stack_size / sizeof(uint32_t)); i++) {
         _thread_def.stack_pointer[i] = 0xE25A2EA5;
     }
 #endif


### PR DESCRIPTION
The warning message is shown as below.

Compile: Thread.cpp
[Warning] Thread.cpp@45: In constructor 'rtos::Thread::Thread(void (*)(const void*), void*, osPriority, uint32_t, unsigned char*)':
  comparison between signed and unsigned integer expressions [-Wsign-compare]

Signed-off-by: Jun-Ru Chang <jrjang@gmail.com>