### PR TITLE
[DISCO_F429ZI] Add target name for progen

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -1082,7 +1082,7 @@ class DISCO_F429ZI(Target):
         self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
         self.default_toolchain = "uARM"
         self.progen = {
-            "target":"",
+            "target":"disco-f429zi",
         }
 
 class DISCO_F469NI(Target):


### PR DESCRIPTION
There is missing the exporters for Keil and IAR. I hope that will solve this issue. Otherwise tell me what is missing.