### PR TITLE
Added mbed-ls to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ pyserial
 prettytable
 Jinja2
 IntelHex
+mbed-ls


### PR DESCRIPTION
mbed-ls is used heavily in CI systems. This adds the tool to the requirements.txt so the CI system can automatically install it with the rest of the dependencies.