### PR TITLE
STM32L476 Update rtc_api.c

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L4/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L4/rtc_api.c
@@ -33,8 +33,6 @@
 
 #include "mbed_error.h"
 
-static int rtc_inited = 0;
-
 static RTC_HandleTypeDef RtcHandle;
 
 void rtc_init(void)
@@ -42,9 +40,6 @@ void rtc_init(void)
     RCC_OscInitTypeDef RCC_OscInitStruct = {0};
     RCC_PeriphCLKInitTypeDef PeriphClkInitStruct = {0};
     uint32_t rtc_freq = 0;
-
-    if (rtc_inited) return;
-    rtc_inited = 1;
 
     RtcHandle.Instance = RTC;
 
@@ -128,13 +123,15 @@ void rtc_free(void)
     RCC_OscInitStruct.LSIState       = RCC_LSI_OFF;
     RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
-
-    rtc_inited = 0;
 }
 
 int rtc_isenabled(void)
 {
-    return rtc_inited;
+    if ((RTC->ISR & RTC_ISR_INITS) ==  RTC_ISR_INITS){
+        return 1;
+    } else {
+        return 0;
+    }
 }
 
 /*

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -120,10 +120,10 @@
 //   <i> Defines the timer clock value.
 //   <i> Default: 6000000  (6MHz)
 #ifndef OS_CLOCK
-#  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368)
+#  if defined(TARGET_LPC1768) || defined(TARGET_LPC2368) || defined(TARGET_TEENSY3_1)
 #    define OS_CLOCK       96000000
 
-#  elif defined(TARGET_LPC1347) || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) || defined(TARGET_STM32F303RE) || defined(TARGET_TEENSY3_1)
+#  elif defined(TARGET_LPC1347) || defined(TARGET_STM32F303VC) || defined(TARGET_LPC1549) || defined(TARGET_STM32F334R8) || defined(TARGET_STM32F334C8) || defined(TARGET_STM32F303RE)
 #    define OS_CLOCK       72000000
 
 #  elif defined(TARGET_STM32F303K8)


### PR DESCRIPTION
Added RTC ISR check code for Mbed rtc_isenabled function.
Removed  rtc_inited parts.

Tested on Nucleo-L476 and Disco-L476 boards with and without vBat pin powered.
Also fully tested on prototype hardware.
Targets no longer resets RTC time registers on POR or nRST including sleep modes.
