### PR TITLE
Added option to build rpc library. closes #1426

### DIFF
--- a/workspace_tools/build.py
+++ b/workspace_tools/build.py
@@ -50,6 +50,12 @@ if __name__ == '__main__':
                       default=False,
                       help="Compile the rtos")
 
+    parser.add_option("--rpc",
+                      action="store_true",
+                      dest="rpc",
+                      default=False,
+                      help="Compile the rpc library")
+
     parser.add_option("-e", "--eth",
                       action="store_true", dest="eth",
                       default=False,
@@ -169,6 +175,8 @@ if __name__ == '__main__':
     # Additional Libraries
     if options.rtos:
         libraries.extend(["rtx", "rtos"])
+    if options.rpc:
+        libraries.extend(["rpc"])
     if options.eth:
         libraries.append("eth")
     if options.usb:

--- a/workspace_tools/libraries.py
+++ b/workspace_tools/libraries.py
@@ -34,6 +34,14 @@ LIBRARIES = [
         "dependencies": [MBED_LIBRARIES, MBED_RTX],
     },
 
+    # RPC
+    {
+        "id": "rpc",
+        "source_dir": MBED_RPC,
+        "build_dir": RPC_LIBRARY,
+        "dependencies": [MBED_LIBRARIES],
+    },
+
     # USB Device libraries
     {
         "id": "usb",

--- a/workspace_tools/make.py
+++ b/workspace_tools/make.py
@@ -30,6 +30,7 @@ sys.path.insert(0, ROOT)
 from workspace_tools.utils import args_error
 from workspace_tools.paths import BUILD_DIR
 from workspace_tools.paths import RTOS_LIBRARIES
+from workspace_tools.paths import RPC_LIBRARY
 from workspace_tools.paths import ETH_LIBRARY
 from workspace_tools.paths import USB_HOST_LIBRARIES, USB_LIBRARIES
 from workspace_tools.paths import DSP_LIBRARIES
@@ -112,6 +113,10 @@ if __name__ == '__main__':
     parser.add_option("--rtos",
                       action="store_true", dest="rtos",
                       default=False, help="Link with RTOS library")
+
+    parser.add_option("--rpc",
+                      action="store_true", dest="rpc",
+                      default=False, help="Link with RPC library")
 
     parser.add_option("--eth",
                       action="store_true", dest="eth",
@@ -218,6 +223,7 @@ if __name__ == '__main__':
 
         # Linking with extra libraries
         if options.rtos:     test.dependencies.append(RTOS_LIBRARIES)
+        if options.rpc:      test.dependencies.append(RPC_LIBRARY)
         if options.eth:      test.dependencies.append(ETH_LIBRARY)
         if options.usb_host: test.dependencies.append(USB_HOST_LIBRARIES)
         if options.usb:      test.dependencies.append(USB_LIBRARIES)

--- a/workspace_tools/paths.py
+++ b/workspace_tools/paths.py
@@ -47,6 +47,8 @@ HOST_TESTS = join(ROOT, "workspace_tools", "host_tests")
 # mbed RPC
 MBED_RPC = join(LIB_DIR, "rpc")
 
+RPC_LIBRARY = join(BUILD_DIR, "rpc")
+
 # mbed RTOS
 RTOS = join(LIB_DIR, "rtos")
 MBED_RTX = join(RTOS, "rtx")


### PR DESCRIPTION
Here's my attempt at fixing #1426, which I filed earlier.  This PR adds a `--rpc` option to `build.py` and `make.py` that does the same thing as similar flags for the other libraries.

Here's what I get when I run the build script now:
~~~{.sh}
$ python2 workspace_tools/build.py --mcu=LPC1768 --tool="GCC_ARM" --rpc

[WARNING] Using default settings. Define your settings in the file "workspace_tools/private_settings.py" or in "./mbed_settings.py"
Building library CMSIS (LPC1768, GCC_ARM)
Building library MBED (LPC1768, GCC_ARM)
Building library RPC (LPC1768, GCC_ARM)

Completed in: (0.02)s

Build successes:
  * GCC_ARM::LPC1768
~~~

And the outputs in the build dir seem to show that it works:
~~~{.sh}
$ tree build/rpc 
build/rpc
├── Arguments.h
├── mbed_rpc.h
├── parse_pins.h
├── RpcClasses.h
├── RPCFunction.h
├── rpc.h
├── RPCVariable.h
└── TARGET_LPC1768
    └── TOOLCHAIN_GCC_ARM
        └── librpc.a

2 directories, 8 files
~~~