### PR TITLE
[STM32F4] Add DEVICE_RTC_LSI=0 to all targets

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/device.h
@@ -52,6 +52,7 @@
 #define DEVICE_SPI_ASYNCH       0
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              0 // MAMM Not present on this module 1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 


### PR DESCRIPTION
Added for clarity.
This flag must be set to 1 if the LSE xtal is not
present on the board or if the RTC must be clocked by the device internal clock.

Continuation of PR #1548 and #1558