### PR TITLE
Changed the heap size to the correct MCU heap size for SRAM1

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
@@ -48,7 +48,7 @@ __initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standb
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size       EQU     0x8000 ; 32KB
+Heap_Size       EQU     0x18000 ; 96KB
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
                 EXPORT  __heap_base

--- a/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
+++ b/libraries/mbed/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
@@ -48,7 +48,7 @@ __initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standb
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ; </h>
 
-Heap_Size       EQU     0x8000 ; 32KB
+Heap_Size       EQU     0x18000 ; 96KB
 
                 AREA    HEAP, NOINIT, READWRITE, ALIGN=3
                 EXPORT  __heap_base


### PR DESCRIPTION
The heap size was wrong for the mbed MICRO online builds. This should fix it. 
L4 Nucleo and Disco versions.

BTW: The HAL libraries are outdated, the latest versions are month ahead.