### PR TITLE
[DISCO_F746NG] missing gcc_arm in targets.py

### DIFF
--- a/workspace_tools/build_travis.py
+++ b/workspace_tools/build_travis.py
@@ -67,7 +67,7 @@ build_list = (
     { "target": "DISCO_F407VG",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
     { "target": "DISCO_F429ZI",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
     { "target": "DISCO_F469NI",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
-    { "target": "DISCO_F746NG",      "toolchains": "GCC_ARM", "libs": ["dsp", "fat"] },
+    { "target": "DISCO_F746NG",      "toolchains": "GCC_ARM", "libs": ["fat"] },
 
     { "target": "LPC1114",           "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },
     { "target": "LPC11U35_401",      "toolchains": "GCC_ARM", "libs": ["dsp", "rtos", "fat"] },

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -841,7 +841,7 @@ class DISCO_F746NG(Target):
         Target.__init__(self)
         self.core = "Cortex-M7"
         self.extra_labels = ['STM', 'STM32F7', 'STM32F746', 'STM32F746NG']
-        self.supported_toolchains = ["ARM", "uARM", "IAR"]
+        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
         self.default_toolchain = "uARM"
         self.detect_code = ["0815"]
 


### PR DESCRIPTION
'normal' tests are OK, RTOS builds fail:

+--------------+--------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result       | Target       | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------------+--------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| OK           | DISCO_F746NG | GCC_ARM   | DTCT_1      | Simple detect test                    |        0.5         |     10        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | EXAMPLE_1   | /dev/null                             |        3.43        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_10     | Hello World                           |        0.36        |     5         |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_11     | Ticker Int                            |       11.37        |     15        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_12     | C++                                   |        1.37        |     10        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_16     | RTC                                   |        4.74        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_2      | stdio                                 |        0.8         |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_23     | Ticker Int us                         |       11.35        |     15        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_24     | Timeout Int us                        |       11.37        |     15        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_25     | Time us                               |       11.37        |     15        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_26     | Integer constant division             |        1.38        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_34     | Ticker Two callbacks                  |        11.4        |     15        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_37     | Serial NC RX                          |       10.91        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_38     | Serial NC TX                          |        15.4        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_A1     | Basic                                 |        1.36        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_A21    | Call function before main (mbed_main) |        1.43        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_A9     | Serial Echo at 115200                 |        6.51        |     20        |  1/1  |
| OK           | DISCO_F746NG | GCC_ARM   | MBED_BUSOUT | BusOut                                |        2.27        |     15        |  1/1  |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_1      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_2      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_3      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_4      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_5      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_6      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_7      | Toolchain build failed                |         0          |     0         |   -   |
| BUILD_FAILED | DISCO_F746NG | GCC_ARM   | RTOS_8      | Toolchain build failed                |         0          |     0         |   -   |
+--------------+--------------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 8 BUILD_FAILED / 18 OK