### PR TITLE
[NUCLEO_L031K6] Change the default pwm pin

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/PinNames.h
@@ -145,7 +145,7 @@ typedef enum {
     SPI_MISO    = PB_4,
     SPI_SCK     = PB_3,
     SPI_CS      = PA_11,
-    PWM_OUT     = PB_3,
+    PWM_OUT     = PB_0,
 
     // Not connected
     NC = (int)0xFFFFFFFF


### PR DESCRIPTION
To be more consistent with other 32 pins Nucleo targets, such as NUCLEO_F031K6 and NUCLEO_F042K6. And also to avoid collision with the led.