### PR TITLE
Fix interrupt handler for endpoints > 2

### DIFF
--- a/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
+++ b/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
@@ -491,6 +491,7 @@ void USBHAL::usbisr(void) {
         uint32_t num  = (USB0->STAT >> 4) & 0x0F;
         uint32_t dir  = (USB0->STAT >> 3) & 0x01;
         uint32_t ev_odd = (USB0->STAT >> 2) & 0x01;
+        int endpoint = (num << 1) | dir;
 
         // setup packet
         if ((num == 0) && (TOK_PID((EP_BDT_IDX(num, dir, ev_odd))) == SETUP_TOKEN)) {
@@ -507,9 +508,9 @@ void USBHAL::usbisr(void) {
                 if (num == 0)
                     EP0out();
                 else {
-                    epComplete |= (1 << EP(num));
-                    if ((instance->*(epCallback[EP(num) - 2]))()) {
-                        epComplete &= ~(1 << EP(num));
+                    epComplete |= EP(endpoint);
+                    if ((instance->*(epCallback[endpoint - 2]))()) {
+                        epComplete &= ~EP(endpoint);
                     }
                 }
             }
@@ -524,9 +525,9 @@ void USBHAL::usbisr(void) {
                     }
                 }
                 else {
-                    epComplete |= (1 << (EP(num) + 1));
-                    if ((instance->*(epCallback[EP(num) + 1 - 2]))()) {
-                        epComplete &= ~(1 << (EP(num) + 1));
+                    epComplete |= EP(endpoint);
+                    if ((instance->*(epCallback[endpoint - 2]))()) {
+                        epComplete &= ~EP(endpoint);
                     }
                 }
             }


### PR DESCRIPTION
The IRQ handler calculated the endpoint number wrong when handling IN and OUT tokens.  The errant code worked by accident for endpoints 1 and 2 but was incorrect for other addresses.  For endpoints 5 and above it resulted in stray pointer read/writes that could crash the device.