### PR TITLE
RTX - init sequence (C++ array init)

### DIFF
--- a/hal/api/semihost_api.h
+++ b/hal/api/semihost_api.h
@@ -28,7 +28,7 @@ extern "C" {
 #ifndef __CC_ARM
 
 #if defined(__ICCARM__)
-inline int __semihost(int reason, const void *arg) {
+static inline int __semihost(int reason, const void *arg) {
     return __semihosting(reason, (void*)arg);
 }
 #else

--- a/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_ARM7/RTX_CM_lib.h
@@ -276,60 +276,6 @@ __asm void __rt_entry (void) {
 
 #elif defined (__GNUC__)
 
-#ifdef __CS3__
-
-/* CS3 start_c routine.
- *
- * Copyright (c) 2006, 2007 CodeSourcery Inc
- *
- * The authors hereby grant permission to use, copy, modify, distribute,
- * and license this software and its documentation for any purpose, provided
- * that existing copyright notices are retained in all copies and that this
- * notice is included verbatim in any distributions. No written agreement,
- * license, or royalty fee is required for any of the authorized uses.
- * Modifications to this software may be copyrighted by their authors
- * and need not follow the licensing terms described here, provided that
- * the new terms are clearly indicated on the first page of each file where
- * they apply.
- */
-
-#include "cs3.h"
-
-extern void __libc_init_array (void);
-
-__attribute ((noreturn)) void __cs3_start_c (void){
-  unsigned regions = __cs3_region_num;
-  const struct __cs3_region *rptr = __cs3_regions;
-
-  /* Initialize memory */
-  for (regions = __cs3_region_num, rptr = __cs3_regions; regions--; rptr++) {
-    long long *src = (long long *)rptr->init;
-    long long *dst = (long long *)rptr->data;
-    unsigned limit = rptr->init_size;
-    unsigned count;
-
-    if (src != dst)
-      for (count = 0; count != limit; count += sizeof (long long))
-        *dst++ = *src++;
-    else
-      dst = (long long *)((char *)dst + limit);
-    limit = rptr->zero_size;
-    for (count = 0; count != limit; count += sizeof (long long))
-      *dst++ = 0;
-  }
-
-  /* Run initializers.  */
-  __libc_init_array ();
-
-  osKernelInitialize();
-  set_main_stack();
-  osThreadCreate(&os_thread_def_main, NULL);
-  osKernelStart();
-  for (;;);
-}
-
-#else
-
 __attribute__((naked)) void software_init_hook (void) {
   __asm (
     ".syntax unified\n"
@@ -352,8 +298,6 @@ __attribute__((naked)) void software_init_hook (void) {
     "bl   exit\n"
   );
 }
-
-#endif
 
 #elif defined (__ICCARM__)
 

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
@@ -447,59 +447,6 @@ __asm void __rt_entry (void) {
 
 #elif defined (__GNUC__)
 
-#ifdef __CS3__
-
-/* CS3 start_c routine.
- *
- * Copyright (c) 2006, 2007 CodeSourcery Inc
- *
- * The authors hereby grant permission to use, copy, modify, distribute,
- * and license this software and its documentation for any purpose, provided
- * that existing copyright notices are retained in all copies and that this
- * notice is included verbatim in any distributions. No written agreement,
- * license, or royalty fee is required for any of the authorized uses.
- * Modifications to this software may be copyrighted by their authors
- * and need not follow the licensing terms described here, provided that
- * the new terms are clearly indicated on the first page of each file where
- * they apply.
- */
-
-#include "cs3.h"
-
-extern void __libc_init_array (void);
-
-__attribute ((noreturn)) void __cs3_start_c (void){
-  unsigned regions = __cs3_region_num;
-  const struct __cs3_region *rptr = __cs3_regions;
-
-  /* Initialize memory */
-  for (regions = __cs3_region_num, rptr = __cs3_regions; regions--; rptr++) {
-    long long *src = (long long *)rptr->init;
-    long long *dst = (long long *)rptr->data;
-    unsigned limit = rptr->init_size;
-    unsigned count;
-
-    if (src != dst)
-      for (count = 0; count != limit; count += sizeof (long long))
-        *dst++ = *src++;
-    else
-      dst = (long long *)((char *)dst + limit);
-    limit = rptr->zero_size;
-    for (count = 0; count != limit; count += sizeof (long long))
-      *dst++ = 0;
-  }
-
-  /* Run initializers.  */
-  __libc_init_array ();
-
-  osKernelInitialize();
-  osThreadCreate(&os_thread_def_main, NULL);
-  osKernelStart();
-  for (;;);
-}
-
-#else
-
 __attribute__((naked)) void software_init_hook (void) {
   __asm (
     ".syntax unified\n"
@@ -521,8 +468,6 @@ __attribute__((naked)) void software_init_hook (void) {
     "bl   exit\n"
   );
 }
-
-#endif
 
 #elif defined (__ICCARM__)
 

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -555,21 +555,14 @@ __asm void __rt_entry (void) {
 
 #elif defined (__GNUC__)
 
-__attribute__((naked)) void pre_main (void) {
-  __asm (
-    ".syntax unified\n"
-    ".thumb\n"
-    /* Save link register (keep 8 byte alignment with dummy r4) */
-    "push    {r4, lr}\n"
-    "ldr  r0,= __libc_fini_array\n"
-    "bl   atexit\n"
-    "bl   __libc_init_array\n"
-    /* Restore link register and branch so when main returns it
-    * goes to the thread destroy function.
-    */
-    "pop     {r4, lr}\n"
-    "b    main\n"
-  );
+extern void __libc_fini_array(void);
+extern void __libc_init_array (void);
+extern int main(int argc, char **argv);
+
+void pre_main(void) {
+    atexit(__libc_fini_array);
+    __libc_init_array();
+    main(0, NULL);
 }
 
 __attribute__((naked)) void software_init_hook (void) {

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -583,6 +583,15 @@ extern void __iar_dynamic_initialization(void);
 extern void mbed_sdk_init(void);
 extern void exit(int arg);
 
+static uint8_t low_level_init_needed;
+
+void pre_main(void) {
+    if (low_level_init_needed) {
+        __iar_dynamic_initialization();
+    }
+    main();
+}
+
 #pragma required=__vector_table
 void __iar_program_start( void )
 {
@@ -590,22 +599,24 @@ void __iar_program_start( void )
   __iar_init_core();
   __iar_init_vfp();
 
-  int a;
+  uint8_t low_level_init_needed_local;
 
-  if (__low_level_init() != 0) {
+  low_level_init_needed_local = __low_level_init();
+  if (low_level_init_needed_local) {
     __iar_data_init3();
     mbed_sdk_init();
-    __iar_dynamic_initialization();
   }
+  /* Store in a global variable after RAM has been initialized */
+  low_level_init_needed = low_level_init_needed_local;
 #endif
   osKernelInitialize();
 #ifdef __MBED_CMSIS_RTOS_CM
   set_main_stack();
 #endif
   osThreadCreate(&os_thread_def_main, NULL);
-  a = osKernelStart();
-  exit(a);
-
+  osKernelStart();
+  /* osKernelStart should not return */
+  while (1);
 }
 
 #endif

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -491,15 +491,13 @@ __asm void pre_main (void)
   LDR     R1,=armcc_heap_top
   LDR     R0,[R0]
   LDR     R1,[R1]
-  /* Save link register (keep 8 byte alignment with dummy r4) */
-  push    {r4, lr}
+  /* Save link register (keep 8 byte alignment with dummy R4) */
+  PUSH    {R4, LR}
   BL      __rt_lib_init
-  /* Restore link register and branch so when main returns it
-   * goes to the thread destroy function.
+  BL       main
+  /* Return to the thread destroy function.
    */
-  pop     {r4, lr}
-  B       main
-
+  POP     {R4, PC}
   ALIGN
 }
 

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -501,62 +501,6 @@ __asm void __rt_entry (void) {
 
 #elif defined (__GNUC__)
 
-#ifdef __CS3__
-
-/* CS3 start_c routine.
- *
- * Copyright (c) 2006, 2007 CodeSourcery Inc
- *
- * The authors hereby grant permission to use, copy, modify, distribute,
- * and license this software and its documentation for any purpose, provided
- * that existing copyright notices are retained in all copies and that this
- * notice is included verbatim in any distributions. No written agreement,
- * license, or royalty fee is required for any of the authorized uses.
- * Modifications to this software may be copyrighted by their authors
- * and need not follow the licensing terms described here, provided that
- * the new terms are clearly indicated on the first page of each file where
- * they apply.
- */
-
-#include "cs3.h"
-
-extern void __libc_init_array (void);
-
-__attribute ((noreturn)) void __cs3_start_c (void){
-  unsigned regions = __cs3_region_num;
-  const struct __cs3_region *rptr = __cs3_regions;
-
-  /* Initialize memory */
-  for (regions = __cs3_region_num, rptr = __cs3_regions; regions--; rptr++) {
-    long long *src = (long long *)rptr->init;
-    long long *dst = (long long *)rptr->data;
-    unsigned limit = rptr->init_size;
-    unsigned count;
-
-    if (src != dst)
-      for (count = 0; count != limit; count += sizeof (long long))
-        *dst++ = *src++;
-    else
-      dst = (long long *)((char *)dst + limit);
-    limit = rptr->zero_size;
-    for (count = 0; count != limit; count += sizeof (long long))
-      *dst++ = 0;
-  }
-
-  /* Run initializers.  */
-  __libc_init_array ();
-
-  osKernelInitialize();
-#ifdef __MBED_CMSIS_RTOS_CM
-  set_main_stack();
-#endif
-  osThreadCreate(&os_thread_def_main, NULL);
-  osKernelStart();
-  for (;;);
-}
-
-#else
-
 __attribute__((naked)) void software_init_hook (void) {
   __asm (
     ".syntax unified\n"
@@ -581,8 +525,6 @@ __attribute__((naked)) void software_init_hook (void) {
     "bl   exit\n"
   );
 }
-
-#endif
 
 #elif defined (__ICCARM__)
 

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_CM_lib.h
@@ -448,7 +448,11 @@ void set_main_stack(void) {
 #if defined (__CC_ARM)
 
 #ifdef __MICROLIB
+
+int main(void);
 void _main_init (void) __attribute__((section(".ARM.Collect$$$$000000FF")));
+void $Super$$__cpp_initialize__aeabi_(void);
+
 void _main_init (void) {
   osKernelInitialize();
 #ifdef __MBED_CMSIS_RTOS_CM
@@ -458,6 +462,19 @@ void _main_init (void) {
   osKernelStart();
   for (;;);
 }
+
+void $Sub$$__cpp_initialize__aeabi_(void)
+{
+  // this should invoke C++ initializers prior _main_init, we keep this empty and
+  // invoke them after _main_init (=starts RTX kernel)
+}
+
+void pre_main()
+{
+  $Super$$__cpp_initialize__aeabi_();
+  main();
+}
+
 #else
 
 void * armcc_heap_base;


### PR DESCRIPTION
This is an update to RTX kernel to allow c++ libc array init to be called after kernel start.

This is done for Cortex-M RTX version. I'll add Cortex-A and ARM7 alignment to the codebase within this pull request.

For instance, the Thread object in the global scope should work with this patch:
```
#include "mbed.h"
#include "rtos.h"
 
DigitalOut led1(LED1);
DigitalOut led2(LED2);
Thread thread(led2_thread);
 
void led2_thread(void const *args) 
{
    while (true) {
        led2 = !led2;
        Thread::wait(1000);
    }
}

int main() 
{  
    while (true) {
        led1 = !led1;
        Thread::wait(500);
    }
}
```

@sg- @c1728p9 @adamgreen @neilt6 @TomoYamanaka 