### PR TITLE
Fix IRQ enabled in serial_irq_set()

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -748,7 +748,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             NVIC_EnableIRQ(irq_n);
 #endif
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(handle, UART_IT_TC);
+            __HAL_UART_ENABLE_IT(handle, UART_IT_TXE);
             NVIC_SetVector(irq_n, vector);
             NVIC_EnableIRQ(irq_n);
 #if DEVICE_SERIAL_ASYNCH_DMA


### PR DESCRIPTION
This is resolution of #1586
 UART_IT_TC was enabled instead of UART_IT_TXE
 This was causing an issue because UART_IT_TXE (and not UART_IT_TC) was disabled  by same function.
  Consequently if a transfer was ongoing when serial_irq_set() was called to disable IRQ, UART_IT_TC would still trigger (once).
 Side effect is maybe speed: I guess using UART_IT_TC prevented implementation of continuous transfer.
 This commit is focused on solving an issue observed with TARGET_STM32F4. It doesn't presume it should or shouldn't be done for other targets.