### PR TITLE
[STM32F3xx] bug fix multiple ADC channels using multiple ADC blocks

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3/analogin_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F3/analogin_api.c
@@ -73,6 +73,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC1)
     if ((obj->adc == ADC_1) && adc1_inited) return;
     if (obj->adc == ADC_1) {
+        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC1_CLK_ENABLE();
         adc1_inited = 1;
     }
@@ -80,6 +81,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC2)
     if ((obj->adc == ADC_2) && adc2_inited) return;
     if (obj->adc == ADC_2) {
+        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC2_CLK_ENABLE();
         adc2_inited = 1;
     }
@@ -87,6 +89,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC3)
     if ((obj->adc == ADC_3) && adc3_inited) return;
     if (obj->adc == ADC_3) {
+        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC34_CLK_ENABLE();
         adc3_inited = 1;
     }
@@ -94,6 +97,7 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC4)
     if ((obj->adc == ADC_4) && adc4_inited) return;
     if (obj->adc == ADC_4) {
+        AdcHandle.State = HAL_ADC_STATE_RESET;
         __ADC34_CLK_ENABLE();
         adc4_inited = 1;
     }


### PR DESCRIPTION
When two or more analogue inputs are initialized on more than one ADC HW block the initialisation fails with:

Cannot initialize ADC

The reason is the reusage of just one ADC_HandleTypeDef for all initializations (in mbed\targets\hal\TARGET_STM\TARGET_STM32F3\analogin_api.c). After the first (successful) ADC initialisation AdcHandle.State is set to HAL_ADC_STATE_READY).
But for the next ADC block initialisation the AdcHandle.State has to be reset so that the HAL initializes it (in mbed\targets\cmsis\TARGET_STM\TARGET_STM32F3\stm32f3xx_hal_adc_ex.c line 424). When this state is not reset the HAL returns with an initialization error. And this error induces the above mbed error message.

The error message can be reproduced just with AnalogIn in1(xx); AnalogIn in2(yy); where xx and yy belongs to two different ADC blocks.