### PR TITLE
add hard fault handlers for MultiTech mDot and Dragonfly platforms

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/system_stm32f4xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/system_stm32f4xx.c
@@ -693,6 +693,15 @@ uint8_t SetSysClock_PLL_HSI(void)
   return 1; // OK
 }
 
+/******************************************************************************/
+/*            Hard Fault Handler                                              */
+/******************************************************************************/
+void HardFault_Handler(void)
+{
+  printf("Hard Fault\n");
+  NVIC_SystemReset();
+}
+
 /**
   * @}
   */

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/system_stm32f4xx.c
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/system_stm32f4xx.c
@@ -694,6 +694,15 @@ uint8_t SetSysClock_PLL_HSI(void)
   return 1; // OK
 }
 
+/******************************************************************************/
+/*            Hard Fault Handler                                              */
+/******************************************************************************/
+void HardFault_Handler(void)
+{
+  printf("Hard Fault\n");
+  NVIC_SystemReset();
+}
+
 /**
   * @}
   */


### PR DESCRIPTION
Since MTS products can be deployed and are expected to stay up and running indefinitely, reset the device if a fault is encountered instead of sitting in a while(1); loop.