### PR TITLE
Call serial_free when Serial object is destroyed

### DIFF
--- a/libraries/mbed/api/SerialBase.h
+++ b/libraries/mbed/api/SerialBase.h
@@ -196,8 +196,7 @@ protected:
 
 protected:
     SerialBase(PinName tx, PinName rx);
-    virtual ~SerialBase() {
-    }
+    virtual ~SerialBase();
 
     int _base_getc();
     int _base_putc(int c);

--- a/libraries/mbed/common/SerialBase.cpp
+++ b/libraries/mbed/common/SerialBase.cpp
@@ -30,6 +30,10 @@ SerialBase::SerialBase(PinName tx, PinName rx) :
     serial_irq_handler(&_serial, SerialBase::_irq_handler, (uint32_t)this);
 }
 
+SerialBase::~SerialBase() {
+    serial_free(&_serial);
+}
+
 void SerialBase::baud(int baudrate) {
     serial_baud(&_serial, baudrate);
     _baud = baudrate;


### PR DESCRIPTION
Make this change so that the serial_free() function is called when the Serial object is destroyed.

Signed-off-by: Mahadevan Mahesh <Mahesh.Mahadevan@nxp.com>