### PR TITLE
[LPC11U68, LPC1549] Fixed PwmOut SCT Bugs

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC11U6X/pwmout_api.c
@@ -137,7 +137,10 @@ void pwmout_write(pwmout_t* obj, float value) {
     uint32_t t_on = (uint32_t)((float)(pwm->MATCHREL0 + 1) * value);
     if (t_on > 0) {
         pwm->MATCHREL1 = t_on - 1;
-        pwm->CTRL &= ~(1 << 2);
+        if (pwm->CTRL & (1 << 2)) {
+            pwm->MATCH1 = pwm->MATCHREL1;
+            pwm->CTRL &= ~(1 << 2);
+        }
     } else {
         pwm->CTRL |= (1 << 2) | (1 << 3);
         pwm->OUTPUT = 0x00000000;
@@ -145,8 +148,9 @@ void pwmout_write(pwmout_t* obj, float value) {
 }
 
 float pwmout_read(pwmout_t* obj) {
-    uint32_t t_off = obj->pwm->MATCHREL0 + 1;
-    uint32_t t_on  = obj->pwm->MATCHREL1 + 1;
+    LPC_SCT0_Type* pwm = obj->pwm;
+    uint32_t t_off = pwm->MATCHREL0 + 1;
+    uint32_t t_on  = (!(pwm->CTRL & (1 << 2))) ? pwm->MATCHREL1 + 1 : 0;
     float v = (float)t_on/(float)t_off;
     return (v > 1.0f) ? (1.0f) : (v);
 }
@@ -163,16 +167,21 @@ void pwmout_period_ms(pwmout_t* obj, int ms) {
 void pwmout_period_us(pwmout_t* obj, int us) {
     LPC_SCT0_Type* pwm = obj->pwm;
     uint32_t t_off = pwm->MATCHREL0 + 1;
-    uint32_t t_on  = pwm->MATCHREL1 + 1;
+    uint32_t t_on  = (!(pwm->CTRL & (1 << 2))) ? pwm->MATCHREL1 + 1 : 0;
     float v = (float)t_on/(float)t_off;
     uint32_t period_ticks = (uint32_t)(((uint64_t)SystemCoreClock * (uint64_t)us) / (uint64_t)1000000);
     uint32_t pulsewidth_ticks = period_ticks * v;
     pwm->MATCHREL0 = period_ticks - 1;
     if (pulsewidth_ticks > 0) {
         pwm->MATCHREL1 = pulsewidth_ticks - 1;
-        pwm->CTRL &= ~(1 << 2);
+        if (pwm->CTRL & (1 << 2)) {
+            pwm->MATCH0 = pwm->MATCHREL0;
+            pwm->MATCH1 = pwm->MATCHREL1;
+            pwm->CTRL &= ~(1 << 2);
+        }
     } else {
         pwm->CTRL |= (1 << 2) | (1 << 3);
+        pwm->MATCH0 = pwm->MATCHREL0;
         pwm->OUTPUT = 0x00000000;
     }
 }
@@ -189,7 +198,10 @@ void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
     LPC_SCT0_Type* pwm = obj->pwm;
     if (us > 0) {
         pwm->MATCHREL1 = (uint32_t)(((uint64_t)SystemCoreClock * (uint64_t)us) / (uint64_t)1000000) - 1;
-        pwm->CTRL &= ~(1 << 2);
+        if (pwm->CTRL & (1 << 2)) {
+            pwm->MATCH1 = pwm->MATCHREL1;
+            pwm->CTRL &= ~(1 << 2);
+        }
     } else {
         pwm->CTRL |= (1 << 2) | (1 << 3);
         pwm->OUTPUT = 0x00000000;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/pwmout_api.c
@@ -118,7 +118,10 @@ void pwmout_write(pwmout_t* obj, float value) {
     uint32_t t_on = (uint32_t)((float)(pwm->MATCHREL0 + 1) * value);
     if (t_on > 0) {
         pwm->MATCHREL1 = t_on - 1;
-        pwm->CTRL &= ~(1 << 2);
+        if (pwm->CTRL & (1 << 2)) {
+            pwm->MATCH1 = pwm->MATCHREL1;
+            pwm->CTRL &= ~(1 << 2);
+        }
     } else {
         pwm->CTRL |= (1 << 2) | (1 << 3);
         pwm->OUTPUT = 0x00000000;
@@ -126,8 +129,9 @@ void pwmout_write(pwmout_t* obj, float value) {
 }
 
 float pwmout_read(pwmout_t* obj) {
-    uint32_t t_off = obj->pwm->MATCHREL0 + 1;
-    uint32_t t_on  = obj->pwm->MATCHREL1 + 1;
+    LPC_SCT0_Type* pwm = obj->pwm;
+    uint32_t t_off = pwm->MATCHREL0 + 1;
+    uint32_t t_on  = (!(pwm->CTRL & (1 << 2))) ? pwm->MATCHREL1 + 1 : 0;
     float v = (float)t_on/(float)t_off;
     return (v > 1.0f) ? (1.0f) : (v);
 }
@@ -144,16 +148,21 @@ void pwmout_period_ms(pwmout_t* obj, int ms) {
 void pwmout_period_us(pwmout_t* obj, int us) {
     LPC_SCT0_Type* pwm = obj->pwm;
     uint32_t t_off = pwm->MATCHREL0 + 1;
-    uint32_t t_on  = pwm->MATCHREL1 + 1;
+    uint32_t t_on  = (!(pwm->CTRL & (1 << 2))) ? pwm->MATCHREL1 + 1 : 0;
     float v = (float)t_on/(float)t_off;
     uint32_t period_ticks = (uint32_t)(((uint64_t)SystemCoreClock * (uint64_t)us) / (uint64_t)1000000);
     uint32_t pulsewidth_ticks = period_ticks * v;
     pwm->MATCHREL0 = period_ticks - 1;
     if (pulsewidth_ticks > 0) {
         pwm->MATCHREL1 = pulsewidth_ticks - 1;
-        pwm->CTRL &= ~(1 << 2);
+        if (pwm->CTRL & (1 << 2)) {
+            pwm->MATCH0 = pwm->MATCHREL0;
+            pwm->MATCH1 = pwm->MATCHREL1;
+            pwm->CTRL &= ~(1 << 2);
+        }
     } else {
         pwm->CTRL |= (1 << 2) | (1 << 3);
+        pwm->MATCH0 = pwm->MATCHREL0;
         pwm->OUTPUT = 0x00000000;
     }
 }
@@ -170,7 +179,10 @@ void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
     LPC_SCT0_Type* pwm = obj->pwm;
     if (us > 0) {
         pwm->MATCHREL1 = (uint32_t)(((uint64_t)SystemCoreClock * (uint64_t)us) / (uint64_t)1000000) - 1;
-        pwm->CTRL &= ~(1 << 2);
+        if (pwm->CTRL & (1 << 2)) {
+            pwm->MATCH1 = pwm->MATCHREL1;
+            pwm->CTRL &= ~(1 << 2);
+        }
     } else {
         pwm->CTRL |= (1 << 2) | (1 << 3);
         pwm->OUTPUT = 0x00000000;

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/pwmout_api.c
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC15XX/pwmout_api.c
@@ -118,11 +118,14 @@ void pwmout_write(pwmout_t* obj, float value) {
     uint32_t t_on = (uint32_t)((float)(pwm->MATCHREL0 + 1) * value);
     if (t_on > 0) {
         pwm->MATCHREL1 = t_on - 1;
+        
+        // Un-halt the timer and ensure the new pulse-width takes immediate effect if necessary
         if (pwm->CTRL & (1 << 2)) {
             pwm->MATCH1 = pwm->MATCHREL1;
             pwm->CTRL &= ~(1 << 2);
         }
     } else {
+        // Halt the timer and force the output low
         pwm->CTRL |= (1 << 2) | (1 << 3);
         pwm->OUTPUT = 0x00000000;
     }
@@ -155,15 +158,20 @@ void pwmout_period_us(pwmout_t* obj, int us) {
     pwm->MATCHREL0 = period_ticks - 1;
     if (pulsewidth_ticks > 0) {
         pwm->MATCHREL1 = pulsewidth_ticks - 1;
+        
+        // Un-halt the timer and ensure the new period & pulse-width take immediate effect if necessary
         if (pwm->CTRL & (1 << 2)) {
             pwm->MATCH0 = pwm->MATCHREL0;
             pwm->MATCH1 = pwm->MATCHREL1;
             pwm->CTRL &= ~(1 << 2);
         }
     } else {
+        // Halt the timer and force the output low
         pwm->CTRL |= (1 << 2) | (1 << 3);
-        pwm->MATCH0 = pwm->MATCHREL0;
         pwm->OUTPUT = 0x00000000;
+        
+        // Ensure the new period will take immediate effect when the timer is un-halted
+        pwm->MATCH0 = pwm->MATCHREL0;
     }
 }
 
@@ -179,11 +187,14 @@ void pwmout_pulsewidth_us(pwmout_t* obj, int us) {
     LPC_SCT0_Type* pwm = obj->pwm;
     if (us > 0) {
         pwm->MATCHREL1 = (uint32_t)(((uint64_t)SystemCoreClock * (uint64_t)us) / (uint64_t)1000000) - 1;
+        
+        // Un-halt the timer and ensure the new pulse-width takes immediate effect if necessary
         if (pwm->CTRL & (1 << 2)) {
             pwm->MATCH1 = pwm->MATCHREL1;
             pwm->CTRL &= ~(1 << 2);
         }
     } else {
+        // Halt the timer and force the output low
         pwm->CTRL |= (1 << 2) | (1 << 3);
         pwm->OUTPUT = 0x00000000;
     }


### PR DESCRIPTION
* 0% duty cycle now reads back correctly
* Period & pulse-width changes now take effect immediately if the timer is halted