### PR TITLE
Target - backward compatibility KSDK 1.0 labels

### DIFF
--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -651,7 +651,7 @@ class K22F(Target):
     def __init__(self):
         Target.__init__(self)
         self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM']
+        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM', 'KPSDK_MCUS', 'KPSDK_CODE']
         self.macros = ["CPU_MK22FN512VLH12", "FSL_RTOS_MBED"]
         self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
         self.supported_form_factors = ["ARDUINO"]
@@ -680,7 +680,7 @@ class K64F(Target):
     def __init__(self):
         Target.__init__(self)
         self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM']
+        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM', 'KPSDK_MCUS', 'KPSDK_CODE', 'MCU_K64F']
         self.macros = ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"]
         self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
         self.supported_form_factors = ["ARDUINO"]
@@ -695,7 +695,7 @@ class MTS_GAMBIT(Target):
     def __init__(self):
         Target.__init__(self)
         self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'K64F']
+        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'K64F', 'KPSDK_MCUS', 'KPSDK_CODE', 'MCU_K64F']
         self.supported_toolchains = ["ARM", "GCC_ARM"]
         self.macros = ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"]
         self.is_disk_virtual = True


### PR DESCRIPTION
The extra_labels should not be removed, as it could break old sources or
mbed-lib or applications.

@screamerbg @sg- 