### PR TITLE
[Silicon Labs] Allow faster I2C baudrates

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
@@ -372,8 +372,8 @@ int block_and_wait_for_ack(I2C_TypeDef *i2c)
 void i2c_slave_mode(i2c_t *obj, int enable_slave)
 {
     if(enable_slave) {
-        /* Datasheet note: DIV must be set to 1 during slave operation */
-        obj->i2c.i2c->DIV = 1;
+        /* Reference manual note: DIV must be set to 1 during slave operation */
+        obj->i2c.i2c->CLKDIV = 1;
         obj->i2c.i2c->CTRL |= _I2C_CTRL_SLAVE_MASK;
         obj->i2c.i2c->CTRL |= _I2C_CTRL_AUTOACK_MASK; //Slave implementation assumes auto acking
     } else {

--- a/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Silicon_Labs/TARGET_EFM32/i2c_api.c
@@ -135,7 +135,9 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl)
                               (pin_location(scl, PinMap_I2C_SCL) << _I2C_ROUTELOC0_SCLLOC_SHIFT);
 #endif
 
-    /* Set up the pins for I2C use: WiredAnd and high drive strength to reduce slew rate */
+    /* Set up the pins for I2C use */
+    /* Note: Set up pins in higher drive strength to reduce slew rate */
+    /*   Though this requires user knowledge, since drive strength is controlled per port, not pin */
     pin_mode(scl, WiredAndPullUp);
     pin_mode(sda, WiredAndPullUp);
 


### PR DESCRIPTION
Added code to the I2C implementation to allow for SCK to go up to 1MHz (up from 100kHz previously)