### PR TITLE
Fix for issue with libraries being built out of order

### DIFF
--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -401,15 +401,15 @@ class SingleTestRunner(object):
 
 
             # First pass through all tests and determine which libraries need to be built
-            libraries = set()
+            libraries = []
             for test_id in valid_test_map_keys:
                 test = TEST_MAP[test_id]
 
                 # Detect which lib should be added to test
                 # Some libs have to compiled like RTOS or ETH
                 for lib in LIBRARIES:
-                    if lib['build_dir'] in test.dependencies:
-                        libraries.add(lib['id'])
+                    if lib['build_dir'] in test.dependencies and lib['build_dir'] not in libraries:
+                        libraries.append(lib['id'])
 
 
             build_project_options = ["analyze"] if self.opts_goanna_for_tests else None


### PR DESCRIPTION
I introduced a regression a while ago that builds library dependencies out of order when building tests. This PR fixes that regression.

Library dependencies are now built in the order they are specified in the test's definition in tests.py.

Ex. for the test `NET_1`, its definition looks like this in tests.py:

```
    {
        "id": "NET_1", "description": "TCP client hello world",
        "source_dir": join(TEST_DIR, "net", "helloworld", "tcpclient"),
        "dependencies": [MBED_LIBRARIES, RTOS_LIBRARIES, ETH_LIBRARY, TEST_MBED_LIB],
        "duration": 15,
        "automated": True,
        "peripherals": ["ethernet"],
    },
```

You can see the order in which the library dependencies will be built by examining the `dependencies` key.