### PR TITLE
Teensy3.1 - K20D50M Update i2c_api.c

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20XX/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_K20XX/i2c_api.c
@@ -85,13 +85,7 @@ int i2c_stop(i2c_t *obj) {
     volatile uint32_t n = 0;
     obj->i2c->C1 &= ~I2C_C1_MST_MASK;
     obj->i2c->C1 &= ~I2C_C1_TX_MASK;
-
-    // It seems that there are timing problems
-    // when there is no waiting time after a STOP.
-    // This wait is also included on the samples
-    // code provided with the freedom board
-    for (n = 0; n < 100; n++)
-        __NOP();
+    while(obj->i2c->S & I2C_S_BUSY_MASK);
     return 0;
 }
 


### PR DESCRIPTION
The increase of the Teensy3.1 core clock to 96MHz has caused the i2c communication to fail.
Problem is caused by a workaround using core _NOP clock cycles to perform a delay in the i2c.stop function.
Clearly running at a higher core clock rate the delay is reduced resulting with the i2c.stop function exiting before completing.
Increasing the _NOP count to 110 does get round the issue, however this will lead to an unnecessary delay for the slower K20D50M Target that requires 60 to work, unless conditional code is employed.
  
Replacing the workaround code to test with I2C_S_BUSY_MASK has fixed the issue.
This now makes the function independent of the core clock frequency allowing the clock set up to be changed without affecting the i2c.stop operation.

Hardware tested on both Targets with several i2c devices.

I have also tested with KLxx range of platforms and is working there as well and should also work with the K22F and K64F Targets, although the code will be slightly different there.
  