### PR TITLE
targets.py: NRF51: support S110 builds for OTA and BOOT targets

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -1098,9 +1098,26 @@ class MCU_NRF51_16K(MCU_NRF51_16K_BASE):
         self.extra_labels += ['MCU_NRF51_16K_S130']
         self.macros += ['TARGET_MCU_NRF51_16K_S130']
 
-class MCU_NRF51_16K_S110(MCU_NRF51_16K_BASE):
+class MCU_NRF51_S110:
+    """ Interface for overwriting the default SoftDevices """
+    def __init__(self):
+        self.EXPECTED_SOFTDEVICES_WITH_OFFSETS = [
+            {
+                'name'   : 's110_nrf51822_8.0.0_softdevice.hex',
+                'boot'   : 's110_nrf51822_8.0.0_bootloader.hex',
+                'offset' : 0x18000
+            },
+            {
+                'name'   : 's110_nrf51822_7.1.0_softdevice.hex',
+                'boot'   : 's110_nrf51822_7.1.0_bootloader.hex',
+                'offset' : 0x16000
+            }
+        ]
+
+class MCU_NRF51_16K_S110(MCU_NRF51_16K_BASE, MCU_NRF51_S110):
     def __init__(self):
         MCU_NRF51_16K_BASE.__init__(self)
+        MCU_NRF51_S110.__init__(self)
         self.extra_labels += ['MCU_NRF51_16K_S110']
         self.macros += ['TARGET_MCU_NRF51_16K_S110']
 
@@ -1110,9 +1127,10 @@ class MCU_NRF51_16K_BOOT(MCU_NRF51_16K_BOOT_BASE):
         self.extra_labels += ['MCU_NRF51_16K_S130']
         self.macros += ['TARGET_MCU_NRF51_16K_S130']
 
-class MCU_NRF51_16K_BOOT_S110(MCU_NRF51_16K_BOOT_BASE):
+class MCU_NRF51_16K_BOOT_S110(MCU_NRF51_16K_BOOT_BASE, MCU_NRF51_S110):
     def __init__(self):
         MCU_NRF51_16K_BOOT_BASE.__init__(self)
+        MCU_NRF51_S110.__init__(self)
         self.extra_labels += ['MCU_NRF51_16K_S110']
         self.macros += ['TARGET_MCU_NRF51_16K_S110']
 
@@ -1122,9 +1140,10 @@ class MCU_NRF51_16K_OTA(MCU_NRF51_16K_OTA_BASE):
         self.extra_labels += ['MCU_NRF51_16K_S130']
         self.macros += ['TARGET_MCU_NRF51_16K_S130']
 
-class MCU_NRF51_16K_OTA_S110(MCU_NRF51_16K_OTA_BASE):
+class MCU_NRF51_16K_OTA_S110(MCU_NRF51_16K_OTA_BASE, MCU_NRF51_S110):
     def __init__(self):
         MCU_NRF51_16K_OTA_BASE.__init__(self)
+        MCU_NRF51_S110.__init__(self)
         self.extra_labels += ['MCU_NRF51_16K_S110']
         self.macros += ['TARGET_MCU_NRF51_16K_S110']
 
@@ -1369,18 +1388,6 @@ class NRF51_DONGLE_OTA(MCU_NRF51_32K_OTA):
 class NRF51_MICROBIT(MCU_NRF51_16K_S110):
     def __init__(self):
         MCU_NRF51_16K_S110.__init__(self)
-        self.EXPECTED_SOFTDEVICES_WITH_OFFSETS = [
-            {
-                'name'   : 's110_nrf51822_8.0.0_softdevice.hex',
-                'boot'   : 's110_nrf51822_8.0.0_bootloader.hex',
-                'offset' : 0x18000
-            },
-            {
-                'name'   : 's110_nrf51822_7.1.0_softdevice.hex',
-                'boot'   : 's110_nrf51822_7.1.0_bootloader.hex',
-                'offset' : 0x16000
-            }
-        ]
         self.macros += ['TARGET_NRF_LFCLK_RC']
 
 class NRF51_MICROBIT_BOOT(MCU_NRF51_16K_BOOT_S110):


### PR DESCRIPTION
Current S110 support is only available for default (SoftDevice + App)
images.
At the moment, a BOOT image built for micro:bit will contain the S130
SoftDevice and the app will be located at 0x1c000, even though we want a
S110 SoftDevice.
Since the elf build is still done with the S110 linker script, the entry
point will be offsetted by 0x2000 and it will fail to run.

This patch creates an interface class that allows all S110 targets to
override the SoftDevices list.

Signed-off-by: Jean-Philippe Brucker <jean-philippe.brucker@arm.com>

---
@screamerbg please consider this patch as a fix for BOOT and OTA builds on the micro:bit