### PR TITLE
Add ARM GCC export for RBLabs BLE Nano

### DIFF
--- a/workspace_tools/export/gcc_arm_rblab_blenano.tmpl
+++ b/workspace_tools/export/gcc_arm_rblab_blenano.tmpl
@@ -1,0 +1,14 @@
+{% extends "gcc_arm_common.tmpl" %}
+
+{% block additional_variables %}
+SOFTDEVICE = mbed/TARGET_RBLAB_BLENANO/TARGET_NORDIC/TARGET_MCU_NRF51822/Lib/s130_nrf51822_1_0_0/s130_nrf51_1.0.0_softdevice.hex
+{% endblock %}
+
+{% block additional_executables %}
+SREC_CAT = srec_cat
+{% endblock %}
+
+{% block additional_targets %}
+merge:
+	$(SREC_CAT) $(SOFTDEVICE) -intel $(PROJECT).hex -intel -o combined.hex -intel --line-length=44
+{% endblock %}

--- a/workspace_tools/export/gccarm.py
+++ b/workspace_tools/export/gccarm.py
@@ -56,6 +56,7 @@ class GccArm(Exporter):
         'NRF51822',
         'HRM1017',
         'RBLAB_NRF51822',
+        'RBLAB_BLENANO',
         'LPC2368',
         'LPC2460',
         'LPCCAPPUCCINO',

--- a/workspace_tools/export_test.py
+++ b/workspace_tools/export_test.py
@@ -181,6 +181,7 @@ if __name__ == '__main__':
             ('gcc_arm', 'DISCO_F746NG'),
             ('gcc_arm', 'NUCLEO_F031K6'),
             ('gcc_arm', 'NRF51822'),
+            ('gcc_arm', 'RBLAB_BLENANO')
             ('gcc_arm', 'HRM1017'),
             ('gcc_arm', 'NUCLEO_F401RE'),
             ('gcc_arm', 'NUCLEO_F411RE'),


### PR DESCRIPTION
This adds support for exporting to ARM GCC.

I wasn't able to figure out what to do about the SOFTDEVICE path for the Makefiles, but none of the other NRF51 boards seem to handle this well either.

Please let me know if I missed something, as this is my first runthrough on this codebase.