### PR TITLE
gcc - use group for ld to resolve symbols from libraries

### DIFF
--- a/workspace_tools/export/gcc_arm_common.tmpl
+++ b/workspace_tools/export/gcc_arm_common.tmpl
@@ -81,7 +81,7 @@ clean:
 
 {% block target_project_elf %}
 $(PROJECT).elf: $(OBJECTS) $(SYS_OBJECTS)
-	$(LD) $(LD_FLAGS) -T$(LINKER_SCRIPT) $(LIBRARY_PATHS) -o $@ $^ $(LIBRARIES) $(LD_SYS_LIBS) $(LIBRARIES) $(LD_SYS_LIBS)
+	$(LD) $(LD_FLAGS) -T$(LINKER_SCRIPT) $(LIBRARY_PATHS) -o $@ $^ -Wl,--start-group $(LIBRARIES) $(LD_SYS_LIBS) -Wl,--end-group
 {% endblock %}
 
 $(PROJECT).bin: $(PROJECT).elf


### PR DESCRIPTION
This fixes problem we have seen with rtos_idle_loop. The symbols
was not resolved as order played a role in this case.

Before the patch ``-lmbed -lrtos -lrtx -leth -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -lmbed -lrtos -lrtx -leth -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys``

After the patch ``-Wl,--start-group -lmbed -lrtos -lrtx -leth -lstdc++ -lsupc++ -lm -lc -lgcc -lnosys -Wl,--end-group``

@neilt6 Fixes the problem with rtos_idle_loop.

@adamgreen @sg- @TomoYamanaka 