### PR TITLE
Fix #1393 - I2C assumes NRF_TWI1

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/i2c_api.c
@@ -54,7 +54,6 @@ void twi_master_init(i2c_t *obj, PinName sda, PinName scl, int frequency)
 
 void i2c_init(i2c_t *obj, PinName sda, PinName scl)
 {
-    twi_master_init_and_clear();
     NRF_TWI_Type *i2c = NULL;
   
     if (i2c0_spi0_peripheral.usage == I2C_SPI_PERIPHERAL_FOR_I2C &&
@@ -87,6 +86,8 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
         // No available peripheral
         error("No available I2C");
     }
+
+	twi_master_init_and_clear(i2c);
 
     obj->i2c               = i2c;
     obj->scl               = scl;

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/twi_master.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/twi_master.c
@@ -21,7 +21,7 @@
  * This is optimized way instead of using timers, this is not power aware. */
 #define MAX_TIMEOUT_LOOPS (20000UL) /**< MAX while loops to wait for RXD/TXD event */
 
-static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_stop_condition)
+static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_stop_condition, NRF_TWI_Type* twi)
 {
     uint32_t timeout = MAX_TIMEOUT_LOOPS; /* max loops to wait for EVENTS_TXDSENT event*/
 
@@ -31,13 +31,13 @@ static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_sto
         return false;
     }
 
-    NRF_TWI1->TXD           = *data++;
-    NRF_TWI1->TASKS_STARTTX = 1;
+	twi->TXD           = *data++;
+	twi->TASKS_STARTTX = 1;
 
     /** @snippet [TWI HW master write] */
     while (true)
     {
-        while (NRF_TWI1->EVENTS_TXDSENT == 0 && NRF_TWI1->EVENTS_ERROR == 0 && (--timeout))
+		while (twi->EVENTS_TXDSENT == 0 && twi->EVENTS_ERROR == 0 && (--timeout))
         {
             // Do nothing.
         }
@@ -47,33 +47,33 @@ static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_sto
             // Recover the peripheral as indicated by PAN 56: "TWI: TWI module lock-up." found at
             // Product Anomaly Notification document found at 
             // https://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822/#Downloads
-            NRF_TWI1->EVENTS_ERROR = 0;
-            NRF_TWI1->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos; 
-            NRF_TWI1->POWER        = 0;
+			twi->EVENTS_ERROR = 0;
+			twi->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
+			twi->POWER        = 0;
             nrf_delay_us(5);
-            NRF_TWI1->POWER        = 1;
-            NRF_TWI1->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
+			twi->POWER        = 1;
+			twi->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
 
-            (void)twi_master_init_and_clear();
+			(void)twi_master_init_and_clear(twi);
 
             return false;
         }
-        NRF_TWI1->EVENTS_TXDSENT = 0;
+		twi->EVENTS_TXDSENT = 0;
         if (--data_length == 0)
         {
             break;
         }
 
-        NRF_TWI1->TXD = *data++;
+		twi->TXD = *data++;
     }
     /** @snippet [TWI HW master write] */
 
     if (issue_stop_condition)
     {
-        NRF_TWI1->EVENTS_STOPPED = 0;
-        NRF_TWI1->TASKS_STOP     = 1;
+		twi->EVENTS_STOPPED = 0;
+		twi->TASKS_STOP     = 1;
         /* Wait until stop sequence is sent */ 
-        while(NRF_TWI1->EVENTS_STOPPED == 0) 
+		while(twi->EVENTS_STOPPED == 0)
         {
             // Do nothing.
         }
@@ -84,7 +84,7 @@ static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_sto
 
 /** @brief Function for read by twi_master. 
  */
-static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop_condition)
+static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop_condition, NRF_TWI_Type* twi)
 {
     uint32_t timeout = MAX_TIMEOUT_LOOPS; /* max loops to wait for RXDREADY event*/
 
@@ -95,39 +95,39 @@ static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop
     }
     else if (data_length == 1)
     {
-        NRF_PPI->CH[0].TEP = (uint32_t)&NRF_TWI1->TASKS_STOP;
+		NRF_PPI->CH[0].TEP = (uint32_t)&twi->TASKS_STOP;
     }
     else
     {
-        NRF_PPI->CH[0].TEP = (uint32_t)&NRF_TWI1->TASKS_SUSPEND;
+		NRF_PPI->CH[0].TEP = (uint32_t)&twi->TASKS_SUSPEND;
     }
 
     NRF_PPI->CHENSET          = PPI_CHENSET_CH0_Msk;
-    NRF_TWI1->EVENTS_RXDREADY = 0;
-    NRF_TWI1->TASKS_STARTRX   = 1;
+	twi->EVENTS_RXDREADY = 0;
+	twi->TASKS_STARTRX   = 1;
 
     /** @snippet [TWI HW master read] */
     while (true)
     {
-        while (NRF_TWI1->EVENTS_RXDREADY == 0 && NRF_TWI1->EVENTS_ERROR == 0 && (--timeout))
+		while (twi->EVENTS_RXDREADY == 0 && NRF_TWI1->EVENTS_ERROR == 0 && (--timeout))
         {
             // Do nothing.
         }
-        NRF_TWI1->EVENTS_RXDREADY = 0;
+		twi->EVENTS_RXDREADY = 0;
 
-        if (timeout == 0 || NRF_TWI1->EVENTS_ERROR != 0)
+		if (timeout == 0 || twi->EVENTS_ERROR != 0)
         {
             // Recover the peripheral as indicated by PAN 56: "TWI: TWI module lock-up." found at
             // Product Anomaly Notification document found at
             // https://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822/#Downloads
-            NRF_TWI1->EVENTS_ERROR = 0;
-            NRF_TWI1->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
-            NRF_TWI1->POWER        = 0;
+			twi->EVENTS_ERROR = 0;
+			twi->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
+			twi->POWER        = 0;
             nrf_delay_us(5);
-            NRF_TWI1->POWER        = 1;
-            NRF_TWI1->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
+			twi->POWER        = 1;
+			twi->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
 
-            (void)twi_master_init_and_clear();
+			(void)twi_master_init_and_clear(twi);
 
             return false;
         }
@@ -149,16 +149,16 @@ static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop
         // Product Anomaly Notification document found at
         // https://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822/#Downloads
         nrf_delay_us(20);
-        NRF_TWI1->TASKS_RESUME = 1;
+		twi->TASKS_RESUME = 1;
     }
     /** @snippet [TWI HW master read] */
 
     /* Wait until stop sequence is sent */
-    while(NRF_TWI1->EVENTS_STOPPED == 0)
+	while(twi->EVENTS_STOPPED == 0)
     {
         // Do nothing.
     }
-    NRF_TWI1->EVENTS_STOPPED = 0;
+	twi->EVENTS_STOPPED = 0;
 
     NRF_PPI->CHENCLR = PPI_CHENCLR_CH0_Msk;
     return true;
@@ -172,7 +172,7 @@ static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop
  * @retval false Bus is stuck.
  * @retval true Bus is clear.
  */
-static bool twi_master_clear_bus(void)
+static bool twi_master_clear_bus(NRF_TWI_Type* twi)
 {
     uint32_t twi_state;
     bool     bus_clear;
@@ -180,8 +180,8 @@ static bool twi_master_clear_bus(void)
     uint32_t data_pin_config;
 
     // Save and disable TWI hardware so software can take control over the pins.
-    twi_state        = NRF_TWI1->ENABLE;
-    NRF_TWI1->ENABLE = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
+	twi_state        = twi->ENABLE;
+	twi->ENABLE = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
 
     clk_pin_config = \
         NRF_GPIO->PIN_CNF[TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER];
@@ -234,7 +234,7 @@ static bool twi_master_clear_bus(void)
     NRF_GPIO->PIN_CNF[TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER] = clk_pin_config;
     NRF_GPIO->PIN_CNF[TWI_MASTER_CONFIG_DATA_PIN_NUMBER]  = data_pin_config;
 
-    NRF_TWI1->ENABLE = twi_state;
+	twi->ENABLE = twi_state;
 
     return bus_clear;
 }
@@ -242,7 +242,7 @@ static bool twi_master_clear_bus(void)
 
 /** @brief Function for initializing the twi_master.
  */
-bool twi_master_init_and_clear(void)
+bool twi_master_init_and_clear(NRF_TWI_Type* twi)
 {
     /* To secure correct signal levels on the pins used by the TWI
        master when the system is in OFF mode, and when the TWI master is
@@ -262,17 +262,17 @@ bool twi_master_init_and_clear(void)
       | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) \
       | (GPIO_PIN_CNF_DIR_Input      << GPIO_PIN_CNF_DIR_Pos);
 
-    NRF_TWI1->EVENTS_RXDREADY = 0;
-    NRF_TWI1->EVENTS_TXDSENT  = 0;
-    NRF_TWI1->PSELSCL         = TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER;
-    NRF_TWI1->PSELSDA         = TWI_MASTER_CONFIG_DATA_PIN_NUMBER;
-    NRF_TWI1->FREQUENCY       = TWI_FREQUENCY_FREQUENCY_K100 << TWI_FREQUENCY_FREQUENCY_Pos;
-    NRF_PPI->CH[0].EEP        = (uint32_t)&NRF_TWI1->EVENTS_BB;
-    NRF_PPI->CH[0].TEP        = (uint32_t)&NRF_TWI1->TASKS_SUSPEND;
+	twi->EVENTS_RXDREADY = 0;
+	twi->EVENTS_TXDSENT  = 0;
+	twi->PSELSCL         = TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER;
+	twi->PSELSDA         = TWI_MASTER_CONFIG_DATA_PIN_NUMBER;
+	twi->FREQUENCY       = TWI_FREQUENCY_FREQUENCY_K100 << TWI_FREQUENCY_FREQUENCY_Pos;
+	NRF_PPI->CH[0].EEP        = (uint32_t)&twi->EVENTS_BB;
+	NRF_PPI->CH[0].TEP        = (uint32_t)&twi->TASKS_SUSPEND;
     NRF_PPI->CHENCLR          = PPI_CHENCLR_CH0_Msk;
-    NRF_TWI1->ENABLE          = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
+	twi->ENABLE          = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
 
-    return twi_master_clear_bus();
+	return twi_master_clear_bus(twi);
 }
 
 
@@ -281,20 +281,21 @@ bool twi_master_init_and_clear(void)
 bool twi_master_transfer(uint8_t   address,
                          uint8_t * data,
                          uint8_t   data_length,
-                         bool      issue_stop_condition)
+						 bool      issue_stop_condition,
+						 NRF_TWI_Type* twi)
 {
     bool transfer_succeeded = false;
-    if (data_length > 0 && twi_master_clear_bus())
+	if (data_length > 0 && twi_master_clear_bus(twi))
     {
-        NRF_TWI1->ADDRESS = (address >> 1);
+		twi->ADDRESS = (address >> 1);
 
-        if ((address & TWI_READ_BIT))
+		if ((address & TWI_READ_BIT))
         {
-            transfer_succeeded = twi_master_read(data, data_length, issue_stop_condition);
+			transfer_succeeded = twi_master_read(data, data_length, issue_stop_condition, twi);
         }
         else
         {
-            transfer_succeeded = twi_master_write(data, data_length, issue_stop_condition);
+			transfer_succeeded = twi_master_write(data, data_length, issue_stop_condition, twi);
         }
     }
     return transfer_succeeded;

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/twi_master.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/twi_master.c
@@ -31,13 +31,13 @@ static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_sto
         return false;
     }
 
-	twi->TXD           = *data++;
-	twi->TASKS_STARTTX = 1;
+    twi->TXD           = *data++;
+    twi->TASKS_STARTTX = 1;
 
     /** @snippet [TWI HW master write] */
     while (true)
     {
-		while (twi->EVENTS_TXDSENT == 0 && twi->EVENTS_ERROR == 0 && (--timeout))
+        while (twi->EVENTS_TXDSENT == 0 && twi->EVENTS_ERROR == 0 && (--timeout))
         {
             // Do nothing.
         }
@@ -47,33 +47,33 @@ static bool twi_master_write(uint8_t * data, uint8_t data_length, bool issue_sto
             // Recover the peripheral as indicated by PAN 56: "TWI: TWI module lock-up." found at
             // Product Anomaly Notification document found at 
             // https://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822/#Downloads
-			twi->EVENTS_ERROR = 0;
-			twi->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
-			twi->POWER        = 0;
+            twi->EVENTS_ERROR = 0;
+            twi->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
+            twi->POWER        = 0;
             nrf_delay_us(5);
-			twi->POWER        = 1;
-			twi->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
+            twi->POWER        = 1;
+            twi->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
 
-			(void)twi_master_init_and_clear(twi);
+            (void)twi_master_init_and_clear(twi);
 
             return false;
         }
-		twi->EVENTS_TXDSENT = 0;
+        twi->EVENTS_TXDSENT = 0;
         if (--data_length == 0)
         {
             break;
         }
 
-		twi->TXD = *data++;
+        twi->TXD = *data++;
     }
     /** @snippet [TWI HW master write] */
 
     if (issue_stop_condition)
     {
-		twi->EVENTS_STOPPED = 0;
-		twi->TASKS_STOP     = 1;
+        twi->EVENTS_STOPPED = 0;
+        twi->TASKS_STOP     = 1;
         /* Wait until stop sequence is sent */ 
-		while(twi->EVENTS_STOPPED == 0)
+        while(twi->EVENTS_STOPPED == 0)
         {
             // Do nothing.
         }
@@ -95,39 +95,39 @@ static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop
     }
     else if (data_length == 1)
     {
-		NRF_PPI->CH[0].TEP = (uint32_t)&twi->TASKS_STOP;
+        NRF_PPI->CH[0].TEP = (uint32_t)&twi->TASKS_STOP;
     }
     else
     {
-		NRF_PPI->CH[0].TEP = (uint32_t)&twi->TASKS_SUSPEND;
+        NRF_PPI->CH[0].TEP = (uint32_t)&twi->TASKS_SUSPEND;
     }
 
     NRF_PPI->CHENSET          = PPI_CHENSET_CH0_Msk;
-	twi->EVENTS_RXDREADY = 0;
-	twi->TASKS_STARTRX   = 1;
+    twi->EVENTS_RXDREADY = 0;
+    twi->TASKS_STARTRX   = 1;
 
     /** @snippet [TWI HW master read] */
     while (true)
     {
-		while (twi->EVENTS_RXDREADY == 0 && NRF_TWI1->EVENTS_ERROR == 0 && (--timeout))
+        while (twi->EVENTS_RXDREADY == 0 && NRF_TWI1->EVENTS_ERROR == 0 && (--timeout))
         {
             // Do nothing.
         }
-		twi->EVENTS_RXDREADY = 0;
+        twi->EVENTS_RXDREADY = 0;
 
-		if (timeout == 0 || twi->EVENTS_ERROR != 0)
+        if (timeout == 0 || twi->EVENTS_ERROR != 0)
         {
             // Recover the peripheral as indicated by PAN 56: "TWI: TWI module lock-up." found at
             // Product Anomaly Notification document found at
             // https://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822/#Downloads
-			twi->EVENTS_ERROR = 0;
-			twi->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
-			twi->POWER        = 0;
+            twi->EVENTS_ERROR = 0;
+            twi->ENABLE       = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
+            twi->POWER        = 0;
             nrf_delay_us(5);
-			twi->POWER        = 1;
-			twi->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
+            twi->POWER        = 1;
+            twi->ENABLE       = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
 
-			(void)twi_master_init_and_clear(twi);
+            (void)twi_master_init_and_clear(twi);
 
             return false;
         }
@@ -149,16 +149,16 @@ static bool twi_master_read(uint8_t * data, uint8_t data_length, bool issue_stop
         // Product Anomaly Notification document found at
         // https://www.nordicsemi.com/eng/Products/Bluetooth-R-low-energy/nRF51822/#Downloads
         nrf_delay_us(20);
-		twi->TASKS_RESUME = 1;
+        twi->TASKS_RESUME = 1;
     }
     /** @snippet [TWI HW master read] */
 
     /* Wait until stop sequence is sent */
-	while(twi->EVENTS_STOPPED == 0)
+    while(twi->EVENTS_STOPPED == 0)
     {
         // Do nothing.
     }
-	twi->EVENTS_STOPPED = 0;
+    twi->EVENTS_STOPPED = 0;
 
     NRF_PPI->CHENCLR = PPI_CHENCLR_CH0_Msk;
     return true;
@@ -180,8 +180,8 @@ static bool twi_master_clear_bus(NRF_TWI_Type* twi)
     uint32_t data_pin_config;
 
     // Save and disable TWI hardware so software can take control over the pins.
-	twi_state        = twi->ENABLE;
-	twi->ENABLE = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
+    twi_state        = twi->ENABLE;
+    twi->ENABLE = TWI_ENABLE_ENABLE_Disabled << TWI_ENABLE_ENABLE_Pos;
 
     clk_pin_config = \
         NRF_GPIO->PIN_CNF[TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER];
@@ -234,7 +234,7 @@ static bool twi_master_clear_bus(NRF_TWI_Type* twi)
     NRF_GPIO->PIN_CNF[TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER] = clk_pin_config;
     NRF_GPIO->PIN_CNF[TWI_MASTER_CONFIG_DATA_PIN_NUMBER]  = data_pin_config;
 
-	twi->ENABLE = twi_state;
+    twi->ENABLE = twi_state;
 
     return bus_clear;
 }
@@ -262,17 +262,17 @@ bool twi_master_init_and_clear(NRF_TWI_Type* twi)
       | (GPIO_PIN_CNF_INPUT_Connect  << GPIO_PIN_CNF_INPUT_Pos) \
       | (GPIO_PIN_CNF_DIR_Input      << GPIO_PIN_CNF_DIR_Pos);
 
-	twi->EVENTS_RXDREADY = 0;
-	twi->EVENTS_TXDSENT  = 0;
-	twi->PSELSCL         = TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER;
-	twi->PSELSDA         = TWI_MASTER_CONFIG_DATA_PIN_NUMBER;
-	twi->FREQUENCY       = TWI_FREQUENCY_FREQUENCY_K100 << TWI_FREQUENCY_FREQUENCY_Pos;
-	NRF_PPI->CH[0].EEP        = (uint32_t)&twi->EVENTS_BB;
-	NRF_PPI->CH[0].TEP        = (uint32_t)&twi->TASKS_SUSPEND;
+    twi->EVENTS_RXDREADY = 0;
+    twi->EVENTS_TXDSENT  = 0;
+    twi->PSELSCL         = TWI_MASTER_CONFIG_CLOCK_PIN_NUMBER;
+    twi->PSELSDA         = TWI_MASTER_CONFIG_DATA_PIN_NUMBER;
+    twi->FREQUENCY       = TWI_FREQUENCY_FREQUENCY_K100 << TWI_FREQUENCY_FREQUENCY_Pos;
+    NRF_PPI->CH[0].EEP        = (uint32_t)&twi->EVENTS_BB;
+    NRF_PPI->CH[0].TEP        = (uint32_t)&twi->TASKS_SUSPEND;
     NRF_PPI->CHENCLR          = PPI_CHENCLR_CH0_Msk;
-	twi->ENABLE          = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
+    twi->ENABLE          = TWI_ENABLE_ENABLE_Enabled << TWI_ENABLE_ENABLE_Pos;
 
-	return twi_master_clear_bus(twi);
+    return twi_master_clear_bus(twi);
 }
 
 
@@ -281,21 +281,21 @@ bool twi_master_init_and_clear(NRF_TWI_Type* twi)
 bool twi_master_transfer(uint8_t   address,
                          uint8_t * data,
                          uint8_t   data_length,
-						 bool      issue_stop_condition,
-						 NRF_TWI_Type* twi)
+                         bool      issue_stop_condition,
+                         NRF_TWI_Type* twi)
 {
     bool transfer_succeeded = false;
-	if (data_length > 0 && twi_master_clear_bus(twi))
+    if (data_length > 0 && twi_master_clear_bus(twi))
     {
-		twi->ADDRESS = (address >> 1);
+        twi->ADDRESS = (address >> 1);
 
-		if ((address & TWI_READ_BIT))
+        if ((address & TWI_READ_BIT))
         {
-			transfer_succeeded = twi_master_read(data, data_length, issue_stop_condition, twi);
+            transfer_succeeded = twi_master_read(data, data_length, issue_stop_condition, twi);
         }
         else
         {
-			transfer_succeeded = twi_master_write(data, data_length, issue_stop_condition, twi);
+            transfer_succeeded = twi_master_write(data, data_length, issue_stop_condition, twi);
         }
     }
     return transfer_succeeded;

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/twi_master.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/twi_master.h
@@ -23,6 +23,8 @@ extern "C" {
 #include <stdbool.h>
 #include <stdint.h>
 
+#include "nrf51.h"
+
 /** @file
 * @brief Software controlled TWI Master driver.
 *
@@ -68,11 +70,12 @@ extern "C" {
  *
  * Both pins are configured as Standard-0, No-drive-1 (open drain).
  *
+ * @param twi The TWI interface to use - either NRF_TWI0 or NRF_TWI1
  * @return
  * @retval true TWI bus is clear for transfers.
  * @retval false TWI bus is stuck.
  */
-bool twi_master_init_and_clear(void);
+bool twi_master_init_and_clear(NRF_TWI_Type* twi);
 
 /**
  * @brief Function for transferring data over TWI bus.
@@ -90,11 +93,12 @@ bool twi_master_init_and_clear(void);
  * @param data Pointer to data.
  * @param data_length Number of bytes to transfer.
  * @param issue_stop_condition If @ref TWI_ISSUE_STOP, STOP condition is issued before exiting function. If @ref TWI_DONT_ISSUE_STOP, STOP condition is not issued before exiting function. If transfer failed for any reason, STOP condition will be issued in any case.
+ * @param twi The TWI interface to use - either NRF_TWI0 or NRF_TWI1
  * @return
  * @retval true Data transfer succeeded without errors.
  * @retval false Data transfer failed.
  */
-bool twi_master_transfer(uint8_t address, uint8_t *data, uint8_t data_length, bool issue_stop_condition);
+bool twi_master_transfer(uint8_t address, uint8_t *data, uint8_t data_length, bool issue_stop_condition, NRF_TWI_Type* twi);
 
 /**
  *@}


### PR DESCRIPTION
Without this fix SPI locks up if it is using the second I2C/SPI peripheral after I2C has been initialised (evne if I2C uses the first peripheral).