### PR TITLE
[STM32F4] Clock and interrupt fixes

### DIFF
--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/can_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/can_api.c
@@ -75,6 +75,9 @@ void can_init(can_t *obj, PinName rd, PinName td)
 
     filter_number = (obj->can == CAN_1) ? 0 : 14;
 
+    // Set initial CAN frequency to 100kb/s
+    can_frequency(obj, 100000);
+
     can_filter(obj, 0, 0, CANStandard, filter_number);
 }
 
@@ -177,7 +180,7 @@ static unsigned int can_speed(unsigned int pclk, unsigned int cclk, unsigned cha
 
 int can_frequency(can_t *obj, int f) 
 {
-    int pclk ; //= PeripheralClock;
+    int pclk = HAL_RCC_GetPCLK1Freq();
     int btr = can_speed(pclk, (unsigned int)f, 1);
     CAN_TypeDef *can = (CAN_TypeDef *)(obj->can);
 

--- a/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/can_api.c
+++ b/libraries/mbed/targets/hal/TARGET_STM/TARGET_STM32F4/can_api.c
@@ -42,7 +42,7 @@ void can_init(can_t *obj, PinName rd, PinName td)
         obj->index = 0;
     } else {
         __HAL_RCC_CAN2_CLK_ENABLE();
-        obj->index = 0;
+        obj->index = 1;
     }
 
     // Configure the CAN pins


### PR DESCRIPTION
CAN bus opperates on APB1 peripheral clock due to that we need to get PCLK1 freq
in *can_frequency()* function to properly calculate CAN speed and reconfigure
BS1, BS2, SJW bits.

Also to fully communicate with other ST platform we set the initical CAN
frequency to 100kb/s to be able to work with the slowest platform which supports
CAN, which is NUCLEO_F303K8 (APB1 is 32MHz).

========

CAN2 interrupt index was wrong leading to not properly registering interrupt.
Having this fix allow us to pass MBED_30 test.