### PR TITLE
[Silicon Labs] Fix incorrect clock selection

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device_peripherals.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32GG_STK3700/device_peripherals.h
@@ -32,12 +32,12 @@
 /* Clocks */
 
 /* Clock definitions */
-#define LFXO	cmuSelect_LFXO
-#define HFXO	cmuSelect_HFXO
-#define LFRCO	cmuSelect_LFRCO
-#define HFRCO	cmuSelect_HFRCO
+#define LFXO	0
+#define HFXO	1
+#define LFRCO	2
+#define HFRCO	3
 #if !defined(_EFM32_GECKO_FAMILY)
-#define ULFRCO	cmuSelect_ULFRCO
+#define ULFRCO	4
 #endif
 
 /* Low Energy peripheral clock source.

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG_STK3400/device_peripherals.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32HG_STK3400/device_peripherals.h
@@ -32,12 +32,12 @@
 /* Clocks */
 
 /* Clock definitions */
-#define LFXO	cmuSelect_LFXO
-#define HFXO	cmuSelect_HFXO
-#define LFRCO	cmuSelect_LFRCO
-#define HFRCO	cmuSelect_HFRCO
+#define LFXO	0
+#define HFXO	1
+#define LFRCO	2
+#define HFRCO	3
 #if !defined(_EFM32_GECKO_FAMILY)
-#define ULFRCO	cmuSelect_ULFRCO
+#define ULFRCO	4
 #endif
 
 /* Low Energy peripheral clock source.

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG_STK3600/device_peripherals.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32LG_STK3600/device_peripherals.h
@@ -32,12 +32,12 @@
 /* Clocks */
 
 /* Clock definitions */
-#define LFXO	cmuSelect_LFXO
-#define HFXO	cmuSelect_HFXO
-#define LFRCO	cmuSelect_LFRCO
-#define HFRCO	cmuSelect_HFRCO
+#define LFXO	0
+#define HFXO	1
+#define LFRCO	2
+#define HFRCO	3
 #if !defined(_EFM32_GECKO_FAMILY)
-#define ULFRCO	cmuSelect_ULFRCO
+#define ULFRCO	4
 #endif
 
 /* Low Energy peripheral clock source.

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG_STK3800/device_peripherals.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32WG_STK3800/device_peripherals.h
@@ -32,12 +32,12 @@
 /* Clocks */
 
 /* Clock definitions */
-#define LFXO	cmuSelect_LFXO
-#define HFXO	cmuSelect_HFXO
-#define LFRCO	cmuSelect_LFRCO
-#define HFRCO	cmuSelect_HFRCO
+#define LFXO	0
+#define HFXO	1
+#define LFRCO	2
+#define HFRCO	3
 #if !defined(_EFM32_GECKO_FAMILY)
-#define ULFRCO	cmuSelect_ULFRCO
+#define ULFRCO	4
 #endif
 
 /* Low Energy peripheral clock source.

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG_STK3200/device_peripherals.h
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/TARGET_EFM32ZG_STK3200/device_peripherals.h
@@ -29,12 +29,12 @@
 /* Clocks */
 
 /* Clock definitions */
-#define LFXO	cmuSelect_LFXO
-#define HFXO	cmuSelect_HFXO
-#define LFRCO	cmuSelect_LFRCO
-#define HFRCO	cmuSelect_HFRCO
+#define LFXO	0
+#define HFXO	1
+#define LFRCO	2
+#define HFRCO	3
 #if !defined(_EFM32_GECKO_FAMILY)
-#define ULFRCO	cmuSelect_ULFRCO
+#define ULFRCO	4
 #endif
 
 /* Low Energy peripheral clock source.

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/mbed_overrides.c
@@ -34,10 +34,12 @@ void mbed_sdk_init()
 
     /* Set up the clock sources for this chip */
 #if( CORE_CLOCK_SOURCE == HFXO)
-    CMU_ClockSelectSet(cmuClock_HF, HFXO);
+    CMU_ClockSelectSet(cmuClock_HF, cmuSelect_HFXO);
+    CMU_ClockSelectSet(cmuClock_HFPER, cmuSelect_HFXO);
     SystemHFXOClockSet(HFXO_FREQUENCY);
 #elif( CORE_CLOCK_SOURCE == HFRCO)
-    CMU_ClockSelectSet(cmuClock_HF, HFRCO);
+    CMU_ClockSelectSet(cmuClock_HF, cmuSelect_HFRCO);
+    CMU_ClockSelectSet(cmuClock_HFPER, cmuSelect_HFRCO);
     CMU_HFRCOBandSet(HFRCO_FREQUENCY);
 #else
 #error "Core clock selection not valid (mbed_overrides.c)"
@@ -47,7 +49,7 @@ void mbed_sdk_init()
 
 #if( LOW_ENERGY_CLOCK_SOURCE == LFXO )
 #ifdef CMU_LFACLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFA, LFXO);
+    CMU_ClockSelectSet(cmuClock_LFA, cmuSelect_LFXO);
 #endif
 #ifdef CMU_LFBCLKSEL_REG
     /* cmuClock_LFB (to date) only has LEUART peripherals.
@@ -58,31 +60,31 @@ void mbed_sdk_init()
     //CMU_ClockSelectSet(cmuClock_LFB, LFXO);
 #endif
 #ifdef CMU_LFECLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFE, LFXO);
+    CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFXO);
 #endif
     SystemLFXOClockSet(LFXO_FREQUENCY);
 
 #elif( LOW_ENERGY_CLOCK_SOURCE == LFRCO )
 #ifdef CMU_LFACLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFA, LFRCO);
+    CMU_ClockSelectSet(cmuClock_LFA, cmuSelect_LFRCO);
 #endif
 #ifdef CMU_LFBCLKSEL_REG
     //CMU_ClockSelectSet(cmuClock_LFB, LFRCO);
 #endif
 #ifdef CMU_LFECLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFE, LFRCO);
+    CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_LFRCO);
 #endif
     CMU_HFRCOBandSet(HFRCO_FREQUENCY);
 
 #elif( LOW_ENERGY_CLOCK_SOURCE == ULFRCO)
 #ifdef CMU_LFACLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFA, ULFRCO);
+    CMU_ClockSelectSet(cmuClock_LFA, cmuSelect_ULFRCO);
 #endif
 #ifdef CMU_LFBCLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFB, ULFRCO);
+    CMU_ClockSelectSet(cmuClock_LFB, cmuSelect_ULFRCO);
 #endif
 #ifdef CMU_LFECLKSEL_REG
-    CMU_ClockSelectSet(cmuClock_LFE, ULFRCO);
+    CMU_ClockSelectSet(cmuClock_LFE, cmuSelect_ULFRCO);
 #endif
 #else
 #error "Low energy clock selection not valid"


### PR DESCRIPTION
In certain cases, the clock selection in the board header did not take effect, even though HFXO was requested.

Root cause: you cannot use a C-enum name in a #if compare, because the preprocessor will replace all enum names with 0 (so all checks on HFXO/LFXO checked out regardless of the define).