### PR TITLE
Fixes issue where library is compiled multiple times during testing

### DIFF
--- a/workspace_tools/test_api.py
+++ b/workspace_tools/test_api.py
@@ -395,7 +395,7 @@ class SingleTestRunner(object):
                 # Detect which lib should be added to test
                 # Some libs have to compiled like RTOS or ETH
                 for lib in LIBRARIES:
-                    if lib['build_dir'] in test.dependencies and lib['build_dir'] not in libraries:
+                    if lib['build_dir'] in test.dependencies and lib['id'] not in libraries:
                         libraries.append(lib['id'])
 
 


### PR DESCRIPTION
There was in issue this commit: https://github.com/mbedmicro/mbed/commit/065705009828b7c1255797f7d628de1cbedc9bb4

It will try to build libraries for the tests (eg RTOS, RTX, et) multiple times. This fixes that issue.