### PR TITLE
Removing the appending of the method name to an RPC call

### DIFF
--- a/libraries/rpc/rpc.cpp
+++ b/libraries/rpc/rpc.cpp
@@ -148,7 +148,6 @@ bool RPC::call(const char *request, char *reply) {
             for (; cur_method->name != NULL; cur_method++) {
                 if (strcmp(cur_method->name, args.method_name) == 0) {
                     (cur_method->method_caller)(p, &args, &r);
-                    r.putData<const char*>(cur_method->name);
                     return true;
                 }
             }


### PR DESCRIPTION
The RPC call appended the method name to the output after the method
had already finished processing. It was unexpected for my use case,
and doesn't feel like the obvious thing to do.  This could be appended
in the RPC method itself, instead.

The adding of the method to the output was first commited in commit
556b889b5ff64126eb430aa8326e8bce0b451100.