### PR TITLE
handle UART RX overrun on stm32l1xx

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
@@ -231,6 +231,9 @@ static void uart_irq(UARTName name, int id)
             irq_handler(serial_irq_ids[id], RxIrq);
             __HAL_UART_CLEAR_FLAG(&UartHandle, UART_FLAG_RXNE);
         }
+        if (__HAL_UART_GET_FLAG(&UartHandle, UART_FLAG_ORE) != RESET) {
+            __HAL_UART_CLEAR_OREFLAG(&UartHandle);
+        }
     }
 }
 


### PR DESCRIPTION
UART RX overrun is causing interrupt flood in uart_irq() on ST platforms. This pull request adds overrun flag clearing in the uart interrupt to prevent lockup from interrupt flooding.  The test program is here https://developer.mbed.org/users/dudmuck/code/uart_overrun_test/   I have seen lockup on NUCLEO_L152RE and _F103RB boards, but not on NXP11U68.   For now I am only concerned with stm32l1xx platform.