### PR TITLE
[NUCLEO_F042K6] HSI default value rightly set

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/system_stm32f0xx.c
@@ -117,7 +117,7 @@
   */
 
 /* Select the clock sources (other than HSI) to start with (0=OFF, 1=ON) */
-#define USE_PLL_HSE_EXTC (0) /* Use external clock */
+#define USE_PLL_HSE_EXTC (1) /* Use external clock */
 #define USE_PLL_HSE_XTAL (0) /* Use external xtal */
 
 /**
@@ -420,6 +420,7 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI;
   RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
   RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL6;
+  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }


### PR DESCRIPTION
this resolves a lot of problems and the external clock can be check