### PR TITLE
[STM32F4 STM32F7] Overwrite HAL_Delay to allow SD example

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
@@ -26,6 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cmsis.h"
+extern void wait_ms(int ms);
 
 // This function is called after RAM initialization and before main.
 void mbed_sdk_init()
@@ -34,4 +35,20 @@ void mbed_sdk_init()
     SystemCoreClockUpdate();
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
+}
+
+/**
+  * @brief This function provides accurate delay (in milliseconds) based 
+  *        on variable incremented.
+  * @note In the default implementation , SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals where uwTick
+  *       is incremented.
+  * @note This function is the modified version of the __weak version contained in 
+  *       stm32f4xx_hal.c
+  * @param Delay: specifies the delay time length, in milliseconds.
+  * @retval None
+  */
+void HAL_Delay(__IO uint32_t Delay)
+{
+    wait_ms((int)Delay);
 }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/mbed_overrides.c
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cmsis.h"
-extern void wait_ms(int ms);
+#include "us_ticker_api.h"
 
 // This function is called after RAM initialization and before main.
 void mbed_sdk_init()
@@ -38,17 +38,16 @@ void mbed_sdk_init()
 }
 
 /**
-  * @brief This function provides accurate delay (in milliseconds) based 
+  * @brief This function provides accurate delay (in milliseconds) based
   *        on variable incremented.
-  * @note In the default implementation , SysTick timer is the source of time base.
-  *       It is used to generate interrupts at regular time intervals where uwTick
-  *       is incremented.
-  * @note This function is the modified version of the __weak version contained in 
-  *       stm32f4xx_hal.c
+  * @note This function is the modified version of the __weak version contained in
+  *       stm32f4xx_hal.c, using us_ticker
   * @param Delay: specifies the delay time length, in milliseconds.
   * @retval None
   */
 void HAL_Delay(__IO uint32_t Delay)
 {
-    wait_ms((int)Delay);
+    uint32_t start = us_ticker_read();
+    while ((us_ticker_read() - start) < (uint32_t)(Delay * 1000));
 }
+

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
@@ -26,6 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cmsis.h"
+extern void wait_ms(int ms);
 
 HAL_StatusTypeDef HAL_Init(void);
 
@@ -37,3 +38,20 @@ void mbed_sdk_init()
     // Need to restart HAL driver after the RAM is initialized
     HAL_Init();
 }
+
+/**
+  * @brief This function provides accurate delay (in milliseconds) based 
+  *        on variable incremented.
+  * @note In the default implementation , SysTick timer is the source of time base.
+  *       It is used to generate interrupts at regular time intervals where uwTick
+  *       is incremented.
+  * @note This function is the modified version of the __weak version contained in 
+  *       stm32f7xx_hal.c
+  * @param Delay: specifies the delay time length, in milliseconds.
+  * @retval None
+  */
+void HAL_Delay(__IO uint32_t Delay)
+{
+    wait_ms((int)Delay);
+}
+

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F7/mbed_overrides.c
@@ -26,7 +26,7 @@
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  */
 #include "cmsis.h"
-extern void wait_ms(int ms);
+#include "us_ticker_api.h"
 
 HAL_StatusTypeDef HAL_Init(void);
 
@@ -39,19 +39,18 @@ void mbed_sdk_init()
     HAL_Init();
 }
 
+
 /**
-  * @brief This function provides accurate delay (in milliseconds) based 
+  * @brief This function provides accurate delay (in milliseconds) based
   *        on variable incremented.
-  * @note In the default implementation , SysTick timer is the source of time base.
-  *       It is used to generate interrupts at regular time intervals where uwTick
-  *       is incremented.
-  * @note This function is the modified version of the __weak version contained in 
-  *       stm32f7xx_hal.c
+  * @note This function is the modified version of the __weak version contained in
+  *       stm32f7xx_hal.c, using us_ticker
   * @param Delay: specifies the delay time length, in milliseconds.
   * @retval None
-  */
+*/
 void HAL_Delay(__IO uint32_t Delay)
 {
-    wait_ms((int)Delay);
+    uint32_t start = us_ticker_read();
+    while ((us_ticker_read() - start) < (uint32_t)(Delay * 1000));
 }
 


### PR DESCRIPTION
The weak function HAL_Delay is overwritten to use mbed function
'wait_ms'.
Thanks to this, the user can use stm32f[4/7]xx_hal_sd.c that calls
HAL_Delay
This will allow us to add an example detecting / writing / reading an SD
card on DISCO_F469NI and DISCO_F746NG

(cherry picked from commit d491e3cd8b1d973793e6168a5037a812eadea961)