### PR TITLE
Fix typo in some NUCLEO uvproj files

### DIFF
--- a/workspace_tools/export/uvision4_nucleo_f042k6.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_nucleo_f042k6.uvproj.tmpl
@@ -79,9 +79,9 @@
             <nStopB2X>0</nStopB2X>
           </BeforeMake>
           <AfterMake>
-            <RunUserProg1>0</RunUserProg1>
+            <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F302R8.bin build\{{name}}.axf</UserProg1Name>
+            <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F042K6.bin build\{{name}}.axf</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/workspace_tools/export/uvision4_nucleo_f302r8.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_nucleo_f302r8.uvproj.tmpl
@@ -74,7 +74,7 @@
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
           </BeforeMake>
           <AfterMake>
-            <RunUserProg1>0</RunUserProg1>
+            <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
             <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F302R8.bin build\{{name}}.axf</UserProg1Name>
             <UserProg2Name></UserProg2Name>

--- a/workspace_tools/export/uvision4_nucleo_f303k8.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_nucleo_f303k8.uvproj.tmpl
@@ -74,9 +74,9 @@
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
           </BeforeMake>
           <AfterMake>
-            <RunUserProg1>0</RunUserProg1>
+            <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F302R8.bin build\{{name}}.axf</UserProg1Name>
+            <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F303K8.bin build\{{name}}.axf</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/workspace_tools/export/uvision4_nucleo_f303re.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_nucleo_f303re.uvproj.tmpl
@@ -74,9 +74,9 @@
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
           </BeforeMake>
           <AfterMake>
-            <RunUserProg1>0</RunUserProg1>
+            <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
-            <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F302R8.bin build\{{name}}.axf</UserProg1Name>
+            <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F303RE.bin build\{{name}}.axf</UserProg1Name>
             <UserProg2Name></UserProg2Name>
             <UserProg1Dos16Mode>0</UserProg1Dos16Mode>
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>

--- a/workspace_tools/export/uvision4_nucleo_f334r8.uvproj.tmpl
+++ b/workspace_tools/export/uvision4_nucleo_f334r8.uvproj.tmpl
@@ -74,7 +74,7 @@
             <UserProg2Dos16Mode>0</UserProg2Dos16Mode>
           </BeforeMake>
           <AfterMake>
-            <RunUserProg1>0</RunUserProg1>
+            <RunUserProg1>1</RunUserProg1>
             <RunUserProg2>0</RunUserProg2>
             <UserProg1Name>fromelf --bin -o build\{{name}}_NUCLEO_F334R8.bin build\{{name}}.axf</UserProg1Name>
             <UserProg2Name></UserProg2Name>


### PR DESCRIPTION
Hello,
I fixed typo in some NUCLEO uvproj files.

AfterMake RunUserProg1 options are now enabled.
Updated boards lists are shown below.
F042K6,F302R8,F303K8,F303RE,F334R8

Export .bin file names are now Fixed.
Updated boards lists are shown below.
F042K6,F303K8,F303RE

Regards,
Tiryoh