### PR TITLE
Fixes toolchain filtering

### DIFF
--- a/workspace_tools/build_release.py
+++ b/workspace_tools/build_release.py
@@ -177,7 +177,7 @@ if __name__ == '__main__':
         if options.toolchains:
             print "Only building using the following toolchains: %s" % (options.toolchains)
             toolchainSet = set(toolchains)
-            toolchains = toolchainSet and set((options.toolchains).split(','))
+            toolchains = toolchainSet.intersection(set((options.toolchains).split(',')))
 
         for toolchain in toolchains:
             id = "%s::%s" % (target_name, toolchain)


### PR DESCRIPTION
Fixes an issue where build_release.py tries to build the mbed library for a platform with an unsupported toolchain