### PR TITLE
Prevent recursive processing of us_ticker in FSL

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/us_ticker.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/us_ticker.c
@@ -68,8 +68,11 @@ void us_ticker_clear_interrupt(void) {
 void us_ticker_set_interrupt(timestamp_t timestamp) {
     int delta = (int)(timestamp - us_ticker_read());
     if (delta <= 0) {
-        // This event was in the past:
-        us_ticker_irq_handler();
+        // This event was in the past.
+        // Set the interrupt as pending, but don't process it here.
+        // This prevents a recurive loop under heavy load
+        // which can lead to a stack overflow.
+        NVIC_SetPendingIRQ(PIT3_IRQn);
         return;
     }
  


### PR DESCRIPTION
When a ticker is scheduled to run so fast that it is pending again
before the previous event has been processed then this next event
is processed (recursively) by calling into us_ticker_irq_handle().
This can lead to a stack overflow.

This patch prevents this recursion by replacing the call to
us_ticker_irq_handler() with a call to set the interrupt to pending
again.  This allows the next timer event to be processed without
making the stack deeper.