### PR TITLE
Fix incorrect pin in PinMap_UART_RX - issue mbedmicro/mbed#1657

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralPins.c
+++ b/libraries/mbed/targets/hal/TARGET_Freescale/TARGET_KPSDK_MCUS/TARGET_MCU_K64F/TARGET_FRDM/PeripheralPins.c
@@ -108,7 +108,7 @@ const PinMap PinMap_UART_RX[] = {
     {PTC3 , UART_1, 3},
     {PTC14, UART_4, 3},
     {PTD2 , UART_2, 3},
-    {PTC6 , UART_0, 3},
+    {PTD6 , UART_0, 3},
     {NC  ,  NC    , 0}
 };
 


### PR DESCRIPTION
PTC6 was wrong, should be PTD6