### PR TITLE
Update rtc_api.c

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
@@ -38,14 +38,32 @@ static void init(void) {
 void rtc_init(void) {
     init();
 
-    //Configure the TSR. default value: 1
+    // Configure the TSR. default value: 1
     RTC->TSR = 1;
-    
-    if (PinMap_RTC[0].pin == NC) {        //Use OSC32K
-        RTC->CR |= RTC_CR_OSCE_MASK;
-        //delay for OSCE stabilization
-        for(int i=0; i<0x1000; i++) __NOP();
-    }
+
+    // Configure Time Compensation Register to calibrate RTC accuracy
+
+    // dissable LRL lock
+    RTC->LR &= ~RTC_LR_LRL_MASK;
+    // RTC->TCR: RTC_TCR_CIR_MASK,RTC_TCR_CIR(x)=0,RTC_TCR_TCR(x)=0  Default no correction
+    RTC->TCR = RTC_TCR_CIR(0) | RTC_TCR_TCR(0);
+    /*
+        RTC_TCR_CIR(x) sets the compensation interval in seconds from 1 to 256.
+        0x05 will apply the compensation once every 4 seconds.
+
+        RTC_TCR_TCR(x) sets the Register Overflow
+        0x80 Time Prescaler Register overflows every 32896 clock cycles. (+128)
+        ... ... RTC runs slower
+        0xFF Time Prescaler Register overflows every 32769 clock cycles.
+        0x00 Time Prescaler Register overflows every 32768 clock cycles, Default.
+        0x01 Time Prescaler Register overflows every 32767 clock cycles.
+        ... ... RTC runs faster
+        0x7F Time Prescaler Register overflows every 32641 clock cycles. (-128)
+    */
+    // enable TCL lock
+    RTC->LR |= RTC_LR_TCL_MASK;
+    // enable LRL lock
+    RTC->LR |= RTC_LR_LRL_MASK;
 
     // enable counter
     RTC->SR |= RTC_SR_TCE_MASK;


### PR DESCRIPTION
Removed redundant RTC->CR define code + added RTC compensation code to allow calibration of the RTC.

Tom Russell found the RTC->CR settings in the rtc_api.c file overrode the OSC0->CR setting in system_MKL05Z4.c.
Effectively removing the internal loading capacitors for the external 32KHz crystal when the RTC is initialised.
If the external crystal 32Khz clock source is selected (default on the KL05), it is not necessary to call the RTC->CR functions. All other FRDM KLxx platforms RTC clock source is derived from the interface MCU.

Added RTC compensation function to allow calibration of the RTC.
This needs to be set in the rtc_init area, according to the manual, once the locks are enabled they can only be disabled with a POR or software reset making it difficult, probably impossible to place it in the user program code.
