### PR TITLE
Bugfixes to EFM32 serial, spi and sleep HAL

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/serial_api.c
@@ -1693,14 +1693,14 @@ int serial_irq_handler_asynch(serial_t *obj)
             }
         }else{
             if(obj->serial.periph.uart->IEN & USART_IEN_TXC){
-                USART_IntDisable(obj->serial.periph.leuart,USART_IEN_TXC);
+                USART_IntDisable(obj->serial.periph.uart,USART_IEN_TXC);
                 /* Clean up */
                 serial_dma_irq_fired[obj->serial.dmaOptionsTX.dmaChannel] = false;
                 serial_tx_abort_asynch(obj);
                 /* Notify CPP land of completion */
                 return SERIAL_EVENT_TX_COMPLETE & obj->serial.events;
             }else{
-                USART_IntEnable(obj->serial.periph.leuart,USART_IEN_TXC);
+                USART_IntEnable(obj->serial.periph.uart,USART_IEN_TXC);
             }
         }
     } else {

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/sleep.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/sleep.c
@@ -41,10 +41,7 @@ uint32_t sleep_block_counter[NUM_SLEEP_MODES] = {0};
 
 /**
  * Sleep mode.
- * Enter Energy Mode 1, which turns off the clock to the CPU.
- *
- * In EM1, the CPU is sleeping and the power consumption is only 50 μA/MHz.
- * All peripherals, including DMA, PRS and memory system, are still available.
+ * Enter the lowest possible sleep mode that is not blocked by ongoing activity.
  */
 void sleep(void)
 {
@@ -57,13 +54,10 @@ void sleep(void)
     } else if (sleep_block_counter[2] > 0) {
         /* Blocked everything below EM2, enter EM2 */
         EMU_EnterEM2(true);
-    } else if (sleep_block_counter[3] > 0) {
+    } else {
         /* Blocked everything below EM3, enter EM3 */
         EMU_EnterEM3(true);
-    } else{
-        /* Nothing is blocked, enter EM4 */
-        EMU_EnterEM4();
-    }
+    } /* Never enter EM4, as mbed has no way of configuring EM4 wakeup */
     return;
 }
 

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -359,7 +359,6 @@ int spi_master_write(spi_t *obj, int value)
 
     /* Wait for transmission of last byte */
     while (!(obj->spi.spi->STATUS & USART_STATUS_TXC)) {
-        sleep(); // TODO_LP this might break other code, write should be separate from read?
     }
 
     return spi_read(obj);

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/spi_api.c
@@ -50,7 +50,7 @@
 static uint16_t fill_word = SPI_FILL_WORD;
 #define SPI_LEAST_ACTIVE_SLEEPMODE EM1
 
-inline CMU_Clock_TypeDef spi_get_clock_tree(spi_t *obj)
+static inline CMU_Clock_TypeDef spi_get_clock_tree(spi_t *obj)
 {
     switch ((int)obj->spi.spi) {
 #ifdef USART0
@@ -71,7 +71,7 @@ inline CMU_Clock_TypeDef spi_get_clock_tree(spi_t *obj)
     }
 }
 
-inline uint8_t spi_get_index(spi_t *obj)
+static inline uint8_t spi_get_index(spi_t *obj)
 {
     uint8_t index = 0;
     switch ((int)obj->spi.spi) {


### PR DESCRIPTION
This PR fixes a few bugs in the serial, spi and sleep HAL implementations for EFM32.

* serial: set TXC interrupt flag on the correct peripheral when performing async write using interrupts
* spi: remove erroneous `sleep()` call in `spi_master_write()`, declare init helper functions as static
* sleep: remove option to enter EM4, as there is no way of configuring wakeup from EM4 in mbed

@0xc0170 