### PR TITLE
pyYAML is req for exporters

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,3 +7,4 @@ mbed-ls
 project-generator>=0.8.11,<0.9.0
 junit-xml
 requests
+pyYAML

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ setup(name='mbed-tools',
       url='https://github.com/mbedmicro/mbed',
       packages=find_packages(),
       license=LICENSE,
-      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3", "colorama>=0.3.3", "Jinja2>=2.7.3", "project-generator>=0.8.11,<0.9.0", "junit-xml", "requests"])
+      install_requires=["PrettyTable>=0.7.2", "PySerial>=2.7", "IntelHex>=1.3", "colorama>=0.3.3", "Jinja2>=2.7.3", "project-generator>=0.8.11,<0.9.0", "junit-xml", "requests", "pyYAML"])
 
 # Restore previous private_settings if needed
 if backup:


### PR DESCRIPTION
add pyYAML as dependency, exporters require it. Should be part of the earlier PR (#1636)

@bridadan