### PR TITLE
Fix nRF51 baud table size

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/serial_api.c
@@ -29,7 +29,7 @@
 
 static uint32_t serial_irq_ids[UART_NUM] = {0};
 static uart_irq_handler irq_handler;
-static const int acceptedSpeeds[17][2] = {
+static const int acceptedSpeeds[18][2] = {
     {1200, UART_BAUDRATE_BAUDRATE_Baud1200},
     {2400, UART_BAUDRATE_BAUDRATE_Baud2400},
     {4800, UART_BAUDRATE_BAUDRATE_Baud4800},


### PR DESCRIPTION
Increase the number of entries in the baud rate table from 17 to 18.
This problem was introduced in the patch:
0a6e345400e5e73eeb8df189bc3ce112f0dbd793 -
Add support for 56000 baud on nrf51