### PR TITLE
Handling failures correctly and adding timeout status

### DIFF
--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -1034,12 +1034,11 @@ class SingleTestRunner(object):
         """
         result = self.TEST_RESULT_FAIL
 
-        if waterfall_and_consolidate:
-            if any(res == self.TEST_RESULT_OK for res in test_all_result):
-                result = self.TEST_RESULT_OK
-        else:
-            if all(test_all_result[0] == res for res in test_all_result):
-                result = test_all_result[0]
+        if all(test_all_result[0] == res for res in test_all_result):
+            result = test_all_result[0]
+        elif waterfall_and_consolidate and any(res == self.TEST_RESULT_OK for res in test_all_result):
+            result = self.TEST_RESULT_OK
+
         return result
 
     def run_host_test(self, name, image_path, disk, port, duration,

--- a/workspace_tools/upload_results.py
+++ b/workspace_tools/upload_results.py
@@ -120,10 +120,14 @@ def add_test_runs(args):
                 testRun['output'] = ""
 
             errors = test_case.findall('error')
+            failures = test_case.findall('failure')
 
             if errors:
                 testRun['pass'] = False
                 testRun['result'] = errors[0].attrib['message']
+            elif failures:
+                testRun['pass'] = False
+                testRun['result'] = failures[0].attrib['message']
             else:
                 testRun['pass'] = True
                 testRun['result'] = 'OK'


### PR DESCRIPTION
- Instead reporting any result that's not OK as a FAIL, it will keep the error message (TIMEOUT, FAIL, ERROR, etc)
- Fixes this issue in the upload result script as well