### PR TITLE
Move program_cycle_s into host test copy plugins

### DIFF
--- a/workspace_tools/host_tests/host_test.py
+++ b/workspace_tools/host_tests/host_test.py
@@ -243,7 +243,6 @@ class Mbed:
         copy_method = copy_method if copy_method is not None else self.copy_method
         # Call proper copy method
         result = self.copy_image_raw(image_path, disk, copy_method)
-        sleep(self.program_cycle_s)
         return result
 
     def copy_image_raw(self, image_path=None, disk=None, copy_method=None):
@@ -258,7 +257,7 @@ class Mbed:
         else:
             copy_method = 'shell'
 
-        result = host_tests_plugins.call_plugin('CopyMethod', copy_method, image_path=image_path, destination_disk=disk)
+        result = host_tests_plugins.call_plugin('CopyMethod', copy_method, image_path=image_path, destination_disk=disk, program_cycle_s=self.program_cycle_s)
         return result;
 
     def flush(self):

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_mbed.py
@@ -17,6 +17,7 @@ limitations under the License.
 
 from shutil import copy
 from host_test_plugins import HostTestPluginBase
+from time import sleep
 
 
 class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
@@ -42,7 +43,7 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
     type = 'CopyMethod'
     stable = True
     capabilities = ['shutil', 'default']
-    required_parameters = ['image_path', 'destination_disk']
+    required_parameters = ['image_path', 'destination_disk', 'program_cycle_s']
 
     def setup(self, *args, **kwargs):
         """ Configure plugin, this function should be called before plugin execute() method is used.
@@ -60,9 +61,14 @@ class HostTestPluginCopyMethod_Mbed(HostTestPluginBase):
             if capability == 'shutil':
                 image_path = kwargs['image_path']
                 destination_disk = kwargs['destination_disk']
+                program_cycle_s = kwargs['program_cycle_s']
                 # Wait for mount point to be ready
                 self.check_mount_point_ready(destination_disk)  # Blocking
                 result = self.generic_mbed_copy(image_path, destination_disk)
+
+                # Allow mbed to cycle
+                sleep(program_cycle_s)
+
         return result
 
 

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_shell.py
@@ -18,6 +18,7 @@ limitations under the License.
 import os
 from os.path import join, basename
 from host_test_plugins import HostTestPluginBase
+from time import sleep
 
 
 class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
@@ -27,7 +28,7 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
     type = 'CopyMethod'
     stable = True
     capabilities = ['shell', 'cp', 'copy', 'xcopy']
-    required_parameters = ['image_path', 'destination_disk']
+    required_parameters = ['image_path', 'destination_disk', 'program_cycle_s']
 
     def setup(self, *args, **kwargs):
         """ Configure plugin, this function should be called before plugin execute() method is used.
@@ -43,6 +44,7 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
         if self.check_parameters(capability, *args, **kwargs) is True:
             image_path = kwargs['image_path']
             destination_disk = kwargs['destination_disk']
+            program_cycle_s = kwargs['program_cycle_s']
             # Wait for mount point to be ready
             self.check_mount_point_ready(destination_disk)  # Blocking
             # Prepare correct command line parameter values
@@ -59,6 +61,10 @@ class HostTestPluginCopyMethod_Shell(HostTestPluginBase):
                     result = self.run_command(["sync"])
                 else:
                     result = self.run_command(cmd)
+
+            # Allow mbed to cycle
+            sleep(program_cycle_s)
+
         return result
 
 

--- a/workspace_tools/host_tests/host_tests_plugins/module_copy_silabs.py
+++ b/workspace_tools/host_tests/host_tests_plugins/module_copy_silabs.py
@@ -16,6 +16,7 @@ limitations under the License.
 """
 
 from host_test_plugins import HostTestPluginBase
+from time import sleep
 
 
 class HostTestPluginCopyMethod_Silabs(HostTestPluginBase):
@@ -24,7 +25,7 @@ class HostTestPluginCopyMethod_Silabs(HostTestPluginBase):
     name = 'HostTestPluginCopyMethod_Silabs'
     type = 'CopyMethod'
     capabilities = ['eACommander', 'eACommander-usb']
-    required_parameters = ['image_path', 'destination_disk']
+    required_parameters = ['image_path', 'destination_disk', 'program_cycle_s']
 
     def setup(self, *args, **kwargs):
         """ Configure plugin, this function should be called before plugin execute() method is used.
@@ -41,6 +42,7 @@ class HostTestPluginCopyMethod_Silabs(HostTestPluginBase):
         if self.check_parameters(capabilitity, *args, **kwargs) is True:
             image_path = kwargs['image_path']
             destination_disk = kwargs['destination_disk']
+            program_cycle_s = kwargs['program_cycle_s']
             if capabilitity == 'eACommander':
                 cmd = [self.EACOMMANDER_CMD,
                        '--serialno', destination_disk,
@@ -52,6 +54,10 @@ class HostTestPluginCopyMethod_Silabs(HostTestPluginBase):
                        '--usb', destination_disk,
                        '--flash', image_path]
                 result = self.run_command(cmd)
+
+            # Allow mbed to cycle
+            sleep(program_cycle_s)
+
         return result
 
 


### PR DESCRIPTION
This moves the behavior of sleeping the host test while the mbed is remounting into the host test copy plugin.

This will allow other copy plugins (one that I will submit once this is merged) to have more control over the remounting process and improve performance.