### PR TITLE
[STM32L4] Set NVIC_RAM_VECTOR_ADDRESS to 0x10000000

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/cmsis_nvic.c
@@ -30,7 +30,7 @@
  */ 
 #include "cmsis_nvic.h"
 
-#define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
+#define NVIC_RAM_VECTOR_ADDRESS   (0x10000000)  // Vectors positioned at start of SRAM2
 #define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/cmsis_nvic.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/cmsis_nvic.c
@@ -30,7 +30,7 @@
  */ 
 #include "cmsis_nvic.h"
 
-#define NVIC_RAM_VECTOR_ADDRESS   (0x20000000)  // Vectors positioned at start of RAM
+#define NVIC_RAM_VECTOR_ADDRESS   (0x10000000)  // Vectors positioned at start of SRAM2
 #define NVIC_FLASH_VECTOR_ADDRESS (0x08000000)  // Initial vector position in flash
 
 void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {


### PR DESCRIPTION
Fix issue #1413
Fix issue #1509