### PR TITLE
i2c - fix return value description i2c_byte_write()

### DIFF
--- a/libraries/mbed/hal/i2c_api.h
+++ b/libraries/mbed/hal/i2c_api.h
@@ -124,7 +124,7 @@ int  i2c_byte_read(i2c_t *obj, int last);
 /** Write one byte.
  *  @param obj The i2c object
  *  @param data Byte to be written
- *  @return 1 if NAK was received, 0 if ACK was received, 2 for timeout.
+ *  @return 0 if NAK was received, 1 if ACK was received, 2 for timeout.
  */
 int  i2c_byte_write(i2c_t *obj, int data);
 


### PR DESCRIPTION
Fixes #1670. This follows the C++ i2c int write(int data) method, plus the implementations for nxp 1768 has it as it is with this correction, thus we can assume that's the intentional behavior. The documentation was added the last year, and was mapping some of the targets (I personally haven't noticed this).

We will add tests to get this right , we will need to fix the implementations.

@sg- @kgills 