### PR TITLE
Reflect the change size of structure of Mutex to Ethernet module

### DIFF
--- a/libraries/net/lwip/lwip-sys/arch/sys_arch.c
+++ b/libraries/net/lwip/lwip-sys/arch/sys_arch.c
@@ -285,7 +285,11 @@ void sys_sem_free(sys_sem_t *sem) {}
  * @return a new mutex */
 err_t sys_mutex_new(sys_mutex_t *mutex) {
 #ifdef CMSIS_OS_RTX
+#ifdef __MBED_CMSIS_RTOS_CA9
+    memset(mutex->data, 0, sizeof(int32_t)*4);
+#else
     memset(mutex->data, 0, sizeof(int32_t)*3);
+#endif
     mutex->def.mutex = mutex->data;
 #endif
     mutex->id = osMutexCreate(&mutex->def);

--- a/libraries/net/lwip/lwip-sys/arch/sys_arch.h
+++ b/libraries/net/lwip/lwip-sys/arch/sys_arch.h
@@ -40,7 +40,11 @@ typedef struct {
     osMutexId    id;
     osMutexDef_t def;
 #ifdef CMSIS_OS_RTX
+#ifdef __MBED_CMSIS_RTOS_CA9
+    int32_t      data[4];
+#else
     int32_t      data[3];
+#endif
 #endif
 } sys_mutex_t;
 


### PR DESCRIPTION
Hi,

We reflected the change size of the structure of the Mutex associated with NEON of CMSIS-RTOS RTX for Cortex-A9 support to ethernet module.

Regards,
Yamanaka