### PR TITLE
Typo fix in HAL_CM0.S of ARM7 rtx

### DIFF
--- a/libraries/rtos/rtx/TARGET_ARM7/ARM7/TOOLCHAIN_GCC/HAL_CM0.S
+++ b/libraries/rtos/rtx/TARGET_ARM7/ARM7/TOOLCHAIN_GCC/HAL_CM0.S
@@ -104,7 +104,7 @@ RestoreContext:
     LDMFD  LR, {R0-R12,LR}^
     NOP
 
-    ADD    LR, LR, 15*4               /* increase starck pointer */
+    ADD    LR, LR, 15*4               /* increase stack pointer */
     /* Set SP(user) to LR */
     STMDB  SP!,{LR}
     LDMIA  SP,{SP}^


### PR DESCRIPTION
Simple typo fix "starck" -> "stack"