### PR TITLE
LPC81X: reduce code size and add ARM_GCC support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,4 +72,5 @@ cscope.*
 
 # vim swap files
 *.swp
+*~
 

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC810/TOOLCHAIN_GCC_ARM/LPC810.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC810/TOOLCHAIN_GCC_ARM/LPC810.ld
@@ -1,11 +1,11 @@
-/* Linker script for mbed LPC824-GCC-ARM based on LPC1114-GCC-ARM-LPC1114.ld */
+/* Linker script for mbed LPC810-GCC-ARM based on LPC824.ld */
 
 /* Linker script to configure memory regions. */
 MEMORY
 {
   /* Define each memory region */
-  FLASH (rx) : ORIGIN = 0x0, LENGTH = 0x8000 /* 32K bytes */
-  RAM (rwx) : ORIGIN = 0x10000000+0xC0, LENGTH = 0x2000-0xC0 /* 8K bytes */
+  FLASH (rx) : ORIGIN = 0x0, LENGTH = 0x1000 /* 4K bytes */
+  RAM (rwx) : ORIGIN = 0x10000000+0xC0, LENGTH = 0x400-0xC0 /* 1K bytes */
 
 
 }
@@ -14,7 +14,7 @@ MEMORY
  * with other linker script that defines memory regions FLASH and RAM.
  * It references following symbols, which must be defined in code:
  *   Reset_Handler : Entry of reset handler
- * 
+ *
  * It defines following symbols, which code can use without definition:
  *   __exidx_start
  *   __exidx_end
@@ -69,7 +69,7 @@ SECTIONS
         KEEP(*(.eh_frame*))
     } > FLASH
 
-    .ARM.extab : 
+    .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
     } > FLASH
@@ -82,7 +82,7 @@ SECTIONS
     __exidx_end = .;
 
     __etext = .;
-        
+
     .data : AT (__etext)
     {
         __data_start__ = .;
@@ -123,7 +123,7 @@ SECTIONS
         *(COMMON)
         __bss_end__ = .;
     } > RAM
-    
+
     .heap :
     {
         __end__ = .;
@@ -145,7 +145,7 @@ SECTIONS
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
-    
+
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/TOOLCHAIN_GCC_ARM/LPC812.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TARGET_LPC812/TOOLCHAIN_GCC_ARM/LPC812.ld
@@ -1,11 +1,11 @@
-/* Linker script for mbed LPC824-GCC-ARM based on LPC1114-GCC-ARM-LPC1114.ld */
+/* Linker script for mbed LPC812-GCC-ARM based on LPC824.ld */
 
 /* Linker script to configure memory regions. */
 MEMORY
 {
   /* Define each memory region */
-  FLASH (rx) : ORIGIN = 0x0, LENGTH = 0x8000 /* 32K bytes */
-  RAM (rwx) : ORIGIN = 0x10000000+0xC0, LENGTH = 0x2000-0xC0 /* 8K bytes */
+  FLASH (rx) : ORIGIN = 0x0, LENGTH = 0x4000 /* 16K bytes */
+  RAM (rwx) : ORIGIN = 0x10000000+0xC0, LENGTH = 0x1000-0xC0 /* 4K bytes */
 
 
 }
@@ -14,7 +14,7 @@ MEMORY
  * with other linker script that defines memory regions FLASH and RAM.
  * It references following symbols, which must be defined in code:
  *   Reset_Handler : Entry of reset handler
- * 
+ *
  * It defines following symbols, which code can use without definition:
  *   __exidx_start
  *   __exidx_end
@@ -69,7 +69,7 @@ SECTIONS
         KEEP(*(.eh_frame*))
     } > FLASH
 
-    .ARM.extab : 
+    .ARM.extab :
     {
         *(.ARM.extab* .gnu.linkonce.armextab.*)
     } > FLASH
@@ -82,7 +82,7 @@ SECTIONS
     __exidx_end = .;
 
     __etext = .;
-        
+
     .data : AT (__etext)
     {
         __data_start__ = .;
@@ -123,7 +123,7 @@ SECTIONS
         *(COMMON)
         __bss_end__ = .;
     } > RAM
-    
+
     .heap :
     {
         __end__ = .;
@@ -145,7 +145,7 @@ SECTIONS
     __StackTop = ORIGIN(RAM) + LENGTH(RAM);
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);
-    
+
     /* Check if data + heap + stack exceeds RAM limit */
     ASSERT(__StackLimit >= __HeapLimit, "region RAM overflowed with stack")
 }

--- a/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TOOLCHAIN_GCC_ARM/startup_LPC81X.S
+++ b/libraries/mbed/targets/cmsis/TARGET_NXP/TARGET_LPC81X/TOOLCHAIN_GCC_ARM/startup_LPC81X.S
@@ -1,0 +1,219 @@
+/* File: startup_ARMCM0.S
+ * Purpose: startup file for Cortex-M0 devices. Should use with
+ *   GCC for ARM Embedded Processors
+ * Version: V1.2
+ * Date: 15 Nov 2011
+ *
+ * Copyright (c) 2011, ARM Limited
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+      notice, this list of conditions and the following disclaimer in the
+      documentation and/or other materials provided with the distribution.
+    * Neither the name of the ARM Limited nor the
+      names of its contributors may be used to endorse or promote products
+      derived from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ * ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ * WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL ARM LIMITED BE LIABLE FOR ANY
+ * DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ * LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ * ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ * (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ * SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+    .syntax unified
+    .arch armv6-m
+
+/* Memory Model
+   The HEAP starts at the end of the DATA section and grows upward.
+
+   The STACK starts at the end of the RAM and grows downward.
+
+   The HEAP and stack STACK are only checked at compile time:
+   (DATA_SIZE + HEAP_SIZE + STACK_SIZE) < RAM_SIZE
+
+   This is just a check for the bare minimum for the Heap+Stack area before
+   aborting compilation, it is not the run time limit:
+   Heap_Size + Stack_Size = 0x80 + 0x80 = 0x100
+ */
+    .section .stack
+    .align 3
+#ifdef __STACK_SIZE
+    .equ    Stack_Size, __STACK_SIZE
+#else
+    .equ    Stack_Size, 0x80
+#endif
+    .globl    __StackTop
+    .globl    __StackLimit
+__StackLimit:
+    .space    Stack_Size
+    .size __StackLimit, . - __StackLimit
+__StackTop:
+    .size __StackTop, . - __StackTop
+
+    .section .heap
+    .align 3
+#ifdef __HEAP_SIZE
+    .equ    Heap_Size, __HEAP_SIZE
+#else
+    .equ    Heap_Size, 0x80
+#endif
+    .globl    __HeapBase
+    .globl    __HeapLimit
+__HeapBase:
+    .space    Heap_Size
+    .size __HeapBase, . - __HeapBase
+__HeapLimit:
+    .size __HeapLimit, . - __HeapLimit
+
+    .section .isr_vector
+    .align 2
+    .globl __isr_vector
+__isr_vector:
+    .long    __StackTop            /* Top of Stack */
+    .long    Reset_Handler         /* Reset Handler */
+    .long    NMI_Handler           /* NMI Handler */
+    .long    HardFault_Handler     /* Hard Fault Handler */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    SVC_Handler           /* SVCall Handler */
+    .long    0                     /* Reserved */
+    .long    0                     /* Reserved */
+    .long    PendSV_Handler        /* PendSV Handler */
+    .long    SysTick_Handler       /* SysTick Handler */
+
+/* LPC810 interrupts */
+    .long    SPI0_IRQHandler                         // SPI0 controller
+    .long    SPI1_IRQHandler                         // SPI1 controller
+    .long    0                                       // Reserved
+    .long    UART0_IRQHandler                        // UART0
+    .long    UART1_IRQHandler                        // UART1
+    .long    UART2_IRQHandler                        // UART2
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    I2C_IRQHandler                          // I2C controller
+    .long    SCT_IRQHandler                          // Smart Counter Timer
+    .long    MRT_IRQHandler                          // Multi-Rate Timer
+    .long    CMP_IRQHandler                          // Comparator
+    .long    WDT_IRQHandler                          // PIO1 (0:11)
+    .long    BOD_IRQHandler                          // Brown Out Detect
+    .long    0                                       // Reserved
+    .long    WKT_IRQHandler                          // Wakeup timer
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    0                                       // Reserved
+    .long    PININT0_IRQHandler                      // PIO INT0
+    .long    PININT1_IRQHandler                      // PIO INT1
+    .long    PININT2_IRQHandler                      // PIO INT2
+    .long    PININT3_IRQHandler                      // PIO INT3
+    .long    PININT4_IRQHandler                      // PIO INT4
+    .long    PININT5_IRQHandler                      // PIO INT5
+    .long    PININT6_IRQHandler                      // PIO INT6
+    .long    PININT7_IRQHandler                      // PIO INT7
+
+    .size    __isr_vector, . - __isr_vector
+
+    .section .text.Reset_Handler
+    .thumb
+    .thumb_func
+    .align 2
+    .globl    Reset_Handler
+    .type    Reset_Handler, %function
+Reset_Handler:
+/*     Loop to copy data from read only memory to RAM. The ranges
+ *      of copy from/to are specified by following symbols evaluated in
+ *      linker script.
+ *      __etext: End of code section, i.e., begin of data sections to copy from.
+ *      __data_start__/__data_end__: RAM address range that data should be
+ *      copied to. Both must be aligned to 4 bytes boundary.  */
+
+    ldr    r1, =__etext
+    ldr    r2, =__data_start__
+    ldr    r3, =__data_end__
+
+    subs    r3, r2
+    ble    .Lflash_to_ram_loop_end
+
+    movs    r4, 0
+.Lflash_to_ram_loop:
+    ldr    r0, [r1,r4]
+    str    r0, [r2,r4]
+    adds    r4, 4
+    cmp    r4, r3
+    blt    .Lflash_to_ram_loop
+.Lflash_to_ram_loop_end:
+
+    ldr    r0, =SystemInit
+    blx    r0
+    ldr    r0, =_start
+    bx    r0
+    .pool
+    .size Reset_Handler, . - Reset_Handler
+
+    .text
+/*    Macro to define default handlers. Default handler
+ *    will be weak symbol and just dead loops. They can be
+ *    overwritten by other handlers */
+    .macro    def_default_handler    handler_name
+    .align 1
+    .thumb_func
+    .weak    \handler_name
+    .type    \handler_name, %function
+\handler_name :
+    b    .
+    .size    \handler_name, . - \handler_name
+    .endm
+
+    def_default_handler     NMI_Handler
+    def_default_handler     HardFault_Handler
+    def_default_handler     SVC_Handler
+    def_default_handler     PendSV_Handler
+    def_default_handler     SysTick_Handler
+    def_default_handler     Default_Handler
+
+    .macro    def_irq_default_handler    handler_name
+    .weak     \handler_name
+    .set      \handler_name, Default_Handler
+    .endm
+
+    def_irq_default_handler    SPI0_IRQHandler
+    def_irq_default_handler    SPI1_IRQHandler
+    def_irq_default_handler    UART0_IRQHandler
+    def_irq_default_handler    UART1_IRQHandler
+    def_irq_default_handler    UART2_IRQHandler
+    def_irq_default_handler    I2C_IRQHandler
+    def_irq_default_handler    SCT_IRQHandler
+    def_irq_default_handler    MRT_IRQHandler
+    def_irq_default_handler    CMP_IRQHandler
+    def_irq_default_handler    WDT_IRQHandler
+    def_irq_default_handler    BOD_IRQHandler
+    def_irq_default_handler    WKT_IRQHandler
+    def_irq_default_handler    PININT0_IRQHandler
+    def_irq_default_handler    PININT1_IRQHandler
+    def_irq_default_handler    PININT2_IRQHandler
+    def_irq_default_handler    PININT3_IRQHandler
+    def_irq_default_handler    PININT4_IRQHandler
+    def_irq_default_handler    PININT5_IRQHandler
+    def_irq_default_handler    PININT6_IRQHandler
+    def_irq_default_handler    PININT7_IRQHandler
+
+    .end
+

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/pinmap.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC81X/pinmap.c
@@ -27,7 +27,17 @@ __IO uint32_t* IOCON_REGISTERS[18] = {
 };
 
 void pin_function(PinName pin, int function) {
-    
+    if (function == 0) {
+        // Disable initial fixed function for P0_2, P0_3 and P0_5
+        uint32_t enable = 0;
+        if (pin == P0_2)
+            enable = 1 << 3;
+        else if (pin == P0_3)
+            enable = 1 << 2;
+        else if (pin == P0_5)
+            enable = 1 << 6;
+        LPC_SWM->PINENABLE0 |= enable;
+    }
 }
 
 void pin_mode(PinName pin, PinMode mode) {

--- a/workspace_tools/export/gcc_arm_lpc810.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc810.tmpl
@@ -1,0 +1,10 @@
+{% extends "gcc_arm_common.tmpl" %}
+
+{% block target_project_elf %}
+{{ super() }}
+	@echo ""
+	@echo "*****"
+	@echo "***** You must modify vector checksum value in *.bin and *.hex files."
+	@echo "*****"
+	@echo ""
+{% endblock %}

--- a/workspace_tools/export/gcc_arm_lpc812.tmpl
+++ b/workspace_tools/export/gcc_arm_lpc812.tmpl
@@ -1,0 +1,10 @@
+{% extends "gcc_arm_common.tmpl" %}
+
+{% block target_project_elf %}
+{{ super() }}
+	@echo ""
+	@echo "*****"
+	@echo "***** You must modify vector checksum value in *.bin and *.hex files."
+	@echo "*****"
+	@echo ""
+{% endblock %}

--- a/workspace_tools/export/gccarm.py
+++ b/workspace_tools/export/gccarm.py
@@ -40,6 +40,8 @@ class GccArm(Exporter):
         'LPC11U35_401',
         'LPC11U35_501',
         'LPC11U37H_401',
+        'LPC810',
+        'LPC812',
         'LPC824',
         'SSCI824',
         'STM32F407',

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -315,7 +315,7 @@ class LPC810(LPCTarget):
         LPCTarget.__init__(self)
         self.core = "Cortex-M0+"
         self.extra_labels = ['NXP', 'LPC81X']
-        self.supported_toolchains = ["uARM", "IAR"]
+        self.supported_toolchains = ["uARM", "IAR", "GCC_ARM"]
         self.default_toolchain = "uARM"
         self.is_disk_virtual = True
 
@@ -324,7 +324,7 @@ class LPC812(LPCTarget):
         LPCTarget.__init__(self)
         self.core = "Cortex-M0+"
         self.extra_labels = ['NXP', 'LPC81X']
-        self.supported_toolchains = ["uARM", "IAR"]
+        self.supported_toolchains = ["uARM", "IAR", "GCC_ARM"]
         self.default_toolchain = "uARM"
         self.supported_form_factors = ["ARDUINO"]
         self.is_disk_virtual = True


### PR DESCRIPTION
LPC810 has only 4KB of flash, thus avoiding dead code is really nice.
Here the NVIC interrupt setup was pulled from the us_ticker code even
if no code is using timer events.

This also adds ARM_GCC support for TARGET_LPC81X.

LPC81X and LPC82X support Cortex M0+ VTOR register, so it is not
necessary to put non-init text at 0x200.