### PR TITLE
uvision5 - get_toolchain method

### DIFF
--- a/workspace_tools/export/uvision5.py
+++ b/workspace_tools/export/uvision5.py
@@ -44,6 +44,8 @@ class Uvision5(Exporter):
             # target is not supported yet
             continue
 
+    def get_toolchain(self):
+        return TARGET_MAP[self.target].default_toolchain
 
     def generate(self):
         """ Generates the project files """


### PR DESCRIPTION
same solution as in PR #1687 but for Keil v5

I tested it with blinky and Nucleo_F042 and it works well after the patch.