### PR TITLE
Enabling ADC for NRF51 P26 & P27. Currently these pins can be used as…

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/analogin_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/analogin_api.c
@@ -29,6 +29,8 @@ static const PinMap PinMap_ADC[] = {
     {p4, ADC0_0, 32},
     {p5, ADC0_0, 64},
     {p6, ADC0_0, 128},
+    {p26, ADC0_0, 1},
+    {p27, ADC0_0, 2}, 
     {NC, NC, 0}
 };
 


### PR DESCRIPTION
… Digital In/Out or XTAL input only.