### PR TITLE
[STM32F7] Allow IAR compilation

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -846,7 +846,7 @@ class NUCLEO_F746ZG(Target):
         Target.__init__(self)
         self.core = "Cortex-M7F"
         self.extra_labels = ['STM', 'STM32F7', 'STM32F746', 'STM32F746ZG']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
         self.detect_code = ["0816"]
         self.progen = {
             "target":"nucleo-f746zg",
@@ -1023,7 +1023,7 @@ class DISCO_F746NG(Target):
         Target.__init__(self)
         self.core = "Cortex-M7F"
         self.extra_labels = ['STM', 'STM32F7', 'STM32F746', 'STM32F746NG']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
+        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
         self.detect_code = ["0815"]
         self.progen = {
             "target":"disco-f746ng",

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -851,7 +851,7 @@ class NUCLEO_F746ZG(Target):
         self.progen = {
             "target":"nucleo-f746zg",
             "iar": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'iar_nucleo_f746cg.ewp.tmpl')],
+                "template": [os.path.join(os.path.dirname(__file__), 'export', 'iar_nucleo_f746zg.ewp.tmpl')],
             }
         }
 

--- a/workspace_tools/toolchains/iar.py
+++ b/workspace_tools/toolchains/iar.py
@@ -32,9 +32,12 @@ class IAR(mbedToolchain):
 
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
         mbedToolchain.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
-
+        if target.core == "Cortex-M7F":
+			cpuchoice = "Cortex-M7"
+        else:
+			cpuchoice = target.core
         c_flags = [
-            "--cpu=%s" % target.core, "--thumb",
+            "--cpu=%s" % cpuchoice, "--thumb",
             "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h"),
             "-e", # Enable IAR language extension
             "--no_wrap_diagnostics",
@@ -45,6 +48,10 @@ class IAR(mbedToolchain):
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082",
         ]
 
+        if target.core == "Cortex-M7F":
+            c_flags.append("--fpu=VFPv5_sp")
+                
+
         if "debug-info" in self.options:
             c_flags.append("-r")
             c_flags.append("-On")
@@ -53,7 +60,7 @@ class IAR(mbedToolchain):
 
         IAR_BIN = join(IAR_PATH, "bin")
         main_cc = join(IAR_BIN, "iccarm")
-        self.asm  = [join(IAR_BIN, "iasmarm")] + ["--cpu", target.core]
+        self.asm  = [join(IAR_BIN, "iasmarm")] + ["--cpu", cpuchoice]
         if not "analyze" in self.options:
             self.cc   = [main_cc] + c_flags
             self.cppc = [main_cc, "--c++",  "--no_rtti", "--no_exceptions"] + c_flags

--- a/workspace_tools/toolchains/iar.py
+++ b/workspace_tools/toolchains/iar.py
@@ -33,9 +33,9 @@ class IAR(mbedToolchain):
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
         mbedToolchain.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
         if target.core == "Cortex-M7F":
-			cpuchoice = "Cortex-M7"
+            cpuchoice = "Cortex-M7"
         else:
-			cpuchoice = target.core
+            cpuchoice = target.core
         c_flags = [
             "--cpu=%s" % cpuchoice, "--thumb",
             "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h"),


### PR DESCRIPTION
**targets.py** : add IAR for NUCLEO_F746ZG and DISCO_F746NG

**iar.py:** in case of Cortex-M7F, change it into Cortex-M7 and add --fpu VFPv5_sp
I have been confirmed that for Cortex-M4F we don't need to add the --fpu VFPv4_sp


**test results**
                     DTCT_1 EXAMPLE_1 MBED_10 MBED_11 MBED_12 MBED_16        MBED_2  MBED_23 MBED_24 MBED_25 MBED_26 MBED_34 MBED_37 MBED_38 MBED_A1 MBED_A21 MBED_A9 MBED_BUSOUT RTOS_1        RTOS_2        RTOS_3        RTOS_4        RTOS_5        RTOS_6        RTOS_7       RTOS_8 
ARM DISCO_F746NG     OK     OK        OK      OK      OK      NOT_SUPPORTED  OK      OK      OK      OK      OK      OK      OK      OK      OK      OK       OK      OK          OK            OK            OK            OK            OK            OK            OK           OK
GCC_ARM DISCO_F746NG OK     OK        OK      OK      OK      NOT_SUPPORTED  OK      OK      OK      OK      OK      OK      OK      OK      OK      OK       OK      OK          OK            OK            OK            OK            TIMEOUT       TIMEOUT       OK           OK
IAR DISCO_F746NG     OK     OK        OK      OK      OK      NOT_SUPPORTED  OK      OK      OK      OK      OK      OK      OK      OK      OK      OK       OK      OK          BUILD_FAILED  BUILD_FAILED  BUILD_FAILED  BUILD_FAILED  BUILD_FAILED  BUILD_FAILED  BUILD_FAILED BUILD_FAILED
uARM DISCO_F746NG    OK     OK        OK      OK      OK      NOT_SUPPORTED  OK      OK      OK      OK      OK      OK      OK      OK      OK      OK       OK      OK          OK            OK            TIMEOUT       OK            OK            OK            OK           OK


RTOS tests don't compile for IAR toolchain. I suggest that we investigate this separately.