### PR TITLE
Modify to support NEON for RTOS. (tools files)

### DIFF
--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -52,7 +52,7 @@ class GCC(mbedToolchain):
             self.cpu.append("-mthumb-interwork")
             self.cpu.append("-marm")
             self.cpu.append("-march=armv7-a")
-            self.cpu.append("-mfpu=vfpv3-d16")
+            self.cpu.append("-mfpu=vfpv3")
             self.cpu.append("-mfloat-abi=hard")
             self.cpu.append("-mno-unaligned-access")
 


### PR DESCRIPTION
Hi,

We modified the compile option of GCC to support NEON of CMSIS-RTOS RTX for Cortex-A9.

Regards,
Yamanaka