### PR TITLE
Fixed stack location problem for disco and nucleo boards (STM32L4)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ STMicroelectronics:
 * [Nucleo-F334R8](https://developer.mbed.org/platforms/ST-Nucleo-F334R8/) (Cortex-M4F)
 * [Nucleo-F401RE](https://developer.mbed.org/platforms/ST-Nucleo-F401RE/) (Cortex-M4F)
 * [Nucleo-F411RE](https://developer.mbed.org/platforms/ST-Nucleo-F411RE/) (Cortex-M4F)
+* [Nucleo-L476RG](https://developer.mbed.org/platforms/ST-Nucleo-L476RG/) (Cortex-M4F)
 * STM32F4XX (Cortex-M4F)
 * STM32F3XX (Cortex-M4F)
 * STM32F0-Discovery (Cortex-M0)
@@ -76,6 +77,7 @@ STMicroelectronics:
 * STM32F4-Discovery (Cortex-M4F)
 * STM32F429-Discovery (Cortex-M4F)
 * STM32L0-Discovery (Cortex-M0+)
+* [STM32L4-Discovery](https://developer.mbed.org/platforms/ST-Discovery-L476VG/) (Cortex-M4F)
 * [Arch Max](https://developer.mbed.org/platforms/Seeed-Arch-Max/) (Cortex-M4F)
 
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
@@ -52,8 +52,7 @@ Stack_Size      EQU     0x00000400
                 
 Stack_Mem       SPACE   Stack_Size
 
-;FAIL __initial_sp    EQU     0x20020000 ; Top of RAM
-__initial_sp
+__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
@@ -37,11 +37,11 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
   }
 
   ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x188) (0x20000-0x188)  {  ; RW data
+  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 
-  RW_IRAM2 0x10000000 0x00008000  {
+  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20020000 ; Top of RAM
+__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
@@ -37,11 +37,11 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
   }
 
   ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x188) (0x20000-0x188)  {  ; RW data
+  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 
-  RW_IRAM2 0x10000000 0x00008000  {
+  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -2,8 +2,8 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
-  RAM (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
-  RAM2 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
+  SRAM2 (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
+  SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -112,7 +112,7 @@ SECTIONS
         __data_end__ = .;
         _edata = .;
 
-    } > RAM
+    } > SRAM2
 
     .bss :
     {
@@ -124,7 +124,7 @@ SECTIONS
         . = ALIGN(4);
         __bss_end__ = .;
         _ebss = .;
-    } > RAM
+    } > SRAM2
 
     .heap (COPY):
     {
@@ -132,7 +132,7 @@ SECTIONS
         end = __end__;
         *(.heap*)
         __HeapLimit = .;
-    } > RAM
+    } > SRAM2
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -140,11 +140,11 @@ SECTIONS
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > RAM
+    } > SRAM2
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -2,7 +2,8 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
-  RAM (rwx)  : ORIGIN = 0x20000188, LENGTH = 128K - 0x188
+  RAM (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
+  RAM2 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -3,14 +3,14 @@ define symbol __intvec_start__     = 0x08000000;
 define symbol __region_ROM_start__ = 0x08000000;
 define symbol __region_ROM_end__   = 0x080FFFFF;
 
-/* [RAM = 128kb = 0x20000] */
+/* [RAM = 96kb + 32kb = 0x20000] */
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 49 x 8) */
-define symbol __region_RAM_start__    = 0x20000188;
-define symbol __region_RAM_end__      = 0x2001FFFF;
-define symbol __region_SRAM2_start__  = 0x10000000;
-define symbol __region_SRAM2_end__    = 0x10007FFF;
+define symbol __NVIC_start__          = 0x10000000;
+define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __region_RAM_start__    = 0x10000188;
+define symbol __region_RAM_end__      = 0x10007FFF;
+define symbol __region_SRAM2_start__  = 0x20000000;
+define symbol __region_SRAM2_end__    = 0x20017FFF;
 
 /* Memory regions */
 define memory mem with size = 4G;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -7,16 +7,16 @@ define symbol __region_ROM_end__   = 0x080FFFFF;
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
 define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
-define symbol __region_RAM_start__    = 0x10000188;
-define symbol __region_RAM_end__      = 0x10007FFF;
-define symbol __region_SRAM2_start__  = 0x20000000;
-define symbol __region_SRAM2_end__    = 0x20017FFF;
+define symbol __region_SRAM2_start__  = 0x10000188;
+define symbol __region_SRAM2_end__    = 0x10007FFF;
+define symbol __region_SRAM1_start__  = 0x20000000;
+define symbol __region_SRAM1_end__    = 0x20017FFF;
 
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
+define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 /* Stack 1/8 and Heap 1/4 of RAM */
 define symbol __size_cstack__ = 0x4000;
@@ -31,5 +31,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in RAM_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };
+place in SRAM2_region   { readwrite, block STACKHEAP };
+place in SRAM1_region { };

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
@@ -52,8 +52,7 @@ Stack_Size      EQU     0x00000400
                 
 Stack_Mem       SPACE   Stack_Size
 
-;FAIL __initial_sp    EQU     0x20020000 ; Top of RAM
-__initial_sp
+__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
@@ -37,11 +37,11 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
   }
 
   ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x188) (0x20000-0x188)  {  ; RW data
+  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 
-  RW_IRAM2 0x10000000 0x00008000  {
+  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x20020000 ; Top of RAM
+__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
                 PRESERVE8
                 THUMB

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
@@ -37,11 +37,11 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
   }
 
   ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x20000000+0x188) (0x20000-0x188)  {  ; RW data
+  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 
-  RW_IRAM2 0x10000000 0x00008000  {
+  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
 

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -2,8 +2,8 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
-  RAM (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
-  RAM2 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
+  SRAM2 (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
+  SRAM1 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
 }
 
 /* Linker script to place sections and symbol values. Should be used together
@@ -112,7 +112,7 @@ SECTIONS
         __data_end__ = .;
         _edata = .;
 
-    } > RAM
+    } > SRAM2
 
     .bss :
     {
@@ -124,7 +124,7 @@ SECTIONS
         . = ALIGN(4);
         __bss_end__ = .;
         _ebss = .;
-    } > RAM
+    } > SRAM2
 
     .heap (COPY):
     {
@@ -132,7 +132,7 @@ SECTIONS
         end = __end__;
         *(.heap*)
         __HeapLimit = .;
-    } > RAM
+    } > SRAM2
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -140,11 +140,11 @@ SECTIONS
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > RAM
+    } > SRAM2
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(RAM) + LENGTH(RAM);
+    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -2,7 +2,8 @@
 MEMORY
 { 
   FLASH (rx) : ORIGIN = 0x08000000, LENGTH = 1024K
-  RAM (rwx)  : ORIGIN = 0x20000188, LENGTH = 128K - 0x188
+  RAM (rwx)  : ORIGIN = 0x10000188, LENGTH = 32k - 0x188
+  RAM2 (rwx)  : ORIGIN = 0x20000000, LENGTH = 96k
 }
 
 /* Linker script to place sections and symbol values. Should be used together

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -3,14 +3,14 @@ define symbol __intvec_start__     = 0x08000000;
 define symbol __region_ROM_start__ = 0x08000000;
 define symbol __region_ROM_end__   = 0x080FFFFF;
 
-/* [RAM = 128kb = 0x20000] */
+/* [RAM = 96kb + 32kb = 0x20000] */
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
-define symbol __NVIC_start__          = 0x20000000;
-define symbol __NVIC_end__            = 0x20000187; /* Aligned on 8 bytes (392 = 49 x 8) */
-define symbol __region_RAM_start__    = 0x20000188;
-define symbol __region_RAM_end__      = 0x2001FFFF;
-define symbol __region_SRAM2_start__  = 0x10000000;
-define symbol __region_SRAM2_end__    = 0x10007FFF;
+define symbol __NVIC_start__          = 0x10000000;
+define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
+define symbol __region_RAM_start__    = 0x10000188;
+define symbol __region_RAM_end__      = 0x10007FFF;
+define symbol __region_SRAM2_start__  = 0x20000000;
+define symbol __region_SRAM2_end__    = 0x20017FFF;
 
 /* Memory regions */
 define memory mem with size = 4G;

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -7,16 +7,16 @@ define symbol __region_ROM_end__   = 0x080FFFFF;
 /* Vector table dynamic copy: Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM */
 define symbol __NVIC_start__          = 0x10000000;
 define symbol __NVIC_end__            = 0x10000187; /* Aligned on 8 bytes (392 = 49 x 8) */
-define symbol __region_RAM_start__    = 0x10000188;
-define symbol __region_RAM_end__      = 0x10007FFF;
-define symbol __region_SRAM2_start__  = 0x20000000;
-define symbol __region_SRAM2_end__    = 0x20017FFF;
+define symbol __region_SRAM2_start__  = 0x10000188;
+define symbol __region_SRAM2_end__    = 0x10007FFF;
+define symbol __region_SRAM1_start__  = 0x20000000;
+define symbol __region_SRAM1_end__    = 0x20017FFF;
 
 /* Memory regions */
 define memory mem with size = 4G;
 define region ROM_region = mem:[from __region_ROM_start__ to __region_ROM_end__];
-define region RAM_region = mem:[from __region_RAM_start__ to __region_RAM_end__];
 define region SRAM2_region = mem:[from __region_SRAM2_start__ to __region_SRAM2_end__];
+define region SRAM1_region = mem:[from __region_SRAM1_start__ to __region_SRAM1_end__];
 
 /* Stack 1/8 and Heap 1/4 of RAM */
 define symbol __size_cstack__ = 0x4000;
@@ -31,5 +31,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in RAM_region   { readwrite, block STACKHEAP };
-place in SRAM2_region { };
+place in SRAM2_region   { readwrite, block STACKHEAP };
+place in SRAM1_region { };


### PR DESCRIPTION
Move main ram to the 32k L4-SRAM2 which is being retained in
standby mode. The additional 96k ram comes second.
The new memory layout preserves all vectors and stack in standby mode.
Without this fix the heap and stack overlap on Nucleo/Disco mbed releases because the stack is wrongly defined.

I hope this is correct and it helps. (this supersedes #1349)
Regards helmut@helios.de