### PR TITLE
Increased allocated netbufs to handle DTLS handshakes

### DIFF
--- a/libraries/net/lwip/lwip/lwipopts.h
+++ b/libraries/net/lwip/lwip/lwipopts.h
@@ -51,7 +51,9 @@
 #define PBUF_POOL_SIZE              5
 #define MEMP_NUM_TCP_PCB_LISTEN     4
 #define MEMP_NUM_TCP_PCB            4
+#define MEMP_NUM_UDP_PCB            4
 #define MEMP_NUM_PBUF               8
+#define MEMP_NUM_NETBUF             8
 
 #define TCP_QUEUE_OOSEQ             0
 #define TCP_OVERSIZE                0


### PR DESCRIPTION
UDP based protocols such as DTLS may fragment large packets, resulting in many packets being sent at once. This can lead to significant/irrecoverable packet loss on systems that respond to packets slower than network transfers.

Increasing MEMP_NUM_NETBUF to 8 allows lwip to handle a DTLS handshake successfully and should be more robust for similar protocols.

DTLS handshake:
https://tools.ietf.org/html/rfc4347#section-4.2.3