### PR TITLE
RTOS - fix Cortex-M version - add macros required for new kernel

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -56,6 +56,11 @@
 
 #define CMSIS_OS_RTX
 
+// __MBED_CMSIS_RTOS_CM captures our changes to the RTX kernel
+#define __MBED_CMSIS_RTOS_CM
+// we use __CMSIS_RTOS version, which changes some API in the kernel
+#define __CMSIS_RTOS
+
 // The stack space occupied is mainly dependent on the underling C standard library
 #if defined(TOOLCHAIN_GCC) || defined(TOOLCHAIN_ARM_STD) || defined(TOOLCHAIN_IAR)
 #    define WORDS_STACK_SIZE   512

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -48,6 +48,10 @@
   #error "Missing __CORTEX_Mx definition"
 #endif
 
+// This affects cmsis_os only, as it's not used anywhere else. This was left by kernel team
+// to suppress the warning in rt_tid2ptcb about incompatible pointer assignment.
+#define os_thread_cb OS_TCB
+
 #include "rt_TypeDef.h"
 #include "RTX_Config.h"
 #include "rt_System.h"
@@ -61,8 +65,6 @@
 #include "rt_MemBox.h"
 #include "rt_Memory.h"
 #include "rt_HAL_CM.h"
-
-#define os_thread_cb OS_TCB
 
 #include "cmsis_os.h"
 

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_Task.h
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_Task.h
@@ -34,6 +34,8 @@
 
 /* Definitions */
 
+#include "cmsis_os.h"
+
 /* Values for 'state'   */
 #define INACTIVE        0U
 #define READY           1U

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_Timer.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_Timer.c
@@ -36,6 +36,7 @@
 #include "RTX_Config.h"
 #include "rt_Timer.h"
 #include "rt_MemBox.h"
+#include "cmsis_os.h"
 
 #ifndef __CMSIS_RTOS
 

--- a/workspace_tools/toolchains/__init__.py
+++ b/workspace_tools/toolchains/__init__.py
@@ -166,14 +166,14 @@ class mbedToolchain:
     VERBOSE = True
 
     CORTEX_SYMBOLS = {
-        "Cortex-M0" : ["__CORTEX_M0", "ARM_MATH_CM0", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M0+": ["__CORTEX_M0PLUS", "ARM_MATH_CM0PLUS", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M1" : ["__CORTEX_M3", "ARM_MATH_CM1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M3" : ["__CORTEX_M3", "ARM_MATH_CM3", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M4" : ["__CORTEX_M4", "ARM_MATH_CM4", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M4F" : ["__CORTEX_M4", "ARM_MATH_CM4", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M7" : ["__CORTEX_M7", "ARM_MATH_CM7", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M7F" : ["__CORTEX_M7", "ARM_MATH_CM7", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
+        "Cortex-M0" : ["__CORTEX_M0", "ARM_MATH_CM0"],
+        "Cortex-M0+": ["__CORTEX_M0PLUS", "ARM_MATH_CM0PLUS"],
+        "Cortex-M1" : ["__CORTEX_M3", "ARM_MATH_CM1"],
+        "Cortex-M3" : ["__CORTEX_M3", "ARM_MATH_CM3"],
+        "Cortex-M4" : ["__CORTEX_M4", "ARM_MATH_CM4"],
+        "Cortex-M4F" : ["__CORTEX_M4", "ARM_MATH_CM4", "__FPU_PRESENT=1"],
+        "Cortex-M7" : ["__CORTEX_M7", "ARM_MATH_CM7"],
+        "Cortex-M7F" : ["__CORTEX_M7", "ARM_MATH_CM7", "__FPU_PRESENT=1"],
         "Cortex-A9" : ["__CORTEX_A9", "ARM_MATH_CA9", "__FPU_PRESENT", "__CMSIS_RTOS", "__EVAL", "__MBED_CMSIS_RTOS_CA9"],
     }
 


### PR DESCRIPTION
2 new macros were introduced to capture changes in the kernel. We used toolchains/__init__
script to capture those, which is not in the sync with actual sources. This fix introduces
those macros in the source, rather than a script.

We will further eliminate those macros to be used outside of RTX kernel (c++ API).

@sg- @neilt6 