### PR TITLE
[STM32L4] Fix IAR section placement failed error

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_IAR/stm32l476xx.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_IAR/stm32l476xx.icf
@@ -31,5 +31,5 @@ do not initialize  { section .noinit };
 place at address mem:__intvec_start__ { readonly section .intvec };
 
 place in ROM_region   { readonly };
-place in SRAM2_region   { readwrite, block STACKHEAP };
-place in SRAM1_region { };
+place in SRAM2_region   { readwrite };
+place in SRAM1_region { block STACKHEAP };


### PR DESCRIPTION
For some reason STACKHEAP block was placed in SRAM2 section which lead to
*Error[Lp011]: section placement failed - unable to allocate space for sections/
block* error. This patch modifies the STM32L4 linker script and places STACKHEAP
into SRAM1 section which was previously unused.

Change-Id: Ibe6ca52a9fe7af232a3eade2f6b1f2ce28c9bd49