### PR TITLE
Added exclude_mcu key to tests.py config

### DIFF
--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -1092,6 +1092,8 @@ class Test:
     def is_supported(self, target, toolchain):
         if hasattr(self, 'mcu') and not target in self.mcu:
             return False
+        if hasattr(self, 'exclude_mcu') and target in self.exclude_mcu:
+            return False
         if not hasattr(self, 'supported'):
             return True
         return (target in self.supported) and (toolchain in self.supported[target])
@@ -1111,6 +1113,7 @@ class Test:
     def __getitem__(self, key):
         if key == "id": return self.id
         elif key == "mcu": return self.mcu
+        elif key == "exclude_mcu": return self.exclude_mcu
         elif key == "dependencies": return self.dependencies
         elif key == "description": return self.description
         elif key == "duration": return self.duration


### PR DESCRIPTION
This allows targets to be excluded from automated tests.

For example, the NRF51 does not have a RTC. This will allow the RTC test to run by default except on the NRF51 targets.