### PR TITLE
Fix analogin checking the wrong flag for completion

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/analogin_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/analogin_api.c
@@ -65,8 +65,10 @@ uint16_t analogin_read_u16(analogin_t *obj)
 {
     NRF_ADC->CONFIG     &= ~ADC_CONFIG_PSEL_Msk;
     NRF_ADC->CONFIG     |= obj->adc_pin << ADC_CONFIG_PSEL_Pos;
+    NRF_ADC->EVENTS_END  = 0;
     NRF_ADC->TASKS_START = 1;
-    while (((NRF_ADC->BUSY & ADC_BUSY_BUSY_Msk) >> ADC_BUSY_BUSY_Pos) == ADC_BUSY_BUSY_Busy) {
+
+    while (!NRF_ADC->EVENTS_END) {
     }
 
     return (uint16_t)NRF_ADC->RESULT; // 10 bit


### PR DESCRIPTION
According to the Reference Manual v3, section 31.1.5 Usage, "When the ADC conversion is completed, an END event will be generated..." therefore the END event should be polled instead of the BUSY reg. There are cases where the BUSY flag is deasserted before the result of the conversion has been stored into the RESULT reg.