### PR TITLE
Add Nucleo F303K8 pin parsing for RPC

### DIFF
--- a/libraries/rpc/parse_pins.cpp
+++ b/libraries/rpc/parse_pins.cpp
@@ -59,7 +59,7 @@ PinName parse_pins(const char *str) {
         }
         return port_pin((PortName)port, pin);
 
-#elif defined(TARGET_NUCLEO_F072RB) || defined(TARGET_NUCLEO_F411RE)
+#elif defined(TARGET_NUCLEO_F072RB) || defined(TARGET_NUCLEO_F303K8) || defined(TARGET_NUCLEO_F411RE)
     if (str[0] == 'P') {   // PX_XX e.g.PA_2 PC_15
         uint32_t port = str[1] - 'A';
         uint32_t pin  = str[3] - '0';       


### PR DESCRIPTION
RPC won't compile otherwise. Pin naming format seems consistent with the other Nucleo targets, and `/DigitalOut/new ...` works on my board.