### PR TITLE
[NUCLEO-F030R8] Fixed: The issue of LED blinking too fast.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
@@ -96,10 +96,6 @@ void timer_oc_irq_handler(void)
 // Reconfigure the HAL tick using a standard timer instead of systick.
 HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
   
-    static uint32_t ticker_inited=0;  
-    if(ticker_inited)return HAL_OK;
-    ticker_inited=1;
-  
     // Enable timer clock
     TIM_MST_RCC;
 


### PR DESCRIPTION
Refer to:
https://github.com/mbedmicro/mbed/issues/1329
https://developer.mbed.org/questions/61386/Is-there-system-clock-error-in-STM32F030/