### PR TITLE
[XXX_L0X3XX] Move erasing of BkUpR in RTC API

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/rtc_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/rtc_api.c
@@ -51,16 +51,6 @@ void rtc_init(void)
 
     RtcHandle.Instance = RTC;
 
-    // Enable Power clock
-    __PWR_CLK_ENABLE();
-
-    // Enable access to Backup domain
-    HAL_PWR_EnableBkUpAccess();
-
-    // Reset Backup domain
-    __HAL_RCC_BACKUPRESET_FORCE();
-    __HAL_RCC_BACKUPRESET_RELEASE();
-
 #if !DEVICE_RTC_LSI
     // Enable LSE Oscillator
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
@@ -75,6 +65,16 @@ void rtc_init(void)
         error("Cannot initialize RTC with LSE\n");
     }
 #else
+    // Enable Power clock
+    __PWR_CLK_ENABLE();
+
+    // Enable access to Backup domain
+    HAL_PWR_EnableBkUpAccess();
+
+    // Reset Backup domain
+    __HAL_RCC_BACKUPRESET_FORCE();
+    __HAL_RCC_BACKUPRESET_RELEASE();
+
     // Enable LSI clock
     RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSI | RCC_OSCILLATORTYPE_LSE;
     RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE; // Mandatory, otherwise the PLL is reconfigured!
@@ -107,6 +107,7 @@ void rtc_init(void)
 
 void rtc_free(void)
 {
+#if DEVICE_RTC_LSI
     // Enable Power clock
     __PWR_CLK_ENABLE();
 
@@ -119,6 +120,7 @@ void rtc_free(void)
 
     // Disable access to Backup domain
     HAL_PWR_DisableBkUpAccess();
+#endif
 
     // Disable LSI and LSE clocks
     RCC_OscInitTypeDef RCC_OscInitStruct;


### PR DESCRIPTION
The erasing of back up register is needed only when using LSI in RTC API