### PR TITLE
[ARM_MPS2_M7] Fix capital letter filename

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M7/CMSDK_CM7.h
+++ b/libraries/mbed/targets/cmsis/TARGET_ARM_SSG/TARGET_MPS2_M7/CMSDK_CM7.h
@@ -109,7 +109,7 @@ typedef enum IRQn
 #define __ICACHE_PRESENT          1
 #define __DCACHE_PRESENT          1
 
-#include "core_CM7.h"                         /* Processor and core peripherals                  */
+#include "core_cm7.h"                         /* Processor and core peripherals                  */
 #include "system_CMSDK_CM7.h"                 /* System Header                                   */
 
 


### PR DESCRIPTION
In online compiler (developer.mbed.org) generated following error when build target is ARM_MPS2_M7.
```
Error: Cannot open source input file "core_CM7.h": No such file or directory in "extras/mbed_082adc85693f/TARGET_ARM_MPS2_M7/CMSDK_CM7.h", Line: 112, Col: 101
```

This was because CMSDK_CM7.h included "core_CM7.h" and this should be "core_cm7.h".
This is now fixed.