### PR TITLE
Adding the ability for tests to report they aren't supported on a target

### DIFF
--- a/workspace_tools/build_api.py
+++ b/workspace_tools/build_api.py
@@ -25,7 +25,7 @@ from shutil import rmtree
 from os.path import join, exists, basename
 from time import time
 
-from workspace_tools.utils import mkdir, run_cmd, run_cmd_ext
+from workspace_tools.utils import mkdir, run_cmd, run_cmd_ext, NotSupportedException
 from workspace_tools.paths import MBED_TARGETS_PATH, MBED_LIBRARIES, MBED_API, MBED_HAL, MBED_COMMON
 from workspace_tools.targets import TARGET_NAMES, TARGET_MAP
 from workspace_tools.libraries import Library
@@ -139,12 +139,12 @@ def build_project(src_path, build_path, target, toolchain_name,
                 resources.inc_dirs.extend(inc_dirs)
             else:
                 resources.inc_dirs.append(inc_dirs)
-
         # Compile Sources
         for path in src_paths:
             src = toolchain.scan_resources(path)
             objects = toolchain.compile_sources(src, build_path, resources.inc_dirs)
             resources.objects.extend(objects)
+
 
         # Link Program
         res, needed_update = toolchain.link_program(resources, build_path, name)
@@ -162,7 +162,12 @@ def build_project(src_path, build_path, target, toolchain_name,
     except Exception, e:
         if report != None:
             end = time()
-            cur_result["result"] = "FAIL"
+
+            if isinstance(e, NotSupportedException):
+                cur_result["result"] = "NOT_SUPPORTED"
+            else:
+                cur_result["result"] = "FAIL"
+
             cur_result["elapsed_time"] = end - start
 
             toolchain_output = toolchain.get_output()

--- a/workspace_tools/test_exporters.py
+++ b/workspace_tools/test_exporters.py
@@ -238,7 +238,7 @@ class ReportExporter():
                     tc.add_failure_info(description, _stdout)
                 elif result == 'ERROR':
                     tc.add_error_info(description, _stdout)
-                elif result == 'SKIP':
+                elif result == 'SKIP' or result == 'NOT_SUPPORTED':
                     tc.add_skipped_info(description, _stdout)
 
                 test_cases.append(tc)
@@ -282,7 +282,7 @@ class ReportExporter():
                             message = test_result['result']
                             if test_result['result'] == 'FAIL':
                                 tc.add_failure_info(message, _stdout)
-                            elif test_result['result'] == 'SKIP':
+                            elif test_result['result'] == 'SKIP' or test_result["result"] == 'NOT_SUPPORTED':
                                 tc.add_skipped_info(message, _stdout)
                             elif test_result['result'] != 'OK':
                                 tc.add_error_info(message, _stdout)
@@ -319,7 +319,7 @@ class ReportExporter():
 
                         if test_run["result"] == "FAIL":
                             failures.append(test_run)
-                        elif test_run["result"] == "SKIP":
+                        elif test_run["result"] == "SKIP" or test_run["result"] == "NOT_SUPPORTED":
                             skips.append(test_run)
                         elif test_run["result"] == "OK":
                             successes.append(test_run)

--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -118,6 +118,9 @@ class GCC(mbedToolchain):
                     dependencies = dependencies + [f.replace('\a', ' ') for f in file.split(" ")]
         return dependencies
 
+    def is_not_supported_error(self, output):
+        return "error: #error [NOT_SUPPORTED]" in output
+
     def parse_output(self, output):
         # The warning/error notification is multiline
         WHERE, WHAT = 0, 1

--- a/workspace_tools/utils.py
+++ b/workspace_tools/utils.py
@@ -123,6 +123,8 @@ def rel_path(path, base, dot=False):
 class ToolException(Exception):
     pass
 
+class NotSupportedException(Exception):
+    pass
 
 def split_path(path):
     base, file = split(path)


### PR DESCRIPTION
This allows tests to specifically say they aren't supported on a target. This provides more info to the test suite user and to our build/CI system.

Tests that declare themselves "unsupported" should use the `#error` preprocessor directive in the following manner:

```
#if SUPPORTED
    < Do the test >
#else
    #error [NOT_SUPPORTED] This test is unsupported on this target
#endif
```

You must start the `#error` message with the prefix `[NOT_SUPPORTED]`. After that, you can add a meaningful message.