### PR TITLE
Remove doubling of buffer size in realiseEndpoint()

### DIFF
--- a/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
+++ b/libraries/USBDevice/USBDevice/USBHAL_KL25Z.cpp
@@ -214,21 +214,21 @@ bool USBHAL::realiseEndpoint(uint8_t endpoint, uint32_t maxPacket, uint32_t flag
         handshake_flag = USB_ENDPT_EPHSHK_MASK;
         if (IN_EP(endpoint)) {
             if (endpoint_buffer[EP_BDT_IDX(log_endpoint, TX, ODD)] == NULL)
-                endpoint_buffer[EP_BDT_IDX(log_endpoint, TX, ODD)] = (uint8_t *) malloc (64*2);
+                endpoint_buffer[EP_BDT_IDX(log_endpoint, TX, ODD)] = (uint8_t *) malloc (64);
             buf = &endpoint_buffer[EP_BDT_IDX(log_endpoint, TX, ODD)][0];
         } else {
             if (endpoint_buffer[EP_BDT_IDX(log_endpoint, RX, ODD)] == NULL)
-                endpoint_buffer[EP_BDT_IDX(log_endpoint, RX, ODD)] = (uint8_t *) malloc (64*2);
+                endpoint_buffer[EP_BDT_IDX(log_endpoint, RX, ODD)] = (uint8_t *) malloc (64);
             buf = &endpoint_buffer[EP_BDT_IDX(log_endpoint, RX, ODD)][0];
         }
     } else {
         if (IN_EP(endpoint)) {
             if (endpoint_buffer_iso[2] == NULL)
-                endpoint_buffer_iso[2] = (uint8_t *) malloc (1023*2);
+                endpoint_buffer_iso[2] = (uint8_t *) malloc (1023);
             buf = &endpoint_buffer_iso[2][0];
         } else {
             if (endpoint_buffer_iso[0] == NULL)
-                endpoint_buffer_iso[0] = (uint8_t *) malloc (1023*2);
+                endpoint_buffer_iso[0] = (uint8_t *) malloc (1023);
             buf = &endpoint_buffer_iso[0][0];
         }
     }


### PR DESCRIPTION
realiseEndpoint() was unnecessarily allocating twice the buffer space for each endpoint buffer.  This was presumably for the sake of the hardware SIE's double-buffering (EVEN/ODD) system, but that's vestigial - this implementation doesn't use the double-buffering capability at all, leaving the ODDRST bit in the CTL register always set.  The double-size allocation is a pure waste of memory.