### PR TITLE
Fix HSI configuration for STM32F0x.

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_DISCO_F051R8/system_stm32f0xx.c
@@ -426,12 +426,19 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
   // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/system_stm32f0xx.c
@@ -430,12 +430,19 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
   // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/system_stm32f0xx.c
@@ -430,13 +430,19 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
   // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
-  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/system_stm32f0xx.c
@@ -429,14 +429,20 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_ClkInitTypeDef RCC_ClkInitStruct;
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
-  // Select PLLCLK = 48 MHz ((HSI 8 MHz) * 6)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI;
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL6;
-  RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
+  // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL6;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/system_stm32f0xx.c
@@ -434,12 +434,19 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
   // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/system_stm32f0xx.c
@@ -433,12 +433,19 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
   // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/system_stm32f0xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/system_stm32f0xx.c
@@ -433,12 +433,19 @@ uint8_t SetSysClock_PLL_HSI(void)
   RCC_OscInitTypeDef RCC_OscInitStruct;
  
   // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
-  RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
-  RCC_OscInitStruct.HSIState       = RCC_HSI_ON;
-  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_ON;
-  RCC_OscInitStruct.PLL.PLLSource  = RCC_PLLSOURCE_HSI; // HSI div 2
-  RCC_OscInitStruct.PLL.PREDIV     = RCC_PREDIV_DIV1;
-  RCC_OscInitStruct.PLL.PLLMUL     = RCC_PLL_MUL12;
+  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
+  RCC_OscInitStruct.HSEState                = RCC_HSE_OFF;
+  RCC_OscInitStruct.LSEState                = RCC_LSE_OFF;
+  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
+  RCC_OscInitStruct.HSICalibrationValue     = RCC_HSICALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI14State              = RCC_HSI_OFF;
+  RCC_OscInitStruct.HSI14CalibrationValue   = RCC_HSI14CALIBRATION_DEFAULT;
+  RCC_OscInitStruct.HSI48State              = RCC_HSI_ON;
+  RCC_OscInitStruct.LSIState                = RCC_LSI_OFF;
+  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
+  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
+  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV1;
+  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
       return 0; // FAIL
   }


### PR DESCRIPTION
STM32F0x has OSC_IN and OSC_OUT pins coupled with PF0 and PF_1.
If external oscillator is used then HSE must not be enabled. Otherwise PF0 will be occupied by RCC and can't be used as GPIO.

Current code use default values for init structure:
```CPP
uint8_t SetSysClock_PLL_HSI(void)
{
  RCC_ClkInitTypeDef RCC_ClkInitStruct;
  RCC_OscInitTypeDef RCC_OscInitStruct;

  // Select PLLCLK = 48 MHz ((HSI 8 MHz / 2) * 12)
  RCC_OscInitStruct.OscillatorType          = RCC_OSCILLATORTYPE_HSI;
  RCC_OscInitStruct.HSIState                = RCC_HSI_ON;
  RCC_OscInitStruct.PLL.PLLState            = RCC_PLL_ON;
  RCC_OscInitStruct.PLL.PLLSource           = RCC_PLLSOURCE_HSI; // HSI div 2
  RCC_OscInitStruct.PLL.PREDIV              = RCC_PREDIV_DIV2;
  RCC_OscInitStruct.PLL.PLLMUL              = RCC_PLL_MUL12;
  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
      return 0; // FAIL
  }
```

However `RCC_OscInitTypeDef` has few important fields that must be set to prevent accidental HSE activation. Critical one is `RCC_OscInitStruct.HSICalibrationValue`.

Interesting that F031K6 and F042K6 set it but all other platform ignore.