### PR TITLE
Tools: singletest.py option -c with shell copy method as default copy method

### DIFF
--- a/workspace_tools/host_tests/host_test.py
+++ b/workspace_tools/host_tests/host_test.py
@@ -250,12 +250,15 @@ class Mbed:
         """ Copy file depending on method you want to use. Handles exception
             and return code from shell copy commands.
         """
+        # image_path - Where is binary with target's firmware
         if copy_method is not None:
-            # image_path - Where is binary with target's firmware
-            result = host_tests_plugins.call_plugin('CopyMethod', copy_method, image_path=image_path, destination_disk=disk)
+            # We override 'default' method with 'shell' method
+            if copy_method == 'default':
+                copy_method = 'shell'
         else:
-            copy_method = 'default'
-            result = host_tests_plugins.call_plugin('CopyMethod', copy_method, image_path=image_path, destination_disk=disk)
+            copy_method = 'shell'
+
+        result = host_tests_plugins.call_plugin('CopyMethod', copy_method, image_path=image_path, destination_disk=disk)
         return result;
 
     def flush(self):

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
@@ -49,13 +49,13 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
         """
         return True
 
-    def execute(self, capabilitity, *args, **kwargs):
+    def execute(self, capability, *args, **kwargs):
         """ Executes capability by name.
             Each capability may directly just call some command line
             program or execute building pythonic function
         """
         result = False
-        if self.check_parameters(capabilitity, *args, **kwargs) is True:
+        if self.check_parameters(capability, *args, **kwargs) is True:
             # Capability 'default' is a dummy capability
             if capability == 'shutil':
                 image_path = kwargs['image_path']

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
@@ -41,7 +41,7 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
     name = 'HostTestPluginCopyMethod_Mbed'
     type = 'CopyMethod'
     stable = True
-    capabilities = ['default']
+    capabilities = ['shutil', 'default']
     required_parameters = ['image_path', 'destination_disk']
 
     def setup(self, *args, **kwargs):
@@ -56,7 +56,8 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
         """
         result = False
         if self.check_parameters(capabilitity, *args, **kwargs) is True:
-            if capabilitity == 'default':
+            # Capability 'default' is a dummy capability
+            if capability == 'shutil':
                 image_path = kwargs['image_path']
                 destination_disk = kwargs['destination_disk']
                 # Wait for mount point to be ready

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
@@ -34,13 +34,13 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
         """
         return True
 
-    def execute(self, capabilitity, *args, **kwargs):
+    def execute(self, capability, *args, **kwargs):
         """ Executes capability by name.
             Each capability may directly just call some command line
             program or execute building pythonic function
         """
         result = False
-        if self.check_parameters(capabilitity, *args, **kwargs) is True:
+        if self.check_parameters(capability, *args, **kwargs) is True:
             image_path = kwargs['image_path']
             destination_disk = kwargs['destination_disk']
             # Wait for mount point to be ready
@@ -48,14 +48,17 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
             # Prepare correct command line parameter values
             image_base_name = basename(image_path)
             destination_path = join(destination_disk, image_base_name)
-            if capabilitity == 'shell':
-                if os.name == 'nt': capabilitity = 'copy'
-                elif os.name == 'posix': capabilitity = 'cp'
-            if capabilitity == 'cp' or capabilitity == 'copy' or capabilitity == 'xcopy':
-                copy_method = capabilitity
+            if capability == 'shell':
+                if os.name == 'nt': capability = 'copy'
+                elif os.name == 'posix': capability = 'cp'
+            if capability == 'cp' or capability == 'copy' or capability == 'copy':
+                copy_method = capability
                 cmd = [copy_method, image_path, destination_path]
-                shell = not capabilitity == 'cp'
-                result = self.run_command(cmd, shell=shell)
+                if os.name == 'posix':
+                    result = self.run_command(cmd, shell=False)
+                    result = self.run_command(["sync"])
+                else:
+                    result = self.run_command(cmd)
         return result
 
 


### PR DESCRIPTION
# Description
This PR aligns how mbed 2 and 3 use ```-c``` of switch for ```singletest.py```.
Note: ```-c``` switch allows users to select binary copy method.

With this change default copy (mbed flashing) method will be changed from ```shutil``` to default OS shell copy command:
* posix: ```cp```, ```sync```
* Windows: ```copy```

This hopefully will prevent issues such as 'flashing failed due to shutil.copy() implementation defects';
mbed interface chip handles well default OS copy commands, not Python's ```shutil.copy()```.
