### PR TITLE
Exporter - progen include dirs fix

### DIFF
--- a/workspace_tools/export/exporters.py
+++ b/workspace_tools/export/exporters.py
@@ -62,7 +62,7 @@ class Exporter(object):
                         self.resources.objects + self.resources.libraries,
                 },
                 'includes':  { 
-                    'Include Files': self.resources.headers + self.resources.inc_dirs,
+                    'Include Files': self.resources.headers,
                 },
                 'target': [TARGET_MAP[self.target].progen['target']],
                 'macros': self.get_symbols(),
@@ -76,6 +76,9 @@ class Exporter(object):
         """" Generate project using ProGen Project API """
         settings = ProjectSettings()
         project = Project(self.program_name, [project_data], settings)
+        # TODO: Fix this, the inc_dirs are not valid (our scripts copy files), therefore progen
+        # thinks it is not dict but a file, and adds them to workspace.
+        project.project['common']['include_paths'] = self.resources.inc_dirs
         project.generate(tool_name, copied=True)
 
     def __scan_all(self, path):


### PR DESCRIPTION
mbed scripts copy files, therefore file paths are not valid at the moment of ahe project generation.
Therefore checks like os.path.isdir or isfile fail. If include is set to TARGET/FOLDER, this would be
treated as a file, and added to the project workspace. This commit fixes it, it adds dirs only to
include_paths, as it should.

If we export to IAR, there are non valid files currently, folders as a result of inc_dirs added to includes. It does not affect build, thus cosmetic error in this case.

I'll have a look at this, how progen or mbed scripts can handle this better. One possibility would be to enable include_paths to be set in progen data, as sometimes (in this case) `` includes != include_paths ``

@bridadan 