### PR TITLE
[XXX_F4XX] remove erasing of BkUpR in RTC API

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/stm32l1xx_hal_conf.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/stm32l1xx_hal_conf.h
@@ -122,7 +122,7 @@
 
    
 #if !defined  (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for LSE start up, in ms */
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
    

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/stm32l1xx_hal_conf.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/stm32l1xx_hal_conf.h
@@ -122,7 +122,7 @@
 
    
 #if !defined  (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for LSE start up, in ms */
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
    

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/stm32l1xx_hal_conf.h
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/stm32l1xx_hal_conf.h
@@ -122,7 +122,7 @@
 
    
 #if !defined  (LSE_STARTUP_TIMEOUT)
-  #define LSE_STARTUP_TIMEOUT    ((uint32_t)100)   /*!< Time out for LSE start up, in ms */
+  #define LSE_STARTUP_TIMEOUT    ((uint32_t)5000)   /*!< Time out for LSE start up, in ms */
 #endif /* HSE_STARTUP_TIMEOUT */
 
    

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
@@ -50,16 +50,6 @@ void rtc_init(void)
 
     RtcHandle.Instance = RTC;
 
-    // Enable Power clock
-    __PWR_CLK_ENABLE();
-
-    // Enable access to Backup domain
-    HAL_PWR_EnableBkUpAccess();
-
-    // Reset Backup domain
-    __HAL_RCC_BACKUPRESET_FORCE();
-    __HAL_RCC_BACKUPRESET_RELEASE();
-
 #if !DEVICE_RTC_LSI
     // Enable LSE Oscillator
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
@@ -75,19 +65,29 @@ void rtc_init(void)
       error("RTC error: LSE clock initialization failed.");
     }
 #else
-        // Enable LSI clock
-        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
-        RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
-        RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
-        RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
-        if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
-            error("RTC error: LSI clock initialization failed.");
-        }
-        // Connect LSI to RTC
-        __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSI);
-        __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
-        // [TODO] This value is LSI typical value. To be measured precisely using a timer input capture
-        rtc_freq = LSI_VALUE;
+    // Enable Power clock
+    __PWR_CLK_ENABLE();
+
+    // Enable access to Backup domain
+    HAL_PWR_EnableBkUpAccess();
+
+    // Reset Backup domain
+    __HAL_RCC_BACKUPRESET_FORCE();
+    __HAL_RCC_BACKUPRESET_RELEASE();	
+
+	// Enable LSI clock
+	RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
+	RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
+	RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
+	RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
+	if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+		error("RTC error: LSI clock initialization failed.");
+	}
+	// Connect LSI to RTC
+	__HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSI);
+	__HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
+	// [TODO] This value is LSI typical value. To be measured precisely using a timer input capture
+	rtc_freq = LSI_VALUE;
 #endif    
 
     // Enable RTC
@@ -107,6 +107,7 @@ void rtc_init(void)
 
 void rtc_free(void)
 {
+#if DEVICE_RTC_LSI
     // Enable Power clock
     __PWR_CLK_ENABLE();
 
@@ -119,6 +120,7 @@ void rtc_free(void)
 
     // Disable access to Backup domain
     HAL_PWR_DisableBkUpAccess();
+#endif
 
     // Disable LSI and LSE clocks
     RCC_OscInitTypeDef RCC_OscInitStruct;

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          1
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/device.h
@@ -48,6 +48,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          0
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/device.h
@@ -57,6 +57,7 @@
 #define DEVICE_SPISLAVE         1
 
 #define DEVICE_RTC              1
+#define DEVICE_RTC_LSI          1
 
 #define DEVICE_PWMOUT           1
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L1/rtc_api.c
@@ -33,7 +33,9 @@
 
 #include "mbed_error.h"
 
+#if DEVICE_RTC_LSI
 static int rtc_inited = 0;
+#endif
 
 RTC_HandleTypeDef RtcHandle;
 
@@ -42,8 +44,10 @@ void rtc_init(void)
     RCC_OscInitTypeDef RCC_OscInitStruct;
     uint32_t rtc_freq = 0;
 
+#if DEVICE_RTC_LSI
     if (rtc_inited) return;
     rtc_inited = 1;
+#endif
 
     RtcHandle.Instance = RTC;
 
@@ -57,33 +61,35 @@ void rtc_init(void)
     __HAL_RCC_BACKUPRESET_FORCE();
     __HAL_RCC_BACKUPRESET_RELEASE();
 
+#if !DEVICE_RTC_LSI
     // Enable LSE Oscillator
-    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
+    RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
     RCC_OscInitStruct.LSEState       = RCC_LSE_ON; // External 32.768 kHz clock on OSC_IN/OSC_OUT
-    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {
+    RCC_OscInitStruct.LSIState       = RCC_LSI_OFF;
+    if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) { // Check if LSE has started correctly
         // Connect LSE to RTC
         __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSE);
         __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSE);
         rtc_freq = LSE_VALUE;
     } else {
-        // Enable LSI clock
-        RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
-        RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
-        RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
-        RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
-        if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
-            error("RTC error: LSI clock initialization failed.");
-        }
-        // Connect LSI to RTC
-        __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSI);
-        __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
-        // This value is LSI typical value. To be measured precisely using a timer input capture for example.
-        rtc_freq = 40000;
+	    error("Cannot initialize RTC with LSE\n");
     }
-
-    // Check if RTC is already initialized
-    if ((RTC->ISR & RTC_ISR_INITS) ==  RTC_ISR_INITS) return;
+#else	
+	// Enable LSI clock
+	RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
+	RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
+	RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
+	RCC_OscInitStruct.LSIState       = RCC_LSI_ON;
+	if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
+		error("Cannot initialize RTC with LSI\n");
+	}
+	// Connect LSI to RTC
+    __HAL_RCC_RTC_CLKPRESCALER(RCC_RTCCLKSOURCE_LSI);
+    __HAL_RCC_RTC_CONFIG(RCC_RTCCLKSOURCE_LSI);
+	// This value is LSI typical value. To be measured precisely using a timer input capture for example.
+	rtc_freq = 40000;
+#endif
 
     // Enable RTC
     __HAL_RCC_RTC_ENABLE();
@@ -129,12 +135,22 @@ void rtc_free(void)
     RCC_OscInitStruct.LSEState       = RCC_LSE_OFF;
     HAL_RCC_OscConfig(&RCC_OscInitStruct);
 
+#if DEVICE_RTC_LSI
     rtc_inited = 0;
+#endif
 }
 
 int rtc_isenabled(void)
 {
-    return rtc_inited;
+#if DEVICE_RTC_LSI
+  return rtc_inited;
+#else
+  if ((RTC->ISR & RTC_ISR_INITS) ==  RTC_ISR_INITS) {
+    return 1;
+  } else {
+    return 0;
+  }
+#endif
 }
 
 /*


### PR DESCRIPTION
the erasing of back up registers is only needed when using LSI in RTC API