### PR TITLE
uvision - get_toolchain method regression fix

### DIFF
--- a/workspace_tools/export/uvision4.py
+++ b/workspace_tools/export/uvision4.py
@@ -44,6 +44,8 @@ class Uvision4(Exporter):
             # target is not supported yet
             continue
 
+    def get_toolchain(self):
+        return TARGET_MAP[self.target].default_toolchain
 
     def generate(self):
         """ Generates the project files """


### PR DESCRIPTION
uvision uses default_toolchain, thus exporter needs to provide a method to
distinguish between ARM and uARM. Fixes #1686 

@toyowata Please test. I tested this with KL05 (uARM) and KL25Z (ARM) if proper toolchain is set