### PR TITLE
avoid getting stuck in serial IRQ if ORE is set without RXNE

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -451,6 +451,9 @@ static void uart_irq(int id)
             irq_handler(serial_irq_ids[id], RxIrq);
             __HAL_UART_CLEAR_FLAG(handle, UART_FLAG_RXNE);
         }
+        if (__HAL_UART_GET_FLAG(handle, UART_FLAG_ORE) != RESET) {
+            uint8_t c = handle->Instance->DR;
+        }
     }
 }
 


### PR DESCRIPTION
Fixes #1605 
Applications may encounter situations where UARTx->SR & ORE is true but UARTx->SR & RXNE is not true. If this occurs when a RX interrupt handler is attached, the device will get stuck in a loop executing the serial irq handler. This is because the ORE flag can trigger the RXNE interrupt as well as the RXNE flag.