### PR TITLE
[RTOS] Fixed osThreadGetState()

### DIFF
--- a/libraries/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_A/rt_CMSIS.c
@@ -905,7 +905,7 @@ uint8_t osThreadGetState (osThreadId thread_id) {
   if (__exceptional_mode()) return osErrorISR;     // Not allowed in ISR
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return osErrorParameter;
+  if (ptcb == NULL) return INACTIVE;
 
   return ptcb->state;
 }

--- a/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/libraries/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -842,7 +842,7 @@ uint8_t osThreadGetState (osThreadId thread_id) {
   if (__get_IPSR() != 0U) return osErrorISR;     // Not allowed in ISR
 
   ptcb = rt_tid2ptcb(thread_id);                // Get TCB pointer
-  if (ptcb == NULL) return osErrorParameter;
+  if (ptcb == NULL) return INACTIVE;
 
   return ptcb->state;
 }


### PR DESCRIPTION
Fixed regression that caused terminated threads to return an erroneous state value instead of "inactive".