### PR TITLE
uvision exporter - fix - asm does not like string defined macros

### DIFF
--- a/workspace_tools/export/uvision4.py
+++ b/workspace_tools/export/uvision4.py
@@ -62,13 +62,15 @@ class Uvision4(Exporter):
 
         project_data['tool_specific'] = {}
         project_data['tool_specific'].update(tool_specific)
-        # armasm does not like floating numbers in macros, timestamp to int
         i = 0
         for macro in project_data['common']['macros']:
+            # armasm does not like floating numbers in macros, timestamp to int
             if macro.startswith('MBED_BUILD_TIMESTAMP'):
                 timestamp = macro[len('MBED_BUILD_TIMESTAMP='):]
                 project_data['common']['macros'][i] = 'MBED_BUILD_TIMESTAMP=' + str(int(float(timestamp)))
-                break
+            # armasm does not even accept MACRO=string
+            if macro.startswith('MBED_USERNAME'):
+                project_data['common']['macros'].pop(i)
             i += 1
         project_data['common']['macros'].append('__ASSERT_MSG')
         self.progen_gen_file('uvision', project_data)


### PR DESCRIPTION
Tested with RTOS_1 example which failed with strange error which pinpointed that something with ``MBED_USERNAME=``

I'll try to get some answers for this asm macros behavior for uvision4.