### PR TITLE
Change the sequence of the ROM section in IAR compile

### DIFF
--- a/libraries/mbed/targets/cmsis/TARGET_RENESAS/TARGET_RZ_A1H/TOOLCHAIN_IAR/MBRZA1H.icf
+++ b/libraries/mbed/targets/cmsis/TARGET_RENESAS/TARGET_RZ_A1H/TOOLCHAIN_IAR/MBRZA1H.icf
@@ -38,6 +38,7 @@ define region RetRAM_region       = mem:[from __ICFEDIT_region_RetRAM_start__   
 define region MirrorRAM_region    = mem:[from __ICFEDIT_region_MirrorRAM_start__    to __ICFEDIT_region_MirrorRAM_end__];
 define region MirrorRetRAM_region = mem:[from __ICFEDIT_region_MirrorRetRAM_start__ to __ICFEDIT_region_MirrorRetRAM_end__];
 
+define block ROM_FIXED_ORDER with fixed order { ro code, ro data };
 define block CSTACK    with alignment = 8, size = __ICFEDIT_size_cstack__   { };
 define block SVC_STACK with alignment = 8, size = __ICFEDIT_size_svcstack__ { };
 define block IRQ_STACK with alignment = 8, size = __ICFEDIT_size_irqstack__ { };
@@ -48,11 +49,11 @@ define block HEAP      with alignment = 8, size = __ICFEDIT_size_heap__     { };
 
 initialize by copy { readwrite };
 do not initialize  { section .noinit };
-do not initialize  { section MMU_TT };
+do not initialize  { section .retram };
 
 place at address mem:__ICFEDIT_intvec_start__ { readonly section .intvec };
 
-place in ROM_region     { readonly };
+place in ROM_region     { readonly, block ROM_FIXED_ORDER };
 place in RAM_region     { readwrite,
                           block CSTACK, block SVC_STACK, block IRQ_STACK, block FIQ_STACK,
                           block UND_STACK, block ABT_STACK, block HEAP };


### PR DESCRIPTION
Hi

We changed the sequence of ROM section to "<ro code> <ro data>" when compiled with the IAR.

Regards,
Yamanaka