### PR TITLE
Fixed a problem that can not be the task generation in Cortex-A9.

### DIFF
--- a/libraries/rtos/rtos/Thread.cpp
+++ b/libraries/rtos/rtos/Thread.cpp
@@ -34,7 +34,7 @@ namespace rtos {
 
 Thread::Thread(void (*task)(void const *argument), void *argument,
         osPriority priority, uint32_t stack_size, unsigned char *stack_pointer) {
-#ifdef __MBED_CMSIS_RTOS_CM
+#if defined(__MBED_CMSIS_RTOS_CA9) || defined(__MBED_CMSIS_RTOS_CM)
     _thread_def.pthread = task;
     _thread_def.tpriority = priority;
     _thread_def.stacksize = stack_size;


### PR DESCRIPTION
Hi

https://github.com/mbedmicro/mbed/pull/1702
In this PR, rtx has updated, the macro into the code were changed.
However, by this macro, the process of task generation in Cortex-A9 can no longer be run.
So, we solve the task generation problem by changing the macro into Tread.cpp again.

Regards,
Yamanaka