### PR TITLE
Change the uart pin to DIP pin for XBED_LPC1768

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_XBED_LPC1768/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_XBED_LPC1768/PinNames.h
@@ -72,8 +72,9 @@ typedef enum {
     LED3 = P1_21,
     LED4 = P1_23,
 
-    USBTX = P0_2,
-    USBRX = P0_3,
+    //For USB UART
+    //USBTX = P0_2,
+    //USBRX = P0_3,
 
 	//xbed lpc1768 Pin Names
 	LED5 = P2_6,
@@ -82,7 +83,8 @@ typedef enum {
 	SCL = P0_28,
 	ISP = P2_10,
 	CLK = P1_27,
-
+    USBTX = P2_0, //DIP26
+    USBRX = P2_1, //DIP25
 
 
     // Arch Pro Pin Names

--- a/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_XBED_LPC1768/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/TARGET_XBED_LPC1768/PinNames.h
@@ -77,12 +77,12 @@ typedef enum {
     //USBRX = P0_3,
 
 	//xbed lpc1768 Pin Names
-	LED5 = P2_6,
-	BTN1 = P2_8,
-	SDA = P0_27,
-	SCL = P0_28,
-	ISP = P2_10,
-	CLK = P1_27,
+    LED5 = P2_6,
+    BTN1 = P2_8,
+    SDA = P0_27,
+    SCL = P0_28,
+    ISP = P2_10,
+    CLK = P1_27,
     USBTX = P2_0, //DIP26
     USBRX = P2_1, //DIP25
 


### PR DESCRIPTION
The platform XBED_LPC1768 doesn't have mbed interface. It needs the DIPDAP as interface for automaticed testing, using DIP25 and DIP26 as UART RX/TX.