### PR TITLE
Fix issue #1599

### DIFF
--- a/libraries/mbed/common/retarget.cpp
+++ b/libraries/mbed/common/retarget.cpp
@@ -121,8 +121,10 @@ static inline int openmode_to_posix(int openmode) {
     if (openmode & _LLIO_CREAT ) posix |= O_CREAT;
     if (openmode & _LLIO_APPEND) posix |= O_APPEND;
     if (openmode & _LLIO_TRUNC ) posix |= O_TRUNC;
+#elif defined(TOOLCHAIN_GCC)
+    posix &= ~O_BINARY;
 #endif
-    return posix & ~O_BINARY;
+    return posix;
 }
 
 extern "C" FILEHANDLE PREFIX(_open)(const char* name, int openmode) {


### PR DESCRIPTION
My previous commit, c6d2c81, broke Keil builds and maybe even IAR.

I need to learn how to read C code :)  I thought I was masking off the
O_BINARY bit only for GCC builds but it turns out that my update was
in the fall-through case for all toolchains.  This commit now places
the O_BINARY masking operation into a GCC specific #ifdef clause.

Testing:
I tested the same fopen("/local/out.txt","rb") code as before but this
time I built it with the online compiler and GCC_ARM. I tested the
resulting binaries on mbed-LPC11U24 and mbed-LPC1768 boards.

Thanks to @neilt6 for catching & reporting this!