### PR TITLE
[RTOS] Added idle hook API

### DIFF
--- a/libraries/rtos/rtos/Thread.cpp
+++ b/libraries/rtos/rtos/Thread.cpp
@@ -22,6 +22,7 @@
 #include "Thread.h"
 
 #include "mbed_error.h"
+#include "rtos_idle.h"
 
 namespace rtos {
 
@@ -130,6 +131,10 @@ osStatus Thread::yield() {
 
 osThreadId Thread::gettid() {
     return osThreadGetId();
+}
+
+void Thread::attach_idle_hook(void (*fptr)(void)) {
+    rtos_attach_idle_hook(fptr);
 }
 
 Thread::~Thread() {

--- a/libraries/rtos/rtos/Thread.h
+++ b/libraries/rtos/rtos/Thread.h
@@ -131,6 +131,11 @@ public:
       @return  thread ID for reference by other functions or NULL in case of error.
     */
     static osThreadId gettid();
+    
+    /** Attach a function to be called by the RTOS idle task
+      @param   fptr  pointer to the function to be called
+    */
+    static void attach_idle_hook(void (*fptr)(void));
 
     virtual ~Thread();
 

--- a/libraries/rtos/rtos/rtos_idle.c
+++ b/libraries/rtos/rtos/rtos_idle.c
@@ -1,0 +1,51 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2012 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#include "rtos_idle.h"
+
+static void default_idle_hook(void)
+{
+    /* Sleep: ideally, we should put the chip to sleep.
+     Unfortunately, this usually requires disconnecting the interface chip (debugger).
+     This can be done, but it would break the local file system.
+    */
+    // sleep();
+}
+static void (*idle_hook_fptr)(void) = &default_idle_hook;
+
+void rtos_attach_idle_hook(void (*fptr)(void))
+{
+    //Attach the specified idle hook, or the default idle hook in case of a NULL pointer
+    if (fptr != NULL) {
+        idle_hook_fptr = fptr;
+    } else {
+        idle_hook_fptr = default_idle_hook;
+    }
+}
+
+void rtos_idle_loop(void)
+{
+    //Continuously call the idle hook function pointer
+    while (1) {
+        idle_hook_fptr();
+    }
+}

--- a/libraries/rtos/rtos/rtos_idle.h
+++ b/libraries/rtos/rtos/rtos_idle.h
@@ -1,0 +1,39 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2012 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef RTOS_IDLE_H
+#define RTOS_IDLE_H
+
+#include <stddef.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+void rtos_attach_idle_hook(void (*fptr)(void));
+
+void rtos_idle_loop(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/libraries/rtos/rtos/rtos_idle.h
+++ b/libraries/rtos/rtos/rtos_idle.h
@@ -30,8 +30,6 @@ extern "C" {
 
 void rtos_attach_idle_hook(void (*fptr)(void));
 
-void rtos_idle_loop(void);
-
 #ifdef __cplusplus
 }
 #endif

--- a/libraries/rtos/rtx/TARGET_ARM7/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/TARGET_ARM7/RTX_Conf_CM.c
@@ -204,17 +204,12 @@
 /*----------------------------------------------------------------------------
  *      OS Idle daemon
  *---------------------------------------------------------------------------*/
-void os_idle_demon (void) {
-  /* The idle demon is a system thread, running when no other thread is      */
-  /* ready to run.                                                           */
+extern void rtos_idle_loop(void);
 
-  /* Sleep: ideally, we should put the chip to sleep.
-     Unfortunately, this usually requires disconnecting the interface chip (debugger).
-     This can be done, but it would break the local file system.
-  */
-  for (;;) {
-      // sleep();
-  }
+void os_idle_demon (void) {
+    /* The idle demon is a system thread, running when no other thread is      */
+    /* ready to run.                                                           */
+    rtos_idle_loop();
 }
 
 /*----------------------------------------------------------------------------

--- a/libraries/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -223,14 +223,12 @@
  *---------------------------------------------------------------------------*/
 
 /*--------------------------- os_idle_demon ---------------------------------*/
+extern void rtos_idle_loop(void);
 
 void os_idle_demon (void) {
   /* The idle demon is a system thread, running when no other thread is      */
   /* ready to run.                                                           */
-
-  for (;;) {
-    /* HERE: include optional user code to be executed when no thread runs.*/
-  }
+  rtos_idle_loop();
 }
 
 #if (OS_SYSTICK == 0)   // Functions for alternative timer as RTX kernel timer

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -305,17 +305,12 @@
 /*----------------------------------------------------------------------------
  *      OS Idle daemon
  *---------------------------------------------------------------------------*/
-void os_idle_demon (void) {
-  /* The idle demon is a system thread, running when no other thread is      */
-  /* ready to run.                                                           */
+extern void rtos_idle_loop(void);
 
-  /* Sleep: ideally, we should put the chip to sleep.
-     Unfortunately, this usually requires disconnecting the interface chip (debugger).
-     This can be done, but it would break the local file system.
-  */
-  for (;;) {
-      // sleep();
-  }
+void os_idle_demon (void) {
+    /* The idle demon is a system thread, running when no other thread is      */
+    /* ready to run.                                                           */
+    rtos_idle_loop();
 }
 
 /*----------------------------------------------------------------------------


### PR DESCRIPTION
Added a new API for attaching an idle hook to be executed by the idle task. This will allow developers to add custom logic to the idle task (e.g. to call `sleep()`) without modifying the library code.

_Updated version of #1463._