### PR TITLE
[TY51822r3] add platform

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/system_nrf51.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/system_nrf51.c
@@ -62,7 +62,14 @@ void SystemCoreClockUpdate(void)
 void SystemInit(void)
 {
 #if defined(TARGET_NRF_32MHZ_XTAL)
-    // For 32MHz external XTAL such as Taiyo Yuden
+    /* For 32MHz HFCLK XTAL such as Taiyo Yuden
+       Physically, tiny footprint XTAL oscillate higher freq. To make BLE modules smaller, some modules
+       are using 32MHz XTAL.
+       This code wriging the value 0xFFFFFF00 to the UICR (User Information Configuration Register)
+       at address 0x10001008, to make nRF51 works with 32MHz system clock. This register will be overwritten
+       by SoftDevice to 0xFFFFFFFF, the default value. Each hex files built with mbed classic online compiler
+       contain SoftDevice, so that, this code run once just after the hex file will be flashed onto nRF51.
+       After changing the value, nRF51 need to reboot. */
     if (*(uint32_t *)0x10001008 == 0xFFFFFFFF)
     {
         NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;

--- a/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/system_nrf51.c
+++ b/libraries/mbed/targets/cmsis/TARGET_NORDIC/TARGET_MCU_NRF51822/system_nrf51.c
@@ -61,6 +61,20 @@ void SystemCoreClockUpdate(void)
 
 void SystemInit(void)
 {
+#if defined(TARGET_NRF_32MHZ_XTAL)
+    // For 32MHz external XTAL such as Taiyo Yuden
+    if (*(uint32_t *)0x10001008 == 0xFFFFFFFF)
+    {
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Wen << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+        *(uint32_t *)0x10001008 = 0xFFFFFF00;
+        NRF_NVMC->CONFIG = NVMC_CONFIG_WEN_Ren << NVMC_CONFIG_WEN_Pos;
+        while (NRF_NVMC->READY == NVMC_READY_READY_Busy){}
+        NVIC_SystemReset();
+        while (true){}
+    }
+#endif
+
     /* If desired, switch off the unused RAM to lower consumption by the use of RAMON register.
        It can also be done in the application main() function. */
 

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/PinNames.h
@@ -1,0 +1,178 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2013 Nordic Semiconductor
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_PINNAMES_H
+#define MBED_PINNAMES_H
+
+#include "cmsis.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    PIN_INPUT,
+    PIN_OUTPUT
+} PinDirection;
+
+#define PORT_SHIFT  3
+
+typedef enum {
+    p0  = 0,
+    p1  = 1,
+    p2  = 2,
+    p3  = 3,
+    p4  = 4,
+    p5  = 5,
+    p6  = 6,
+    p7  = 7,
+    p8  = 8,
+    p9  = 9,
+    p10 = 10,
+    p11 = 11,
+    p12 = 12,
+    p13 = 13,
+    p14 = 14,
+    p15 = 15,
+    p16 = 16,
+    p17 = 17,
+    p18 = 18,
+    p19 = 19,
+    p20 = 20,
+    p21 = 21,
+    p22 = 22,
+    p23 = 23,
+    p24 = 24,
+    p25 = 25,
+    p26 = 26,
+    p27 = 27,
+    p28 = 28,
+    p29 = 29,
+    p30 = 30,
+
+    P0_0  = p0,
+    P0_1  = p1,
+    P0_2  = p2,
+    P0_3  = p3,
+    P0_4  = p4,
+    P0_5  = p5,
+    P0_6  = p6,
+    P0_7  = p7,
+
+    P0_8  = p8,
+    P0_9  = p9,
+    P0_10 = p10,
+    P0_11 = p11,
+    P0_12 = p12,
+    P0_13 = p13,
+    P0_14 = p14,
+    P0_15 = p15,
+
+    P0_16 = p16,
+    P0_17 = p17,
+    P0_18 = p18,
+    P0_19 = p19,
+    P0_20 = p20,
+    P0_21 = p21,
+    P0_22 = p22,
+    P0_23 = p23,
+
+    P0_24 = p24,
+    P0_25 = p25,
+    P0_26 = p26,
+    P0_27 = p27,
+    P0_28 = p28,
+    P0_29 = p29,
+    P0_30 = p30,
+
+    LED1    = p21,
+    LED2    = p22,
+    LED3    = p23,
+    LED4    = p24,
+
+    BUTTON1 = p17,
+    BUTTON2 = p18,
+    BUTTON3 = p19,
+    BUTTON4 = p20,
+
+    RX_PIN_NUMBER  = p11,
+    TX_PIN_NUMBER  = p9,
+    CTS_PIN_NUMBER = p10,
+    RTS_PIN_NUMBER = p8,
+
+    // mBed interface Pins
+    USBTX = TX_PIN_NUMBER,
+    USBRX = RX_PIN_NUMBER,
+
+    SPI_PSELMOSI0 = p25,
+    SPI_PSELMISO0 = p28,
+    SPI_PSELSS0   = p24,
+    SPI_PSELSCK0  = p29,
+
+    SPI_PSELMOSI1 = p13,
+    SPI_PSELMISO1 = p14,
+    SPI_PSELSS1   = p12,
+    SPI_PSELSCK1  = p15,
+
+    SPIS_PSELMOSI = p13,
+    SPIS_PSELMISO = p14,
+    SPIS_PSELSS   = p12,
+    SPIS_PSELSCK  = p15,
+
+    I2C_SDA0 = p30,
+    I2C_SCL0 = p7,
+
+    D0  = p12,
+    D1  = p13,
+    D2  = p14,
+    D3  = p15,
+    D4  = p16,
+    D5  = p17,
+    D6  = p18,
+    D7  = p19,
+
+    D8  = p20,
+    D9  = p23,
+    D10 = p24,
+    D11 = p25,
+    D12 = p28,
+    D13 = p29,
+
+    D14 = p30,
+    D15 = p7,
+
+    A0  = p1,
+    A1  = p2,
+    A2  = p3,
+    A3  = p4,
+    A4  = p5,
+    A5  = p6,
+
+    // Not connected
+    NC = (int)0xFFFFFFFF
+} PinName;
+
+typedef enum {
+    PullNone = 0,
+    PullDown = 1,
+    PullUp = 3,
+    PullDefault = PullUp
+} PinMode;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/PinNames.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2013 Nordic Semiconductor
+ * Copyright (c) 2015 Nordic Semiconductor
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/device.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/device.h
@@ -1,0 +1,57 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2013 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef MBED_DEVICE_H
+#define MBED_DEVICE_H
+
+#define DEVICE_PORTIN           1
+#define DEVICE_PORTOUT          1
+#define DEVICE_PORTINOUT        1
+
+#define DEVICE_INTERRUPTIN      1
+
+#define DEVICE_ANALOGIN         1
+#define DEVICE_ANALOGOUT        0
+
+#define DEVICE_SERIAL           1
+
+#define DEVICE_I2C              1
+#define DEVICE_I2CSLAVE         0
+
+#define DEVICE_SPI              1
+#define DEVICE_SPISLAVE         1
+
+#define DEVICE_CAN              0
+
+#define DEVICE_RTC              0
+
+#define DEVICE_ETHERNET         0
+
+#define DEVICE_PWMOUT           1
+
+#define DEVICE_SEMIHOST         0
+#define DEVICE_LOCALFILESYSTEM  0
+
+#define DEVICE_SLEEP            1
+
+#define DEVICE_DEBUG_AWARENESS  0
+
+#define DEVICE_STDIO_MESSAGES   0
+
+#define DEVICE_ERROR_PATTERN    1
+
+#include "objects.h"
+
+#endif

--- a/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/device.h
+++ b/libraries/mbed/targets/hal/TARGET_NORDIC/TARGET_MCU_NRF51822/TARGET_TY51822R3/device.h
@@ -1,5 +1,5 @@
 /* mbed Microcontroller Library
- * Copyright (c) 2006-2013 ARM Limited
+ * Copyright (c) 2006-2015 ARM Limited
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.

--- a/workspace_tools/build_release.py
+++ b/workspace_tools/build_release.py
@@ -106,6 +106,7 @@ OFFICIAL_MBED_LIBRARY_BUILD = (
     ('DELTA_DFCM_NNN40',  ('ARM', 'GCC_ARM')),
     ('NRF51_MICROBIT',      ('ARM',)),
     ('NRF51_MICROBIT_B',      ('ARM',)),
+    ('TY51822R3',     ('ARM', 'GCC_ARM')),
 
     ('LPC11U68',     ('ARM', 'uARM','GCC_ARM','GCC_CR', 'IAR')),
     ('OC_MBUINO',     ('ARM', 'uARM', 'GCC_ARM', 'IAR')),

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -1457,6 +1457,26 @@ class NRF51_MICROBIT_B_OTA(MCU_NRF51_16K_OTA):
         self.extra_labels += ['NRF51_MICROBIT']
         self.macros += ['TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
 
+class TY51822R3(MCU_NRF51_32K):
+    def __init__(self):
+        MCU_NRF51_32K.__init__(self)
+        self.macros += ['TARGET_NRF_32MHZ_XTAL']
+        self.supported_toolchains = ["ARM", "GCC_ARM"]
+
+class TY51822R3_BOOT(MCU_NRF51_32K_BOOT):
+    def __init__(self):
+        MCU_NRF51_32K_BOOT.__init__(self)
+        self.extra_labels += ['TY51822R3']
+        self.macros += ['TARGET_TY51822R3', 'TARGET_NRF_32MHZ_XTAL']
+        self.supported_toolchains = ["ARM", "GCC_ARM"]
+
+class TY51822R3_OTA(MCU_NRF51_32K_OTA):
+    def __init__(self):
+        MCU_NRF51_32K_OTA.__init__(self)
+        self.extra_labels += ['NRF51_DK']
+        self.macros += ['TARGET_TY51822R3', 'TARGET_NRF_32MHZ_XTAL']
+        self.supported_toolchains = ["ARM", "GCC_ARM"]
+
         
 ### ARM ###
 
@@ -1817,6 +1837,9 @@ TARGETS = [
     NRF51_MICROBIT_B(),     # nRF51_16K - default
     NRF51_MICROBIT_B_BOOT(),# nRF51_16K - default
     NRF51_MICROBIT_B_OTA(), # nRF51_16K - default
+    TY51822R3(),            # nRF51_32K
+    TY51822R3_BOOT(),       # nRF51_32K
+    TY51822R3_OTA(),        # nRF51_32K
 
 
     ### ARM ###

--- a/workspace_tools/tests.py
+++ b/workspace_tools/tests.py
@@ -462,6 +462,7 @@ TESTS = [
                         "NRF51_MICROBIT", "NRF51_MICROBIT_B", "NRF51_MICROBIT_BOOT",
                         "NRF51_MICROBIT_B_BOOT", "NRF51_MICROBIT_B_OTA", "NRF51_MICROBIT_OTA",
                         "HRM1017", "HRM1017_BOOT", "HRM1701_OTA",
+                        "TY51822R3", "TY51822R3_BOOT", "TY51822R3_OTA",
                         "NRF15_DONGLE", "NRF15_DONGLE_BOOT", "NRF15_DONGLE_OTA",
                         "ARCH_BLE", "ARCH_BLE_BOOT", "ARCH_BLE_OTA",
                         "ARCH_LINK", "ARCH_LINK_BOOT", "ARCH_LINK_OTA",


### PR DESCRIPTION
Added new nRF51822 platform.
```
Test summary:
+---------+-----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| Result  | Target    | Toolchain | Test ID     | Test Description                      | Elapsed Time (sec) | Timeout (sec) | Loops |
+---------+-----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
| TIMEOUT | TY51822R3 | ARM       | DTCT_1      | Simple detect test                    |       80.41        |       40      |  0/1  |
| OK      | TY51822R3 | ARM       | EXAMPLE_1   | /dev/null                             |        3.46        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_10     | Hello World                           |        0.37        |       5       |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_11     | Ticker Int                            |       11.37        |       15      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_12     | C++                                   |        1.39        |       10      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_2      | stdio                                 |        0.78        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_23     | Ticker Int us                         |       11.34        |       15      |  1/1  |
| FAIL    | TY51822R3 | ARM       | MBED_24     | Timeout Int us                        |       16.63        |       15      |  0/1  |
| OK      | TY51822R3 | ARM       | MBED_25     | Time us                               |       12.14        |       15      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_26     | Integer constant division             |        1.39        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_34     | Ticker Two callbacks                  |       11.37        |       15      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_37     | Serial NC RX                          |       11.07        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_38     | Serial NC TX                          |       15.58        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_A1     | Basic                                 |        1.37        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_A21    | Call function before main (mbed_main) |        1.42        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_A9     | Serial Echo at 115200                 |        6.93        |       20      |  1/1  |
| OK      | TY51822R3 | ARM       | MBED_BUSOUT | BusOut                                |        2.29        |       45      |  1/1  |
+---------+-----------+-----------+-------------+---------------------------------------+--------------------+---------------+-------+
Result: 1 FAIL / 15 OK / 1 TIMEOUT
```