### PR TITLE
Fix broken STM32_NUCLEO_L152RE UARTs 4 and 5.

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
@@ -95,13 +95,13 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         obj->index = 2;
     }
 
-#if defined(USART4_BASE)
+#if defined(UART4_BASE)
     if (obj->uart == UART_4) {
         __UART4_CLK_ENABLE();
         obj->index = 3;
     }
 #endif
-#if defined(USART5_BASE)
+#if defined(UART5_BASE)
     if (obj->uart == UART_5) {
         __UART5_CLK_ENABLE();
         obj->index = 4;
@@ -156,14 +156,14 @@ void serial_free(serial_t *obj)
         __USART3_CLK_DISABLE();
     }
 
-#if defined(USART4_BASE)
+#if defined(UART4_BASE)
     if (obj->uart == UART_4) {
         __UART4_FORCE_RESET();
         __UART4_RELEASE_RESET();
         __UART4_CLK_DISABLE();
     }
 #endif
-#if defined(USART5_BASE)
+#if defined(UART5_BASE)
     if (obj->uart == UART_5) {
         __UART5_FORCE_RESET();
         __UART5_RELEASE_RESET();
@@ -249,14 +249,14 @@ static void uart3_irq(void)
     uart_irq(UART_3, 2);
 }
 
-#if defined(USART4_BASE)
+#if defined(UART4_BASE)
 static void uart4_irq(void)
 {
     uart_irq(UART_4, 3);
 }
 #endif
 
-#if defined(USART5_BASE)
+#if defined(UART5_BASE)
 static void uart5_irq(void)
 {
     uart_irq(UART_5, 4);
@@ -291,14 +291,14 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         vector = (uint32_t)&uart3_irq;
     }
 
-#if defined(USART4_BASE)
+#if defined(UART4_BASE)
     if (obj->uart == UART_4) {
         irq_n = UART4_IRQn;
         vector = (uint32_t)&uart4_irq;
     }
 #endif
 
-#if defined(USART5_BASE)
+#if defined(UART5_BASE)
     if (obj->uart == UART_5) {
         irq_n = UART5_IRQn;
         vector = (uint32_t)&uart5_irq;


### PR DESCRIPTION
Fixes issue #1405. USART4_BASE and USART5_BASE are changed to UART4_BASE and UART5_BASE in <code>libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c</code>.