### PR TITLE
ignore target files not supported by the yotta module

### DIFF
--- a/libraries/mbed/.yotta_ignore
+++ b/libraries/mbed/.yotta_ignore
@@ -1,0 +1,14 @@
+# ignore files for targets that aren't supported by the yotta build (to
+# minimise the size of the published module)
+
+TARGET_ARM_SSG
+TARGET_Freescale
+TARGET_RENESAS
+TARGET_Silicon_Labs
+TARGET_Atmel
+TARGET_Maxim
+TARGET_NXP
+TARGET_STM
+TARGET_WIZNET
+TOOLCHAIN_IAR
+


### PR DESCRIPTION
This minimises the published module size.

@0xc0170 @stevenewey @jaustin