### PR TITLE
[STM32F1 F4] Fix #1705 MBED_37

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/serial_api.c
@@ -50,6 +50,8 @@ serial_t stdio_uart;
 
 static void init_uart(serial_t *obj)
 {
+    int dummywrite = 0;
+
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
 
     UartHandle.Init.BaudRate   = obj->baudrate;
@@ -67,6 +69,9 @@ static void init_uart(serial_t *obj)
     }
 
     HAL_UART_Init(&UartHandle);
+
+    /* DUMMY write in Transmit register to clear its content */
+    UartHandle.Instance->DR = (uint8_t)(dummywrite & (uint8_t)0xFF);
 }
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F1/serial_api.c
@@ -50,7 +50,6 @@ serial_t stdio_uart;
 
 static void init_uart(serial_t *obj)
 {
-    int dummywrite = 0;
 
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
 
@@ -70,8 +69,6 @@ static void init_uart(serial_t *obj)
 
     HAL_UART_Init(&UartHandle);
 
-    /* DUMMY write in Transmit register to clear its content */
-    UartHandle.Instance->DR = (uint8_t)(dummywrite & (uint8_t)0xFF);
 }
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)
@@ -86,14 +83,20 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 
     // Enable UART clock
     if (obj->uart == UART_1) {
+    	__USART1_FORCE_RESET();
+    	__USART1_RELEASE_RESET();
         __HAL_RCC_USART1_CLK_ENABLE();
         obj->index = 0;
     }
     if (obj->uart == UART_2) {
+    	__USART2_FORCE_RESET();
+    	__USART2_RELEASE_RESET();
         __HAL_RCC_USART2_CLK_ENABLE();
         obj->index = 1;
     }
     if (obj->uart == UART_3) {
+    	__USART3_FORCE_RESET();
+    	__USART3_RELEASE_RESET();
         __HAL_RCC_USART3_CLK_ENABLE();
         obj->index = 2;
     }

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -101,8 +101,6 @@ serial_t stdio_uart;
 
 static void init_uart(serial_t *obj, UARTName instance)
 {
-    int dummywrite = 0;
-
     UART_HandleTypeDef *handle = &UartHandle[SERIAL_OBJ(index)];
     handle->Instance = (USART_TypeDef *)instance;
 
@@ -188,8 +186,6 @@ static void init_uart(serial_t *obj, UARTName instance)
         error("Cannot initialize UART\n");
     }
 
-    /* DUMMY write in Transmit register to clear its content */
-    handle->Instance->DR = (uint8_t)(dummywrite & (uint8_t)0xFF);
 }
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)
@@ -206,6 +202,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
     // Enable USART clock
     switch (instance) {
         case UART_1:
+        	__USART1_FORCE_RESET();
+        	__USART1_RELEASE_RESET();
             __HAL_RCC_USART1_CLK_ENABLE();
             SERIAL_OBJ(index) = 0;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -213,6 +211,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
             break;
         case UART_2:
+        	__USART2_FORCE_RESET();
+        	__USART2_RELEASE_RESET();
             __HAL_RCC_USART2_CLK_ENABLE();
             SERIAL_OBJ(index) = 1;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -221,6 +221,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
             break;
 #if defined(USART3_BASE)
         case UART_3:
+        	__USART3_FORCE_RESET();
+        	__USART3_RELEASE_RESET();
             __HAL_RCC_USART3_CLK_ENABLE();
             SERIAL_OBJ(index) = 2;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -230,6 +232,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
 #if defined(UART4_BASE)
         case UART_4:
+        	__USART4_FORCE_RESET();
+        	__USART4_RELEASE_RESET();
             __HAL_RCC_UART4_CLK_ENABLE();
             SERIAL_OBJ(index) = 3;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -239,6 +243,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
 #if defined(UART5_BASE)
         case UART_5:
+        	__USART5_FORCE_RESET();
+        	__USART5_RELEASE_RESET();
             __HAL_RCC_UART5_CLK_ENABLE();
             SERIAL_OBJ(index) = 4;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -248,6 +254,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
 #if defined(USART6_BASE)
         case UART_6:
+        	__USART6_FORCE_RESET();
+        	__USART6_RELEASE_RESET();
             __HAL_RCC_USART6_CLK_ENABLE();
             SERIAL_OBJ(index) = 5;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -257,6 +265,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
 #if defined(UART7_BASE)
         case UART_7:
+        	__USART8_FORCE_RESET();
+        	__USART8_RELEASE_RESET();
             __HAL_RCC_UART7_CLK_ENABLE();
             SERIAL_OBJ(index) = 6;
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -266,6 +276,8 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
 #endif
 #if defined(UART8_BASE)
         case UART_8:
+        	__USART8_FORCE_RESET();
+        	__USART8_RELEASE_RESET();
             __HAL_RCC_UART8_CLK_ENABLE();
             SERIAL_OBJ(index) = 7;
 #if DEVICE_SERIAL_ASYNCH_DMA

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -101,6 +101,7 @@ serial_t stdio_uart;
 
 static void init_uart(serial_t *obj, UARTName instance)
 {
+    int dummywrite = 0;
 
     UART_HandleTypeDef *handle = &UartHandle[SERIAL_OBJ(index)];
     handle->Instance = (USART_TypeDef *)instance;
@@ -186,6 +187,9 @@ static void init_uart(serial_t *obj, UARTName instance)
     if (HAL_UART_Init(handle) != HAL_OK) {
         error("Cannot initialize UART\n");
     }
+
+    /* DUMMY write in Transmit register to clear its content */
+    handle->Instance->DR = (uint8_t)(dummywrite & (uint8_t)0xFF);
 }
 
 void serial_init(serial_t *obj, PinName tx, PinName rx)


### PR DESCRIPTION
The transmit data register needs to be flushed at the initialisation of the uart.
In case previous transmission was interrupted by a uart init, uart may contain a char that will be transmitted at the next start.

This is the case in MBED_37 test (serial_auto_nc_rx).
The MCU is writting {{start}}\n
At the moment of the \n the main program is handling 'new serial'. The next time the main program is handling a printf, the previous \n is
still present in the uart->DR register and is transmitted.
This cannot happen anymore with this commit