### PR TITLE
Make Nucleo F303K8 number of interrupts consistent with amount of SRAM allocated

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/cmsis_nvic.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/cmsis_nvic.h
@@ -32,11 +32,7 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
-// STM32F303RE
-// CORE: 16 vectors = 64 bytes from 0x00 to 0x3F
-// MCU Peripherals: 85 vectors = 340 bytes from 0x40 to 0x193
-// Total: 101 vectors = 404 bytes (0x194) to be reserved in RAM
-#define NVIC_NUM_VECTORS      101
+#define NVIC_NUM_VECTORS      98
 #define NVIC_USER_IRQ_OFFSET  16
 
 #include "cmsis.h"


### PR DESCRIPTION
Fix for #1631 

The linker scripts allocate 0x188 bytes of SRAM, but for 101 vectors, it really needs 0x194 bytes. This causes the NVIC initialization to clobber the beginning the the data section, leading to all kinds of fun like the heap pointer getting clobbered and crashing when attempting to create a Serial object.

I'm not convinced that 98 vectors is actually correct, but it seems consistently used in all the F303K8 linker scripts. And it allows Serial to initialize properly as well, too.
The STM32F3 reference (http://www.st.com/web/en/resource/technical/document/programming_manual/DM00046982.pdf section 4.3) says the NVIC supports up to 81 interrupts.
The STM32F303X6/8 reference (http://www.st.com/st-web-ui/static/active/en/resource/technical/document/datasheet/DM00092070.pdf section 3.9) says its NVIC supports 60 interrupt channels.
Some documentation also mentions 16 core interrupts separate from the NVIC.
In any case, 98 vectors may be more than actually necessary, but it shouldn't cause errors.

So if the chip actually needs less than 98 interrupt vectors, there's more optimization possible to save some SRAM. But that seems like a much larger clean-up effort, since it's also unclear where the interrupt vector numbers for some of the other chips like the F303RE are coming from (whose code says it has 16 core vectors + 85 peripheral vectors, while the datasheet only mentions 73 masked interrupt channels under the NVIC).