### PR TITLE
LocalFileSystem fails to open binary files

### DIFF
--- a/libraries/mbed/common/retarget.cpp
+++ b/libraries/mbed/common/retarget.cpp
@@ -122,7 +122,7 @@ static inline int openmode_to_posix(int openmode) {
     if (openmode & _LLIO_APPEND) posix |= O_APPEND;
     if (openmode & _LLIO_TRUNC ) posix |= O_TRUNC;
 #endif
-    return posix;
+    return posix & ~O_BINARY;
 }
 
 extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {


### PR DESCRIPTION
Fixes issue #1562 reported by @justbuchanan.

When building code with GCC-ARM / newlib, attempting to use the
b (binary) mode in a fopen() call would fail. newlib would parse
this option and pass it down to the LocalFileSystem open call which
didn't like the unexpected O_BINARY flag in openmode.

The openmode_to_posix() function in retarget.cpp would never set the
O_BINARY flag for the other toolchains but for GCC it would just pass
down whatever newlib placed there.  This commit masks out the O_BINARY
bit so that it never gets passed down to the file system drivers, just
as occurs for the other supported toolchains.

Test case:
  FILE *fp = fopen("/local/out.txt", "rb");

I tested that code on mbed LPC1768 and LPC11U24 boards while using
GCC_ARM as the toolchain. It failed on both platforms previous to
this change and succeeded there after.