### PR TITLE
Fix glitch when initializing NRF51-DK serial port

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -58,6 +58,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx) {
     obj->uart = (NRF_UART_Type *)uart;
 
     //pin configurations --
+    NRF_GPIO->OUT |= (1 << tx);
+    NRF_GPIO->OUT |= (1 << RTS_PIN_NUMBER);
     NRF_GPIO->DIR |= (1 << tx); //TX_PIN_NUMBER);
     NRF_GPIO->DIR |= (1 << RTS_PIN_NUMBER);
 


### PR DESCRIPTION
When initializing the NRF51's serial TX and RTS pins set the
data output register to high before setting the setting them to
output.  This prevents these pins from glitching low before
the UART has been turned on.