### PR TITLE
The predivider should be 2 here.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/system_stm32f0xx.c
@@ -437,7 +437,7 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
   RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
   RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV2;
   RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL


### PR DESCRIPTION
Since we want to get a 48M PLLCLK when using HSI as resource and PLLMUL is 12 as it in current code, then we should set PREDIV to 2. If set the PREDIV to 1 as current code, the system clock is 96M.

 PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
 PLLCLK = 96 MHz ((HSI 8 MHz / 1) * 12)