### PR TITLE
uvision - add --diag_suppress=1

### DIFF
--- a/workspace_tools/export/uvision.uvproj.tmpl
+++ b/workspace_tools/export/uvision.uvproj.tmpl
@@ -347,7 +347,7 @@
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <VariousControls>
-              <MiscControls>--gnu --no_rtti</MiscControls>
+              <MiscControls>--gnu --no_rtti --diag_suppress=1</MiscControls>
               <Define> </Define>
               <Undefine></Undefine>
               <IncludePath>  </IncludePath>

--- a/workspace_tools/export/uvision_microlib.uvproj.tmpl
+++ b/workspace_tools/export/uvision_microlib.uvproj.tmpl
@@ -347,7 +347,7 @@
             <uSurpInc>0</uSurpInc>
             <uC99>1</uC99>
             <VariousControls>
-              <MiscControls>--gnu --no_rtti</MiscControls>
+              <MiscControls>--gnu --no_rtti --diag_suppress=1</MiscControls>
               <Define></Define>
               <Undefine></Undefine>
               <IncludePath>  .;  env;  mbed;  </IncludePath>


### PR DESCRIPTION
Suppress warning - end of the file without a new line. This is not
reported by the online compiler, and causes 700 warnings for some
code within mbed SDK.

For instance for BLE, over 700 warnings are issued. This does not fix the problem, but at least does not annoy users. We can create an issue to add new lines to our current code base, and enforce this in the online IDE. This is common warning, and many editors put newline automatically.

@sg- @bridadan 