### PR TITLE
Moved target definitions to JSON format

### DIFF
--- a/docs/mbed_targets.md
+++ b/docs/mbed_targets.md
@@ -120,7 +120,7 @@ This is the list of toolchains that can be used to compile code for the target. 
 
 ## default_toolchain
 
-The name of the toolchain that will be used by default to compile this target (if another toolchain is not specified). Possible values are `ARM`, `uARM`, `GCC_ARM`, `GCC_CR`, `IAR`.
+The name of the toolchain that will be used by default to compile this target (if another toolchain is not specified). Possible values are `ARM` or `uARM`.
 
 ## post_binary_hook
 

--- a/docs/mbed_targets.md
+++ b/docs/mbed_targets.md
@@ -1,0 +1,169 @@
+# Adding and configuring mbed targets
+
+mbed uses JSON as a description language for its build targets. The JSON description of mbed targets can be found in `workspace_tools/targets.json`. To better understand how a target is defined, we'll use this example (taken from `targets.json`):
+
+```
+    "TEENSY3_1": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "extra_labels": ["Freescale", "K20XX", "K20DX256"],
+        "OUTPUT_EXT": "hex",
+        "is_disk_virtual": true,
+        "supported_toolchains": ["GCC_ARM", "ARM"],
+        "post_binary_hook": {
+            "function": "TEENSY3_1Code.binary_hook",
+            "toolchains": ["ARM_STD", "ARM_MICRO", "GCC_ARM"]
+        },
+        "progen": {"target": "teensy-31"},
+        "detect_code": ["0230"]
+```
+
+The definition of the target called **TEENSY3_1** is a JSON object. The properties in the object are either "standard" (understood by the mbed build system) or specific to the target.
+
+# Standard properties
+
+This section lists all the properties that are known to the mbed build system. Unless specified otherwise, all properties are optional.
+
+## inherits
+
+The description of a mbed target can "inherit" from one of more descriptions of other targets. When a target **A** inherits from another target **B** (**A** is the _child_ of **B** and **B** is the _parent_ of **A**), it automatically "borrows" all the definitions of properties from **B** and can modify them as needed (if you're familiar with Python, this is very similar with how class inheritance works in Python). In our example above, `TEENSY3_1` inherits from `Target` (most mbed targets inherit from `Target`). This is how `Target` is defined:
+
+```
+"Target": {
+    "core": null,
+    "default_toolchain": "ARM",
+    "supported_toolchains": null,
+    "extra_labels": [],
+    "is_disk_virtual": false,
+    "macros": [],
+    "detect_code": [],
+    "public": false
+}
+```
+
+Since `TEENSY3_1` inherits from `Target`:
+
+- `core` is a property defined both in `TEENSY3_1` and `Target`. Since `TEENSY3_1` redefines it, the value of `core` for `TEENSY3_1` will be `Cortex-M4`.
+- `default_toolchain` is not defined in `TEENSY3_1`, but since it is defined in `Target`, `TEENSY3_1` borrows it, so the value of `default_toolchain` for `TEENSY3_1` will be `ARM`.
+
+A target can add properties that don't exist in its parent(s). For example, `OUTPUT_EXT` is defined in `TEENSY3_1`, but doesn't exist in `Target`.
+
+It's possible to inherit from more than one target. For example:
+
+```
+"ImaginaryTarget": {
+    "inherits": ["Target", "TEENSY3_1"]
+}
+```
+
+In this case, `ImaginaryTarget` inherits the properties of both `Target` and `TEENSY3_1`, so:
+
+- the value of `ImaginaryTarget.default_toolchain` will be `ARM` (from `Target`)
+- the value of `ImaginaryTarget.OUTPUT_EXT` will be `hex` (from `TEENSY3_1`).
+- the value of `ImaginaryTarget.core` will be `null` (from `Target`, since that's the first parent of `ImaginaryTarget` that defines `core`).
+
+Avoid using multiple inheritance for your targets if possible, since it can get pretty tricky to figure out how a property is inherited if multiple inheritance is used. If you have to use multiple inheritance, keep in mind that the mbed target description mechanism uses the old (pre 2.3) Python mechanism for finding the method resolution order:
+
+- look for the property in the current target.
+- if not found, look for the property in the first target's parent, then in the parent of the parent and so on.
+- if not found, look for the property in the rest of the target's parents, relative to the current inheritance level.
+
+For more details about the Python method resolution order, check for example [this link](http://makina-corpus.com/blog/metier/2014/python-tutorial-understanding-python-mro-class-search-path).
+
+## core
+
+The name of the ARM core used by the target.
+
+Possible values: `"Cortex-M0"`, `"Cortex-M0+"`, `"Cortex-M1"`, `"Cortex-M3"`, `"Cortex-M4"`, `"Cortex-M4F"`, `"Cortex-M7"`, `"Cortex-M7F"`, `"Cortex-A9"`
+
+## public
+
+Some mbed targets might be defined solely for the purpose of serving as an inheritance base for other targets (as opposed to being used to build mbed code). When such a target is defined, its description must have the `public` property set to `false` to prevent the mbed build system from considering it as a build target. An example is the `Target` target shown in a previous paragraph.
+
+If `public` is not defined for a target, it defaults to `true`.
+
+Note that unlike other target properties, **the value of `public` is not inherited from a parent to its children**.
+
+## macros, macros_add, macros_remove
+
+The macros in this list will be defined when compiling mbed code. The macros can be defined with or without a value. For example, the declaration `"macros": ["NO_VALUE", "VALUE=10"]` will add these definitions to the compiler's command line: `-DNO_VALUE -DVALUE=10`.
+
+When target inheritance is used, it's possible to alter the values of `macros` in inherited targets without re-defining `macros` completely:
+
+- an inherited target can use `macros_add` to add its own macros.
+- an inherited target can use `macros_remove` to remove macros defined by its parents.
+
+For example, in this configuration:
+
+```
+    "TargetA": {
+        "macros": ["PARENT_MACRO1", "PARENT_MACRO2"]
+    },
+    "TargetB": {
+        "inherits": ["TargetA"],
+        "macros_add": ["CHILD_MACRO1"],
+        "macros_remove": ["PARENT_MACRO2"]
+    }
+```
+
+the value of `TargetB.macros` will be `["PARENT_MACRO1", "CHILD_MACRO1"]`.
+
+## extra_labels, extra_labels_add, extra_labels_remove
+
+The list of **labels** defines how the build system looks for sources, libraries, include directories and any other additional files that are needed at compile time. `extra_labels` can be used to make the build system aware of additional directories that must be scanned for such files.
+
+If target inheritance is used, it's possible to alter the values of `extra_labels` using `extra_labels_add` and `extra_labels_remove`. This is similar to the `macros_add` and `macros_remove` mechanism described in the previous paragraph.
+
+## supported_toolchains
+
+This is the list of toolchains that can be used to compile code for the target. The known toolchains are `ARM`, `uARM`, `GCC_ARM`, `GCC_CR`, `IAR`.
+
+## default_toolchain
+
+The name of the toolchain that will be used by default to compile this target (if another toolchain is not specified). Possible values are `ARM`, `uARM`, `GCC_ARM`, `GCC_CR`, `IAR`.
+
+## post_binary_hook
+
+Some mbed targets require specific actions for generating a binary image that can be flashed to the target. If that's the case, these specific actions can be specified using the `post_binary_hook` property and custom Python code. For the `TEENSY3_1` target above, the definition of `post_binary_hook` looks like this:
+
+```
+"post_binary_hook": {
+    "function": "TEENSY3_1Code.binary_hook",
+    "toolchains": ["ARM_STD", "ARM_MICRO", "GCC_ARM"]
+}
+```
+
+Following this definition, the build system will call the function `binary_hook` in the `TEENSY3_1Code` class after the initial binary image for the target is generated. The definition of the `TEENSY3_1Code` class **must** exist in the *targets.py* file. Since `toolchains` is also specified, `binary_hook` will only be called if the toolchain used for compiling the code is either `ARM_STD`, `ARM_MICRO` or `GCC_ARM`. Note that specifying `toolchains` is optional: if it's not specified, the hook will be called no matter what toolchain is used.
+
+As for the `binary_hook` code, this is how it looks in *targets.py*:
+
+```
+class TEENSY3_1Code:
+    @staticmethod
+    def binary_hook(t_self, resources, elf, binf):
+        from intelhex import IntelHex
+        binh = IntelHex()
+        binh.loadbin(binf, offset = 0)
+
+        with open(binf.replace(".bin", ".hex"), "w") as f:
+            binh.tofile(f, format='hex')
+```
+
+In this case, it converts the output file (`binf`) from binary format to Intel HEX format.
+
+The hook code can look quite different between different targets. Take a look at the other classes in *targets.py* for more examples of hook code.
+
+## progen
+
+This property is used to pass additional data to the project generator (used to export the mbed code to various 3rd party tools and IDEs). A definition for `progen` looks like this:
+
+```
+"progen": {
+    "target": "lpc11u35_401",
+    "uvision": {
+        "template": ["uvision_microlib.uvproj.tmpl"]
+    }
+```
+
+The `target` property of `progen` specifies the target name that must be used for the exporter (if different than the mbed target name).
+For each exporter, a template for exporting can also be specified. In this example, the template used for generating a uVision project file is in a file called `uvision_microlib.uvproj.tmpl`. It is assumed that all the templates are located in `workspace_tools/export`.

--- a/workspace_tools/targets.json
+++ b/workspace_tools/targets.json
@@ -1,0 +1,1543 @@
+{
+    "Target": {
+        "core": null,
+        "default_toolchain": "ARM",
+        "supported_toolchains": null,
+        "extra_labels": [],
+        "is_disk_virtual": false,
+        "macros": [],
+        "detect_code": [],
+        "public": false
+    },
+    "CM4_UARM": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "default_toolchain": "uARM",
+        "public": false,
+        "supported_toolchains": ["uARM"]
+    },
+    "CM4_ARM": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "public": false,
+        "supported_toolchains": ["ARM"]
+    },
+    "CM4F_UARM": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "public": false,
+        "supported_toolchains": ["uARM"]
+    },
+    "CM4F_ARM": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "public": false,
+        "supported_toolchains": ["ARM"]
+    },
+    "LPCTarget": {
+        "inherits": ["Target"],
+        "post_binary_hook": {
+            "function": "LPCTargetCode.lpc_patch"
+        },
+        "public": false
+    },
+    "LPC11C24": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "progen": {"target": "lpc11c24_301"},
+        "extra_labels": ["NXP", "LPC11XX_11CXX", "LPC11CXX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"]
+    },
+    "LPC1114": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11XX_11CXX", "LPC11XX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc1114_102",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC11U24": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX", "LPC11U24_401"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "progen": {
+            "target": "lpc11u24_201",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        },
+        "detect_code": ["1040"]
+    },
+    "OC_MBUINO": {
+        "inherits": ["LPC11U24"],
+        "macros": ["TARGET_LPC11U24"],
+        "progen": {
+            "target": "lpc11u24_201",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        },
+        "extra_labels": ["NXP", "LPC11UXX"]
+    },
+    "LPC11U24_301": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "extra_labels": ["NXP", "LPC11UXX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"]
+    },
+    "LPC11U34_421": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"]
+    },
+    "MICRONFCBOARD": {
+        "inherits": ["LPC11U34_421"],
+        "macros": ["LPC11U34_421", "APPNEARME_MICRONFCBOARD"],
+        "extra_labels_add": ["APPNEARME_MICRONFCBOARD"]
+    },
+    "LPC11U35_401": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc11u35_401",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC11U35_501": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc11u35_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC11U35_501_IBDAP": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc11u35_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "XADOW_M0": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc11u35_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC11U35_Y5_MBUG": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX", "MCU_LPC11U35_501"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc11u35_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC11U37_501": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {
+            "target": "lpc11u37_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPCCAPPUCCINO": {
+        "inherits": ["LPC11U37_501"],
+        "progen": {
+            "target": "lpc11u37_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "ARCH_GPRS": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX", "LPC11U37_501"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "inherits": ["LPCTarget"],
+        "progen": {
+            "target": "lpc11u37_501",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC11U68": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11U6X"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_CR", "GCC_ARM", "IAR"],
+        "inherits": ["LPCTarget"],
+        "progen": {
+            "target": "lpc11u68",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        },
+        "detect_code": ["1168"]
+    },
+    "LPC1347": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M3",
+        "progen": {"target": "lpc1347"},
+        "extra_labels": ["NXP", "LPC13XX"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"]
+    },
+    "LPC1549": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M3",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC15XX"],
+        "supported_toolchains": ["uARM", "GCC_CR", "GCC_ARM", "IAR"],
+        "inherits": ["LPCTarget"],
+        "progen": {
+            "target": "lpc1549",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        },
+        "detect_code": ["1549"]
+    },
+    "LPC1768": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M3",
+        "extra_labels": ["NXP", "LPC176X", "MBED_LPC1768"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "progen": {"target": "mbed-lpc1768"},
+        "detect_code": ["1010"]
+    },
+    "ARCH_PRO": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M3",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "extra_labels": ["NXP", "LPC176X"],
+        "macros": ["TARGET_LPC1768"],
+        "inherits": ["LPCTarget"],
+        "progen": {"target": "arch-pro"}
+    },
+    "UBLOX_C027": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M3",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "extra_labels": ["NXP", "LPC176X"],
+        "macros": ["TARGET_LPC1768"],
+        "inherits": ["LPCTarget"],
+        "progen": {"target": "ublox-c027"}
+    },
+    "XBED_LPC1768": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M3",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "extra_labels": ["NXP", "LPC176X", "XBED_LPC1768"],
+        "macros": ["TARGET_LPC1768"],
+        "progen": {"target": "lpc1768"},
+        "detect_code": ["1010"]
+    },
+    "LPC2368": {
+        "inherits": ["LPCTarget"],
+        "core": "ARM7TDMI-S",
+        "progen": {"target": "lpc2368"},
+        "extra_labels": ["NXP", "LPC23XX"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "GCC_CR"]
+    },
+    "LPC2460": {
+        "inherits": ["LPCTarget"],
+        "core": "ARM7TDMI-S",
+        "progen": {"target": "lpc2460"},
+        "extra_labels": ["NXP", "LPC2460"],
+        "supported_toolchains": ["GCC_ARM"]
+    },
+    "LPC810": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC81X"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["uARM", "IAR", "GCC_ARM"],
+        "progen": {
+            "target": "lpc810",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC812": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC81X"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["uARM", "IAR", "GCC_ARM"],
+        "inherits": ["LPCTarget"],
+        "progen": {
+            "target": "lpc812m101",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        },
+        "detect_code": ["1050"]
+    },
+    "LPC824": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC82X"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["uARM", "GCC_ARM", "GCC_CR", "IAR"],
+        "inherits": ["LPCTarget"],
+        "progen": {
+            "target": "lpc824m201",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "SSCI824": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC82X"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["uARM", "GCC_ARM"],
+        "progen": {
+            "target": "ssci824",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "LPC4088": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M4F",
+        "extra_labels": ["NXP", "LPC408X"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["ARM", "GCC_CR", "GCC_ARM", "IAR"],
+        "post_binary_hook": {
+            "function": "LPC4088Code.binary_hook",
+            "toolchains": ["ARM_STD", "ARM_MICRO"]
+        },
+        "progen": {"target": "lpc4088"}
+    },
+    "LPC4088_DM": {
+        "inherits": ["LPC4088"]
+    },
+    "LPC4330_M4": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M4F",
+        "progen": {"target": "lpc4330"},
+        "extra_labels": ["NXP", "LPC43XX", "LPC4330"],
+        "supported_toolchains": ["ARM", "GCC_CR", "IAR", "GCC_ARM"]
+    },
+    "LPC4330_M0": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M0",
+        "extra_labels": ["NXP", "LPC43XX", "LPC4330"],
+        "supported_toolchains": ["ARM", "GCC_CR", "IAR"]
+    },
+    "LPC4337": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M4F",
+        "progen": {"target": "lpc4337"},
+        "extra_labels": ["NXP", "LPC43XX", "LPC4337"],
+        "supported_toolchains": ["ARM"]
+    },
+    "LPC1800": {
+        "inherits": ["LPCTarget"],
+        "core": "Cortex-M3",
+        "extra_labels": ["NXP", "LPC43XX"],
+        "public": false,
+        "supported_toolchains": ["ARM", "GCC_CR", "IAR"]
+    },
+    "LPC11U37H_401": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["NXP", "LPC11UXX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "GCC_CR"],
+        "inherits": ["LPCTarget"],
+        "progen": {
+            "target": "lpc11u37_401",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "KL05Z": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["Freescale", "KLXX"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {
+            "target": "frdm-kl05z",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "KL25Z": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "extra_labels": ["Freescale", "KLXX"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "frdm-kl25z"},
+        "detect_code": ["0200"]
+    },
+    "KL26Z": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "extra_labels": ["Freescale", "KLXX"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "kl26z"}
+    },
+    "KL43Z": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "extra_labels": ["Freescale", "KLXX"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["GCC_ARM", "ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "frdm-kl43z"}
+    },
+    "KL46Z": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0+",
+        "extra_labels": ["Freescale", "KLXX"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "frdm-kl46z"},
+        "detect_code": ["0220"]
+    },
+    "K20D50M": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "extra_labels": ["Freescale", "K20XX"],
+        "is_disk_virtual": true,
+        "supported_toolchains": ["GCC_ARM", "ARM", "IAR"],
+        "progen": {"target": "frdm-k20d50m"},
+        "detect_code": ["0230"]
+    },
+    "TEENSY3_1": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "extra_labels": ["Freescale", "K20XX", "K20DX256"],
+        "OUTPUT_EXT": "hex",
+        "is_disk_virtual": true,
+        "supported_toolchains": ["GCC_ARM", "ARM"],
+        "post_binary_hook": {
+            "function": "TEENSY3_1Code.binary_hook",
+            "toolchains": ["ARM_STD", "ARM_MICRO", "GCC_ARM"]
+        },
+        "progen": {"target": "teensy-31"},
+        "detect_code": ["0230"]
+    },
+    "K22F": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "extra_labels": ["Freescale", "KSDK2_MCUS", "FRDM", "KPSDK_MCUS", "KPSDK_CODE"],
+        "is_disk_virtual": true,
+        "macros": ["CPU_MK22FN512VLH12", "FSL_RTOS_MBED"],
+        "inherits": ["Target"],
+        "progen": {"target": "frdm-k22f"},
+        "detect_code": ["0231"]
+    },
+    "KL27Z": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "extra_labels": ["Freescale", "KSDK2_MCUS", "FRDM"],
+        "macros": ["CPU_MKL27Z64VLH4", "FSL_RTOS_MBED"],
+        "supported_toolchains": ["ARM","GCC_ARM","IAR"],
+        "supported_form_factors": ["ARDUINO"],
+        "is_disk_virtual": true,
+        "default_toolchain": "ARM",
+        "detect_code": ["0261"],
+        "progen_target": {"target":"frdm-kl27z"}
+    },
+    "K64F": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "extra_labels": ["Freescale", "KSDK2_MCUS", "FRDM", "KPSDK_MCUS", "KPSDK_CODE", "MCU_K64F"],
+        "is_disk_virtual": true,
+        "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"],
+        "inherits": ["Target"],
+        "progen": {"target": "frdm-k64f"},
+        "detect_code": ["0240"]
+    },
+    "MTS_GAMBIT": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "GCC_ARM"],
+        "extra_labels": ["Freescale", "KSDK2_MCUS", "K64F", "KPSDK_MCUS", "KPSDK_CODE", "MCU_K64F"],
+        "is_disk_virtual": true,
+        "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"],
+        "progen": {"target": "mts-gambit"}
+    },
+    "HEXIWEAR": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "extra_labels": ["Freescale", "KSDK2_MCUS", "K64F"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"],
+        "is_disk_virtual": true,
+        "default_toolchain": "ARM",
+        "detect_code": ["0214"],
+        "progen": {"target":"hexiwear-k64f"}
+    },
+    "NUCLEO_F030R8": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F030R8"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f030r8"},
+        "detect_code": ["0725"]
+    },
+    "NUCLEO_F031K6": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F031K6"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f031k6"},
+        "detect_code": ["0791"]
+    },
+    "NUCLEO_F042K6": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F042K6"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f042k6"},
+        "detect_code": ["0785"]
+    },
+    "NUCLEO_F070RB": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F070RB"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f070rb"},
+        "detect_code": ["0755"]
+    },
+    "NUCLEO_F072RB": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F072RB"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f072rb"},
+        "detect_code": ["0730"]
+    },
+    "NUCLEO_F091RC": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F091RC"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f091rc"},
+        "detect_code": ["0750"]
+    },
+    "NUCLEO_F103RB": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M3",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F1", "STM32F103RB"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f103rb"},
+        "detect_code": ["0700"]
+    },
+    "NUCLEO_F302R8": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3", "STM32F302R8"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f302r8"},
+        "detect_code": ["0705"]
+    },
+    "NUCLEO_F303K8": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3", "STM32F303K8"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f303k8"},
+        "detect_code": ["0775"]
+    },
+    "NUCLEO_F303RE": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3", "STM32F303RE"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f303re"},
+        "detect_code": ["0745"]
+    },
+    "NUCLEO_F334R8": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3", "STM32F334R8"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f334r8"},
+        "detect_code": ["0735"]
+    },
+    "NUCLEO_F401RE": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F401RE"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f401re"},
+        "detect_code": ["0720"]
+    },
+    "NUCLEO_F410RB": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F410RB"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f410rb"},
+        "detect_code": ["0740"]
+    },
+    "NUCLEO_F411RE": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f411re"},
+        "detect_code": ["0740"]
+    },
+    "ELMO_F411RE": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "inherits": ["Target"],
+        "detect_code": ["----"]
+    },
+    "NUCLEO_F446RE": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F446RE"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-f446re"},
+        "detect_code": ["0777"]
+    },
+    "B96B_F446VE": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F446VE"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "detect_code": ["0840"]
+    },
+    "NUCLEO_F746ZG": {
+        "inherits": ["Target"],
+        "core": "Cortex-M7F",
+        "extra_labels": ["STM", "STM32F7", "STM32F746", "STM32F746ZG"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "progen": {
+            "target": "nucleo-f746zg",
+            "iar": {
+                "template": ["iar_nucleo_f746zg.ewp.tmpl"]
+            }
+        },
+        "detect_code": ["0816"]
+    },
+    "NUCLEO_L031K6": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0",
+        "extra_labels": ["STM", "STM32L0", "STM32L031K6"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "default_toolchain": "uARM",
+        "supported_form_factors": ["ARDUINO"],
+        "detect_code": ["0790"],
+        "progen": {"target":"nucleo-l031k6"}
+    },
+    "NUCLEO_L053R8": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L0", "STM32L053R8"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-l053r8"},
+        "detect_code": ["0715"]
+    },
+    "NUCLEO_L073RZ": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L0", "STM32L073RZ"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-l073rz"},
+        "detect_code": ["0760"]
+    },
+    "NUCLEO_L152RE": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M3",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L1", "STM32L152RE"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-l152re"},
+        "detect_code": ["0710"]
+    },
+    "NUCLEO_L476RG": {
+        "supported_form_factors": ["ARDUINO", "MORPHO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L4", "STM32L476RG"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "nucleo-l476rg"},
+        "detect_code": ["0765"]
+    },
+    "STM32F3XX": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3XX"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"]
+    },
+    "STM32F407": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "extra_labels": ["STM", "STM32F4", "STM32F4XX"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"]
+    },
+    "ARCH_MAX": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "program_cycle_s": 2,
+        "extra_labels": ["STM", "STM32F4", "STM32F407", "STM32F407VG"],
+        "macros": ["LSI_VALUE=32000"],
+        "inherits": ["Target"],
+        "progen": {"target": "lpc1768"}
+    },
+    "DISCO_F051R8": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F0", "STM32F051", "STM32F051R8"],
+        "supported_toolchains": ["GCC_ARM"]
+    },
+    "DISCO_F100RB": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F1", "STM32F100RB"],
+        "supported_toolchains": ["GCC_ARM"]
+    },
+    "DISCO_F303VC": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3", "STM32F303", "STM32F303VC"],
+        "supported_toolchains": ["GCC_ARM"]
+    },
+    "DISCO_F334C8": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F3", "STM32F334C8"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "progen": {"target": "disco-f334c8"},
+        "detect_code": ["0810"]
+    },
+    "DISCO_F407VG": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "progen": {"target": "disco-f407vg"},
+        "extra_labels": ["STM", "STM32F4", "STM32F407", "STM32F407VG"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"]
+    },
+    "DISCO_F429ZI": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F429", "STM32F429ZI"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "progen": {"target": "disco-f429zi"}
+    },
+    "DISCO_F469NI": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F469", "STM32F469NI"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "disco-f469ni"},
+        "detect_code": ["0788"]
+    },
+    "DISCO_L053C8": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L0", "STM32L053C8"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "progen": {"target": "disco-l053c8"}
+    },
+    "DISCO_F746NG": {
+        "inherits": ["Target"],
+        "core": "Cortex-M7F",
+        "extra_labels": ["STM", "STM32F7", "STM32F746", "STM32F746NG"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "progen": {"target": "disco-f746ng"},
+        "detect_code": ["0815"]
+    },
+    "DISCO_L476VG": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L4", "STM32L476VG"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "progen": {"target": "disco-l476vg"},
+        "detect_code": ["0820"]
+    },
+    "MTS_MDOT_F405RG": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "extra_labels": ["STM", "STM32F4", "STM32F405RG"],
+        "is_disk_virtual": true,
+        "macros": ["HSE_VALUE=26000000", "OS_CLOCK=48000000"],
+        "progen": {"target": "mts-mdot-f405rg"}
+    },
+    "MTS_MDOT_F411RE": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
+        "macros": ["HSE_VALUE=26000000", "OS_CLOCK=96000000", "USE_PLL_HSE_EXTC=0", "VECT_TAB_OFFSET=0x00010000"],
+        "post_binary_hook": {
+            "function": "MTSCode.combine_bins_mts_dot",
+            "toolchains": ["GCC_ARM", "ARM_STD", "ARM_MICRO"]
+        },
+        "progen": {"target": "mts-mdot-f411re"}
+    },
+    "MTS_DRAGONFLY_F411RE": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
+        "macros": ["HSE_VALUE=26000000", "VECT_TAB_OFFSET=0x08010000"],
+         "post_binary_hook": {
+            "function": "MTSCode.combine_bins_mts_dragonfly",
+            "toolchains": ["GCC_ARM", "ARM_STD", "ARM_MICRO"]
+        },
+        "progen": {"target": "mts-dragonfly-f411re"}
+    },
+    "MOTE_L152RC": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "default_toolchain": "uARM",
+        "extra_labels": ["STM", "STM32L1", "STM32L152RC"],
+        "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
+        "progen": {"target": "stm32l151rc"},
+        "detect_code": ["4100"]
+    },
+    "DISCO_F401VC": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "GCC_ARM",
+        "extra_labels": ["STM", "STM32F4", "STM32F401", "STM32F401VC"],
+        "supported_toolchains": ["GCC_ARM"]
+    },
+    "UBLOX_C029": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M4F",
+        "default_toolchain": "uARM",
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI"],
+        "macros": ["HSE_VALUE=24000000", "HSE_STARTUP_TIMEOUT=5000"],
+        "inherits": ["Target"]
+    },
+    "NZ32_SC151": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "default_toolchain": "uARM",
+        "program_cycle_s": 1.5,
+        "extra_labels": ["STM", "STM32L1", "STM32L151RC"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
+        "progen": {"target": "stm32l151rc"}
+    },
+    "MCU_NRF51": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0",
+        "OVERRIDE_BOOTLOADER_FILENAME": "nrf51822_bootloader.hex",
+        "macros": ["NRF51", "TARGET_NRF51822"],
+        "MERGE_BOOTLOADER": false,
+        "extra_labels": ["NORDIC", "MCU_NRF51", "MCU_NRF51822"],
+        "OUTPUT_EXT": "hex",
+        "is_disk_virtual": true,
+        "supported_toolchains": ["ARM", "GCC_ARM"],
+        "public": false,
+        "MERGE_SOFT_DEVICE": true,
+        "EXPECTED_SOFTDEVICES_WITH_OFFSETS": [
+            {
+                "boot": "s130_nrf51_1.0.0_bootloader.hex",
+                "name": "s130_nrf51_1.0.0_softdevice.hex",
+                "offset": 114688
+            },
+            {
+                "boot": "s110_nrf51822_8.0.0_bootloader.hex",
+                "name": "s110_nrf51822_8.0.0_softdevice.hex",
+                "offset": 98304
+            },
+            {
+                "boot": "s110_nrf51822_7.1.0_bootloader.hex",
+                "name": "s110_nrf51822_7.1.0_softdevice.hex",
+                "offset": 90112
+            },
+            {
+                "boot": "s110_nrf51822_7.0.0_bootloader.hex",
+                "name": "s110_nrf51822_7.0.0_softdevice.hex",
+                "offset": 90112
+            },
+            {
+                "boot": "s110_nrf51822_6.0.0_bootloader.hex",
+                "name": "s110_nrf51822_6.0.0_softdevice.hex",
+                "offset": 81920
+            }
+        ],
+        "detect_code": ["1070"],
+        "post_binary_hook": {
+            "function": "MCU_NRF51Code.binary_hook",
+            "toolchains": ["ARM_STD", "GCC_ARM"]
+        },
+        "program_cycle_s": 6
+    },
+    "MCU_NRF51_16K_BASE": {
+        "inherits": ["MCU_NRF51"],
+        "extra_labels_add": ["MCU_NORDIC_16K", "MCU_NRF51_16K"],
+        "macros_add": ["TARGET_MCU_NORDIC_16K", "TARGET_MCU_NRF51_16K"],
+        "public": false
+    },
+    "MCU_NRF51_16K_BOOT_BASE": {
+        "inherits": ["MCU_NRF51_16K_BASE"],
+        "MERGE_BOOTLOADER": true,
+        "extra_labels_add": ["MCU_NRF51_16K_BOOT"],
+        "macros_add": ["TARGET_MCU_NRF51_16K_BOOT", "TARGET_OTA_ENABLED"],
+        "public": false
+    },
+    "MCU_NRF51_16K_OTA_BASE": {
+        "inherits": ["MCU_NRF51_16K_BASE"],
+        "public": false,
+        "extra_labels_add": ["MCU_NRF51_16K_OTA"],
+        "macros_add": ["TARGET_MCU_NRF51_16K_OTA", "TARGET_OTA_ENABLED"],
+        "MERGE_SOFT_DEVICE": false
+    },
+    "MCU_NRF51_16K": {
+        "inherits": ["MCU_NRF51_16K_BASE"],
+        "extra_labels_add": ["MCU_NRF51_16K_S130"],
+        "macros_add": ["TARGET_MCU_NRF51_16K_S130"],
+        "public": false
+    },
+    "MCU_NRF51_S110": {
+        "extra_labels_add": ["MCU_NRF51_16K_S110"],
+        "macros_add": ["TARGET_MCU_NRF51_16K_S110"],
+        "EXPECTED_SOFTDEVICES_WITH_OFFSETS": [
+            {
+                "name"   : "s110_nrf51822_8.0.0_softdevice.hex",
+                "boot"   : "s110_nrf51822_8.0.0_bootloader.hex",
+                "offset" : 98304
+            },
+            {
+                "name"   : "s110_nrf51822_7.1.0_softdevice.hex",
+                "boot"   : "s110_nrf51822_7.1.0_bootloader.hex",
+                "offset" : 90112
+            }
+        ],
+        "public": false
+    },
+    "MCU_NRF51_16K_S110": {
+        "inherits": ["MCU_NRF51_S110", "MCU_NRF51_16K_BASE"],
+        "public": false
+    },
+    "MCU_NRF51_16K_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT_BASE"],
+        "extra_labels_add": ["MCU_NRF51_16K_S130"],
+        "macros_add": ["TARGET_MCU_NRF51_16K_S130"],
+        "public": false
+    },
+    "MCU_NRF51_16K_BOOT_S110": {
+        "inherits": ["MCU_NRF51_S110", "MCU_NRF51_16K_BOOT_BASE"],
+        "public": false
+    },
+    "MCU_NRF51_16K_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA_BASE"],
+        "extra_labels_add": ["MCU_NRF51_16K_S130"],
+        "macros_add": ["TARGET_MCU_NRF51_16K_S130"],
+        "public": false
+    },
+    "MCU_NRF51_16K_OTA_S110": {
+        "inherits": ["MCU_NRF51_S110", "MCU_NRF51_16K_OTA_BASE"],
+        "public": false
+    },
+    "MCU_NRF51_32K": {
+        "inherits": ["MCU_NRF51"],
+        "extra_labels_add": ["MCU_NORDIC_32K", "MCU_NRF51_32K"],
+        "macros_add": ["TARGET_MCU_NORDIC_32K", "TARGET_MCU_NRF51_32K"],
+        "public": false
+    },
+    "MCU_NRF51_32K_BOOT": {
+        "inherits": ["MCU_NRF51_32K"],
+        "MERGE_BOOTLOADER": true,
+        "extra_labels_add": ["MCU_NRF51_32K_BOOT"],
+        "macros_add": ["TARGET_MCU_NRF51_32K_BOOT", "TARGET_OTA_ENABLED"],
+        "public": false
+    },
+    "MCU_NRF51_32K_OTA": {
+        "inherits": ["MCU_NRF51_32K"],
+        "public": false,
+        "extra_labels_add": ["MCU_NRF51_32K_OTA"],
+        "macros_add": ["TARGET_MCU_NRF51_32K_OTA", "TARGET_OTA_ENABLED"],
+        "MERGE_SOFT_DEVICE": false
+    },
+    "NRF51822": {
+        "inherits": ["MCU_NRF51_16K"],
+        "progen": {"target": "mkit"},
+        "extra_labels_add": ["NRF51822", "NRF51822_MKIT"],
+        "macros_add": ["TARGET_NRF51822_MKIT"]
+    },
+    "NRF51822_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["NRF51822", "NRF51822_MKIT"],
+        "macros_add": ["TARGET_NRF51822_MKIT"]
+    },
+    "NRF51822_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["NRF51822", "NRF51822_MKIT"],
+        "macros_add": ["TARGET_NRF51822_MKIT"]
+    },
+    "ARCH_BLE": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K"],
+        "progen": {"target": "arch-ble"}
+    },
+    "ARCH_BLE_BOOT": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["ARCH_BLE"],
+        "macros_add": ["TARGET_ARCH_BLE"]
+    },
+    "ARCH_BLE_OTA": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["ARCH_BLE"],
+        "macros_add": ["TARGET_ARCH_BLE"]
+    },
+    "ARCH_LINK": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K"],
+        "extra_labels_add": ["ARCH_BLE"],
+        "macros_add": ["TARGET_ARCH_BLE"]
+    },
+    "ARCH_LINK_BOOT": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["ARCH_BLE", "ARCH_LINK"],
+        "macros_add": ["TARGET_ARCH_BLE", "TARGET_ARCH_LINK"]
+    },
+    "ARCH_LINK_OTA": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["ARCH_BLE", "ARCH_LINK"],
+        "macros_add": ["TARGET_ARCH_BLE", "TARGET_ARCH_LINK"]
+    },
+    "SEEED_TINY_BLE": {
+        "inherits": ["MCU_NRF51_16K"],
+        "progen": {"target": "seed-tinyble"}
+    },
+    "SEEED_TINY_BLE_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["SEEED_TINY_BLE"],
+        "macros_add": ["TARGET_SEEED_TINY_BLE"]
+    },
+    "SEEED_TINY_BLE_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["SEEED_TINY_BLE"],
+        "macros_add": ["TARGET_SEEED_TINY_BLE"]
+    },
+    "HRM1017": {
+        "inherits": ["MCU_NRF51_16K"],
+        "progen": {"target": "hrm1017"},
+        "macros_add": ["TARGET_NRF_LFCLK_RC"]
+    },
+    "HRM1017_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["HRM1017"],
+        "macros_add": ["TARGET_HRM1017", "TARGET_NRF_LFCLK_RC"]
+    },
+    "HRM1017_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["HRM1017"],
+        "macros_add": ["TARGET_HRM1017", "TARGET_NRF_LFCLK_RC"]
+    },
+    "RBLAB_NRF51822": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K"],
+        "progen": {"target": "rblab-nrf51822"}
+    },
+    "RBLAB_NRF51822_BOOT": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["RBLAB_NRF51822"],
+        "macros_add": ["TARGET_RBLAB_NRF51822"]
+    },
+    "RBLAB_NRF51822_OTA": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["RBLAB_NRF51822"],
+        "macros_add": ["TARGET_RBLAB_NRF51822"]
+    },
+    "RBLAB_BLENANO": {
+        "inherits": ["MCU_NRF51_16K"]
+    },
+    "RBLAB_BLENANO_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["RBLAB_BLENANO"],
+        "macros_add": ["TARGET_RBLAB_BLENANO"]
+    },
+    "RBLAB_BLENANO_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["RBLAB_BLENANO"],
+        "macros_add": ["TARGET_RBLAB_BLENANO"]
+    },
+    "NRF51822_Y5_MBUG": {
+        "inherits": ["MCU_NRF51_16K"]
+    },
+    "WALLBOT_BLE": {
+        "inherits": ["MCU_NRF51_16K"]
+    },
+    "WALLBOT_BLE_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["WALLBOT_BLE"],
+        "macros_add": ["TARGET_WALLBOT_BLE"]
+    },
+    "WALLBOT_BLE_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["WALLBOT_BLE"],
+        "macros_add": ["TARGET_WALLBOT_BLE"]
+    },
+    "DELTA_DFCM_NNN40": {
+        "inherits": ["MCU_NRF51_32K"],
+        "program_cycle_s": 10,
+        "progen": {"target": "dfcm-nnn40"},
+        "macros_add": ["TARGET_NRF_LFCLK_RC"]
+    },
+    "DELTA_DFCM_NNN40_BOOT": {
+        "inherits": ["MCU_NRF51_32K_BOOT"],
+        "program_cycle_s": 10,
+        "extra_labels_add": ["DELTA_DFCM_NNN40"],
+        "macros_add": ["TARGET_DELTA_DFCM_NNN40", "TARGET_NRF_LFCLK_RC"]
+    },
+    "DELTA_DFCM_NNN40_OTA": {
+        "inherits": ["MCU_NRF51_32K_OTA"],
+        "program_cycle_s": 10,
+        "extra_labels_add": ["DELTA_DFCM_NNN40"],
+        "macros_add": ["TARGET_DELTA_DFCM_NNN40", "TARGET_NRF_LFCLK_RC"]
+    },
+    "NRF51_DK": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_32K"],
+        "progen": {"target": "nrf51-dk"}
+    },
+    "NRF51_DK_BOOT": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_32K_BOOT"],
+        "extra_labels_add": ["NRF51_DK"],
+        "macros_add": ["TARGET_NRF51_DK"]
+    },
+    "NRF51_DK_OTA": {
+        "supported_form_factors": ["ARDUINO"],
+        "inherits": ["MCU_NRF51_32K_OTA"],
+        "extra_labels_add": ["NRF51_DK"],
+        "macros_add": ["TARGET_NRF51_DK"]
+    },
+    "NRF51_DONGLE": {
+        "inherits": ["MCU_NRF51_32K"],
+        "progen": {"target": "nrf51-dongle"}
+    },
+    "NRF51_DONGLE_BOOT": {
+        "inherits": ["MCU_NRF51_32K_BOOT"],
+        "extra_labels_add": ["NRF51_DONGLE"],
+        "macros_add": ["TARGET_NRF51_DONGLE"]
+    },
+    "NRF51_DONGLE_OTA": {
+        "inherits": ["MCU_NRF51_32K_OTA"],
+        "extra_labels_add": ["NRF51_DONGLE"],
+        "macros_add": ["TARGET_NRF51_DONGLE"]
+    },
+    "NRF51_MICROBIT": {
+        "inherits": ["MCU_NRF51_16K_S110"],
+        "macros_add": ["TARGET_NRF_LFCLK_RC"]
+    },
+    "NRF51_MICROBIT_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT_S110"],
+        "extra_labels_add": ["NRF51_MICROBIT"],
+        "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
+    },
+    "NRF51_MICROBIT_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA_S110"],
+        "extra_labels_add": ["NRF51_MICROBIT"],
+        "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
+    },
+    "NRF51_MICROBIT_B": {
+        "inherits": ["MCU_NRF51_16K"],
+        "extra_labels_add": ["NRF51_MICROBIT"],
+        "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
+    },
+    "NRF51_MICROBIT_B_BOOT": {
+        "inherits": ["MCU_NRF51_16K_BOOT"],
+        "extra_labels_add": ["NRF51_MICROBIT"],
+        "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
+    },
+    "NRF51_MICROBIT_B_OTA": {
+        "inherits": ["MCU_NRF51_16K_OTA"],
+        "extra_labels_add": ["NRF51_MICROBIT"],
+        "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"]
+    },
+    "TY51822R3": {
+        "inherits": ["MCU_NRF51_32K"],
+        "macros_add": ["TARGET_NRF_32MHZ_XTAL"]
+    },
+    "TY51822R3_BOOT": {
+        "inherits": ["MCU_NRF51_32K_BOOT"],
+        "extra_labels_add": ["TY51822R3"],
+        "macros_add": ["TARGET_TY51822R3", "TARGET_NRF_32MHZ_XTAL"]
+    },
+    "TY51822R3_OTA": {
+        "inherits": ["MCU_NRF51_32K_OTA"],
+        "extra_labels_add": ["NRF51_DK"],
+        "macros_add": ["TARGET_TY51822R3", "TARGET_NRF_32MHZ_XTAL"]
+    },
+    "ARM_MPS2_Target": {
+        "inherits": ["Target"],
+        "public": false
+    },
+    "ARM_MPS2_M0": {
+        "inherits": ["ARM_MPS2_Target"],
+        "core": "Cortex-M0",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0"],
+        "macros": ["CMSDK_CM0"]
+    },
+    "ARM_MPS2_M0P": {
+        "inherits": ["ARM_MPS2_Target"],
+        "core": "Cortex-M0+",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0P"],
+        "macros": ["CMSDK_CM0plus"]
+    },
+    "ARM_MPS2_M1": {
+        "inherits": ["ARM_MPS2_Target"],
+        "core": "Cortex-M1",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M1"],
+        "macros": ["CMSDK_CM1"]
+    },
+    "ARM_MPS2_M3": {
+        "inherits": ["ARM_MPS2_Target"],
+        "core": "Cortex-M3",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M3"],
+        "macros": ["CMSDK_CM3"]
+    },
+    "ARM_MPS2_M4": {
+        "inherits": ["ARM_MPS2_Target"],
+        "core": "Cortex-M4F",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M4"],
+        "macros": ["CMSDK_CM4"]
+    },
+    "ARM_MPS2_M7": {
+        "inherits": ["ARM_MPS2_Target"],
+        "core": "Cortex-M7",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M7"],
+        "macros": ["CMSDK_CM7"]
+    },
+    "ARM_IOTSS_Target": {
+        "inherits": ["Target"],
+        "public": false
+    },
+    "ARM_IOTSS_BEID": {
+        "inherits": ["ARM_IOTSS_Target"],
+        "core": "Cortex-M3",
+        "supported_toolchains": ["ARM"],
+        "extra_labels": ["ARM_SSG", "IOTSS", "IOTSS_BEID"],
+        "macros": ["CMSDK_BEID"]
+    },
+    "RZ_A1H": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-A9",
+        "program_cycle_s": 2,
+        "extra_labels": ["RENESAS", "MBRZA1H"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "inherits": ["Target"],
+        "progen": {
+            "target": "gr-peach",
+            "iar": {
+                "template": ["iar_rz_a1h.ewp.tmpl"]
+            }
+        }
+    },
+    "VK_RZ_A1H": {
+        "inherits": ["Target"],
+        "core": "Cortex-A9",
+        "extra_labels": ["RENESAS", "VKRZA1H"],
+        "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
+        "default_toolchain": "ARM",
+        "progen": {
+            "target": "vk-rza1h",
+            "iar": {
+                "template": ["iar_rz_a1h.ewp.tmpl"]
+            }
+        },
+        "program_cycle_s": 2
+    },
+    "MAXWSNENV": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "macros": ["__SYSTEM_HFX=24000000"],
+        "extra_labels": ["Maxim", "MAX32610"],
+        "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
+        "progen": {"target": "maxwsnenv"}
+    },
+    "MAX32600MBED": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "macros": ["__SYSTEM_HFX=24000000"],
+        "extra_labels": ["Maxim", "MAX32600"],
+        "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
+        "progen": {"target": "max32600mbed"}
+    },
+    "EFM32GG_STK3700": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "macros": ["EFM32GG990F1024"],
+        "extra_labels": ["Silicon_Labs", "EFM32"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "efm32gg_stk3700"}
+    },
+    "EFM32LG_STK3600": {
+        "inherits": ["Target"],
+        "core": "Cortex-M3",
+        "macros": ["EFM32LG990F256"],
+        "extra_labels": ["Silicon_Labs", "EFM32"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "efm32lg_stk3600"}
+    },
+    "EFM32WG_STK3800": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "macros": ["EFM32WG990F256"],
+        "extra_labels": ["Silicon_Labs", "EFM32"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "efm32wg_stk3800"}
+    },
+    "EFM32ZG_STK3200": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "supported_toolchains": ["GCC_ARM", "uARM"],
+        "extra_labels": ["Silicon_Labs", "EFM32"],
+        "macros": ["EFM32ZG222F32"],
+        "progen": {
+            "target": "efm32zg_stk3200",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "EFM32HG_STK3400": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "default_toolchain": "uARM",
+        "supported_toolchains": ["GCC_ARM", "uARM"],
+        "extra_labels": ["Silicon_Labs", "EFM32"],
+        "macros": ["EFM32HG322F64"],
+        "progen": {
+            "target": "efm32hg_stk3400",
+            "uvision": {
+                "template": ["uvision_microlib.uvproj.tmpl"]
+            }
+        }
+    },
+    "EFM32PG_STK3401": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4F",
+        "macros": ["EFM32PG1B200F256GM48"],
+        "extra_labels": ["Silicon_Labs", "EFM32"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM", "IAR"],
+        "progen": {"target": "efm32pg_stk3401"}
+    },
+    "WIZWIKI_W7500": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0",
+        "extra_labels": ["WIZNET", "W7500x", "WIZwiki_W7500"],
+        "supported_toolchains": ["uARM", "ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "wizwiki_w7500"}
+    },
+    "WIZWIKI_W7500P": {
+        "supported_form_factors": ["ARDUINO"],
+        "core": "Cortex-M0",
+        "extra_labels": ["WIZNET", "W7500x", "WIZwiki_W7500P"],
+        "supported_toolchains": ["uARM", "ARM"],
+        "inherits": ["Target"],
+        "progen": {"target": "wizwiki_w7500p"}
+    },
+    "WIZWIKI_W7500ECO": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0",
+        "progen": {"target": "wizwiki_w7500eco"},
+        "extra_labels": ["WIZNET", "W7500x", "WIZwiki_W7500ECO"],
+        "supported_toolchains": ["uARM", "ARM"]
+    },
+    "SAMR21G18A": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "macros": [
+            "__SAMR21G18A__",
+            "I2C_MASTER_CALLBACK_MODE=true",
+            "EXTINT_CALLBACK_MODE=true",
+            "USART_CALLBACK_MODE=true",
+            "TC_ASYNC=true"
+        ],
+        "extra_labels": ["Atmel", "SAM_CortexM0P", "SAMR21"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "samr21g18a"}
+    },
+    "SAMD21J18A": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "macros": [
+            "__SAMD21J18A__",
+            "I2C_MASTER_CALLBACK_MODE=true",
+            "EXTINT_CALLBACK_MODE=true",
+            "USART_CALLBACK_MODE=true",
+            "TC_ASYNC=true"
+        ],
+        "extra_labels": ["Atmel", "SAM_CortexM0P", "SAMD21"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "samd21j18a"}
+    },
+    "SAMD21G18A": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "macros": [
+            "__SAMD21G18A__",
+            "I2C_MASTER_CALLBACK_MODE=true",
+            "EXTINT_CALLBACK_MODE=true",
+            "USART_CALLBACK_MODE=true",
+            "TC_ASYNC=true"
+        ],
+        "extra_labels": ["Atmel", "SAM_CortexM0P", "SAMD21"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "samd21g18a"}
+    },
+    "SAML21J18A": {
+        "inherits": ["Target"],
+        "core": "Cortex-M0+",
+        "macros": [
+            "__SAML21J18A__",
+            "I2C_MASTER_CALLBACK_MODE=true",
+            "EXTINT_CALLBACK_MODE=true",
+            "USART_CALLBACK_MODE=true",
+            "TC_ASYNC=true"
+        ],
+        "extra_labels": ["Atmel", "SAM_CortexM0P", "SAML21"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "progen": {"target": "samr21j18a"},
+        "progen_target": "samr21j18a"
+    },
+    "SAMG55J19": {
+        "inherits": ["Target"],
+        "core": "Cortex-M4",
+        "extra_labels": ["Atmel", "SAM_CortexM4", "SAMG55"],
+        "macros": ["__SAMG55J19__", "BOARD=75", "I2C_MASTER_CALLBACK_MODE=true", "EXTINT_CALLBACK_MODE=true", "USART_CALLBACK_MODE=true", "TC_ASYNC=true"],
+        "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
+        "default_toolchain": "ARM",
+        "progen": {"target":"samg55j19"},
+        "progen_target": "samg55j19"
+    }
+}

--- a/workspace_tools/targets.py
+++ b/workspace_tools/targets.py
@@ -34,462 +34,213 @@ import struct
 import shutil
 from workspace_tools.patch import patch
 from paths import TOOLS_BOOTLOADERS
+import json
+import inspect
+import sys
+
+
+########################################################################################################################
+# Generic Target class that reads and interprets the data in targets.json
+
+# A simple class that represents all the exceptions associated with hooking
+class HookError(Exception):
+    pass
+
+# A simple decorator used for automatically caching data returned by a function
+caches = {}
+def cached(func):
+    def wrapper(*args, **kwargs):
+        if not caches.has_key(func):
+            caches[func] = func(*args, **kwargs)
+        return caches[func]
+    return wrapper
 
 class Target:
-    def __init__(self):
-        # ARM Core
-        self.core = None
+    # Cumulative attributes can have values appended to them, so they
+    # need to be computed differently than regular attributes
+    __cumulative_attributes = ['extra_labels', 'macros']
 
-        # Is the disk provided by the interface chip of this board virtual?
-        self.is_disk_virtual = False
+    # Utility function: traverse a dictionary and change all the strings in the dictionary to
+    # ASCII from Unicode. Needed because the original mbed target definitions were written in
+    # Python and used only ASCII strings, but the Python JSON decoder always returns Unicode
+    # Based on http://stackoverflow.com/a/13105359
+    @staticmethod
+    def to_ascii(input):
+        if isinstance(input, dict):
+            return dict([(Target.to_ascii(key), Target.to_ascii(value)) for key, value in input.iteritems()])
+        elif isinstance(input, list):
+            return [Target.to_ascii(element) for element in input]
+        elif isinstance(input, unicode):
+            return input.encode('ascii')
+        else:
+            return input
 
-        # list of toolchains that are supported by the mbed SDK for this target
-        self.supported_toolchains = None
+    # Load the description of JSON target data
+    @staticmethod
+    @cached
+    def get_json_target_data():
+        with open(os.path.join(os.path.dirname(os.path.abspath(__file__)), "targets.json"), "rt") as f:
+            return Target.to_ascii(json.load(f))
 
-        # list of extra specific labels
-        self.extra_labels = []
+    # Get the members of this module using Python's "inspect" module
+    @staticmethod
+    @cached
+    def get_module_data():
+        return dict([(m[0], m[1]) for m in inspect.getmembers(sys.modules[__name__])])
 
-        # list of macros (-D)
-        self.macros = []
+    # Return the order in which target descriptions are searched for attributes
+    # This mimics the Python 2.2 method resolution order, which is what the old targets.py module used
+    # For more details, check http://makina-corpus.com/blog/metier/2014/python-tutorial-understanding-python-mro-class-search-path
+    # The resolution order contains (name, level) tuples, where "name" is the name of the class and "level"
+    # is the level in the inheritance hierarchy (the target itself is at level 0, its first parent at level 1,
+    # its parent's parent at level 1 and so on)
+    def __get_resolution_order(self, target_name, order, level = 0):
+        if not target_name in [l[0] for l in order]: # the resolution order can't contain duplicate target names
+            order.append((target_name, level))
+        parents = self.get_json_target_data()[target_name].get("inherits", [])
+        for p in parents:
+            order = self.__get_resolution_order(p, order, level + 1)
+        return order
 
-        # Default online compiler:
-        self.default_toolchain = "ARM"
+    # Modify the exporter specification ("progen") by changing all "template" keys to full paths
+    @staticmethod
+    def __add_paths_to_progen(data):
+        out = {}
+        for key, value in data.items():
+            if isinstance(value, dict):
+                out[key] = Target.__add_paths_to_progen(value)
+            elif key == "template":
+                out[key] = [os.path.join(os.path.dirname(__file__), 'export', v) for v in value]
+            else:
+                out[key] = value
+        return out
 
-        self.name = self.__class__.__name__
+    # Comute the value of a given target attribute
+    def __getattr_helper(self, attrname):
+        tdata = self.get_json_target_data()
+        if attrname in self.__cumulative_attributes:
+            # For a cumulative attribute, figure out when it was defined the last time (in attribute
+            # resolution order) then follow the "_add" and "_remove" data fields
+            for idx, t in enumerate(self.resolution_order):
+                if attrname in tdata[t[0]]: # the attribute was defined at this level in the resolution order
+                    def_idx = idx
+                    break
+            else:
+                raise AttributeError("Attribute '%s' not found in target '%s'" % (attrname, self.name))
+            # Get the starting value of the attribute
+            v = (tdata[self.resolution_order[def_idx][0]][attrname] or [])[:]
+            # Traverse the resolution list in high inheritance to low inheritance level, left to right order
+            # to figure out all the other classes that change the definition by adding or removing elements
+            for idx in xrange(self.resolution_order[def_idx][1] - 1, -1, -1):
+                same_level_targets = [t[0] for t in self.resolution_order if t[1] == idx]
+                for t in same_level_targets:
+                    data = tdata[t]
+                    # Do we have anything to add ?
+                    if data.has_key(attrname + "_add"):
+                        v.extend(data[attrname + "_add"])
+                    # Do we have anything to remove ?
+                    if data.has_key(attrname + "_remove"):
+                        # Macros can be defined either without a value (MACRO) or with a value (MACRO=10).
+                        # When removing, we specify only the name of the macro, without the value. So we need
+                        # to create a mapping between the macro name and its value. This will work for
+                        # extra_labels and other type of arrays as well, since they fall into the "macros
+                        # without a value" category (simple definitions without a value).
+                        name_def_map = {}
+                        for crtv in v:
+                            if crtv.find('=') != -1:
+                                temp = crtv.split('=')
+                                if len(temp) != 2:
+                                    raise ValueError("Invalid macro definition '%s'" % crtv)
+                                name_def_map[temp[0]] = crtv
+                            else:
+                                name_def_map[crtv] = crtv
+                        for e in data[attrname + "_remove"]:
+                            if not e in name_def_map:
+                                raise ValueError("Unable to remove '%s' in '%s.%s' since it doesn't exist" % (e, self.name, attrname))
+                            v.remove(name_def_map[e])
+            return v
+        # Look for the attribute in the class and its parents, as defined by the resolution order
+        v = None
+        for t in self.resolution_order:
+            data = tdata[t[0]]
+            if data.has_key(attrname):
+                v = data[attrname]
+                break
+        else: # Attribute not found
+            raise AttributeError("Attribute '%s' not found in target '%s'" % (attrname, self.name))
+        # 'progen' needs the full path to the template (the path in JSON is relative to workspace_tools/export)
+        return v if attrname != "progen" else self.__add_paths_to_progen(v)
 
-        # Code used to determine devices' platform
-        # This code is prefix in URL link provided in mbed.htm (in mbed disk)
-        self.detect_code = []
+    # Return the value of an attribute
+    # This function only looks for the attribute's value in the cache, the real work of computing the
+    # attribute's value is done in the function above (__getattr_helper)
+    def __getattr__(self, attrname):
+        if not self.attr_cache.has_key(attrname):
+            self.attr_cache[attrname] = self.__getattr_helper(attrname)
+        return self.attr_cache[attrname]
+
+    def __init__(self, name):
+        self.name = name
+
+        # Compute resolution order once (it will be used later in __getattr__)
+        self.resolution_order = self.__get_resolution_order(self.name, [])
+
+        # Attribute cache: once an attribute's value is computed, don't compute it again
+        self.attr_cache = {}
 
     def program_cycle_s(self):
-        return 4 if self.is_disk_virtual else 1.5
+        try:
+            return self.__getattr__("program_cycle_s")
+        except AttributeError:
+            return 4 if self.is_disk_virtual else 1.5
 
     def get_labels(self):
         return [self.name] + CORE_LABELS[self.core] + self.extra_labels
 
+    # For now, this function only allows "post binary" hooks (hooks that are executed after
+    # the binary image is extracted from the executable file)
     def init_hooks(self, hook, toolchain_name):
-        pass
+        # If there's no hook, simply return
+        try:
+            hook_data = self.post_binary_hook
+        except AttributeError:
+            return
+        # A hook was found. The hook's name is in the format "classname.functionname"
+        temp = hook_data["function"].split(".")
+        if len(temp) != 2:
+            raise HookError("Invalid format for hook '%s' in target '%s' (must be 'class_name.function_name')" % (hook_data["function"], self.name))
+        class_name, function_name = temp[0], temp[1]
+        # "class_name" must refer to a class in this file, so check if the class exists
+        mdata = self.get_module_data()
+        if not mdata.has_key(class_name) or not inspect.isclass(mdata[class_name]):
+            raise HookError("Class '%s' required by '%s' in target '%s' not found in targets.py" % (class_name, hook_data["function"], self.name))
+        # "function_name" must refer to a static function inside class "class_name"
+        cls = mdata[class_name]
+        if (not hasattr(cls, function_name)) or (not inspect.isfunction(getattr(cls, function_name))):
+            raise HookError("Static function '%s' required by '%s' in target '%s' not found in class '%s'" % (function_name, hook_data["function"], self.name, class_name))
+        # Check if the hook specification also has target restrictions
+        toolchain_restrictions = hook_data.get("toolchains", [])
+        if toolchain_restrictions and (toolchain_name not in toolchain_restrictions):
+            return
+        # Finally, hook the requested function
+        hook.hook_add_binary("post", getattr(cls, function_name))
 
+########################################################################################################################
+# Target specific code goes in this section
+# This code can be invoked from the target description using the "post_binary_hook" key
 
-### MCU Support ###
-
-class CM4_UARM(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4"
-        self.supported_toolchains = ["uARM"]
-        self.default_toolchain = "uARM"
-
-class CM4_ARM(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4"
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class CM4F_UARM(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.supported_toolchains = ["uARM"]
-        self.default_toolchain = "uARM"
-
-class CM4F_ARM(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-
-### NXP ###
-
-# This class implements the post-link patching step needed by LPC targets
-class LPCTarget(Target):
-    def __init__(self):
-        Target.__init__(self)
-
-    def init_hooks(self, hook, toolchain_name):
-        hook.hook_add_binary("post", self.lpc_patch)
-
+class LPCTargetCode:
     @staticmethod
     def lpc_patch(t_self, resources, elf, binf):
         t_self.debug("LPC Patch: %s" % os.path.split(binf)[1])
         patch(binf)
 
-class LPC11C24(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11XX_11CXX', 'LPC11CXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-
-        self.progen = {
-            "target":"lpc11c24_301",
-        }
-
-class LPC1114(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11XX_11CXX', 'LPC11XX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc1114_102",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U24(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX', 'LPC11U24_401']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.detect_code = ["1040"]
-        self.progen = {
-            "target":"lpc11u24_201",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class OC_MBUINO(LPC11U24):
-    def __init__(self):
-        LPC11U24.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX']
-        self.macros = ['TARGET_LPC11U24']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u24_201",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U24_301(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-
-class LPC11U34_421(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-
-class MICRONFCBOARD(LPC11U34_421):
-    def __init__(self):
-        LPC11U34_421.__init__(self)
-        self.macros = ['LPC11U34_421', 'APPNEARME_MICRONFCBOARD']
-        self.extra_labels = ['NXP', 'LPC11UXX', 'APPNEARME_MICRONFCBOARD']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-
-class LPC11U35_401(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u35_401",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U35_501(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX', 'MCU_LPC11U35_501']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR" , "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u35_501",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U35_501_IBDAP(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX', 'MCU_LPC11U35_501']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR" , "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u35_501",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class XADOW_M0(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX', 'MCU_LPC11U35_501']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u35_501",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U35_Y5_MBUG(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX', 'MCU_LPC11U35_501']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR" , "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u35_501",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U37_501(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"lpc11u37_501",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPCCAPPUCCINO(LPC11U37_501):
-    def __init__(self):
-        LPC11U37_501.__init__(self)
-
-class ARCH_GPRS(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX', 'LPC11U37_501']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"lpc11u37_501",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC11U68(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['NXP', 'LPC11U6X']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_CR", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["1168"]
-        self.progen = {
-            "target":"lpc11u68",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC1347(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC13XX']
-        self.supported_toolchains = ["ARM", "GCC_ARM","IAR"]
-        self.progen = {
-            "target":"lpc1347",
-        }
-
-class LPC1549(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC15XX']
-        self.supported_toolchains = ["uARM", "GCC_CR", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["1549"]
-        self.progen = {
-            "target":"lpc1549",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC1768(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC176X', 'MBED_LPC1768']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.detect_code = ["1010"]
-        self.progen = {
-            "target":"mbed-lpc1768",
-        }
-
-class ARCH_PRO(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC176X']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.macros = ['TARGET_LPC1768']
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"arch-pro",
-        }
-
-class UBLOX_C027(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC176X']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.macros = ['TARGET_LPC1768']
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"ublox-c027",
-        }
-
-class XBED_LPC1768(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC176X', 'XBED_LPC1768']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR", "IAR"]
-        self.macros = ['TARGET_LPC1768']
-        self.detect_code = ["1010"]
-        self.progen = {
-            "target":"lpc1768",
-        }
-
-class LPC2368(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "ARM7TDMI-S"
-        self.extra_labels = ['NXP', 'LPC23XX']
-        self.supported_toolchains = ["ARM", "GCC_ARM", "GCC_CR"]
-        self.progen = {
-            "target":"lpc2368",
-        }
-
-class LPC2460(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "ARM7TDMI-S"
-        self.extra_labels = ['NXP', 'LPC2460']
-        self.supported_toolchains = ["GCC_ARM"]
-        self.progen = {
-            "target":"lpc2460",
-        }
-
-class LPC810(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['NXP', 'LPC81X']
-        self.supported_toolchains = ["uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"lpc810",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC812(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['NXP', 'LPC81X']
-        self.supported_toolchains = ["uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.detect_code = ["1050"]
-        self.progen = {
-            "target":"lpc812m101",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC824(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['NXP', 'LPC82X']
-        self.supported_toolchains = ["uARM", "GCC_ARM","GCC_CR", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"lpc824m201",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class SSCI824(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['NXP', 'LPC82X']
-        self.supported_toolchains = ["uARM", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"ssci824",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class LPC4088(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['NXP', 'LPC408X']
-        self.supported_toolchains = ["ARM", "GCC_CR", "GCC_ARM", "IAR"]
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"lpc4088",
-        }
-
-    def init_hooks(self, hook, toolchain_name):
-        if toolchain_name in ['ARM_STD', 'ARM_MICRO']:
-            hook.hook_add_binary("post", self.binary_hook)
-
+class LPC4088Code:
     @staticmethod
     def binary_hook(t_self, resources, elf, binf):
         if not os.path.isdir(binf):
             # Regular binary file, nothing to do
-            LPCTarget.lpc_patch(t_self, resources, elf, binf)
+            LPCTargetCode.lpc_patch(t_self, resources, elf, binf)
             return
         outbin = open(binf + ".temp", "wb")
         partf = open(os.path.join(binf, "ER_IROM1"), "rb")
@@ -513,229 +264,9 @@ class LPC4088(LPCTarget):
         shutil.rmtree(binf, True)
         os.rename(binf + '.temp', binf)
         t_self.debug("Generated custom binary file (internal flash + SPIFI)")
-        LPCTarget.lpc_patch(t_self, resources, elf, binf)
+        LPCTargetCode.lpc_patch(t_self, resources, elf, binf)
 
-class LPC4088_DM(LPC4088):
-    pass
-
-class LPC4330_M4(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['NXP', 'LPC43XX', 'LPC4330']
-        self.supported_toolchains = ["ARM", "GCC_CR", "IAR", "GCC_ARM"]
-        self.progen = {
-            "target":"lpc4330",
-        }
-
-class LPC4330_M0(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC43XX', 'LPC4330']
-        self.supported_toolchains = ["ARM", "GCC_CR", "IAR"]
-
-class LPC4337(LPCTarget):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['NXP', 'LPC43XX', 'LPC4337']
-        self.supported_toolchains = ["ARM"]
-        self.progen = {
-            "target":"lpc4337",
-        }
-
-class LPC1800(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['NXP', 'LPC43XX']
-        self.supported_toolchains = ["ARM", "GCC_CR", "IAR"]
-
-class LPC11U37H_401(LPCTarget):
-    def __init__(self):
-        LPCTarget.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['NXP', 'LPC11UXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "GCC_CR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"lpc11u37_401",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-### Freescale ###
-
-class KL05Z(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Freescale', 'KLXX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"frdm-kl05z",
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-class KL25Z(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Freescale', 'KLXX']
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.detect_code = ["0200"]
-        self.progen = {
-            "target":"frdm-kl25z",
-        }
-
-class KL26Z(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Freescale', 'KLXX']
-        self.supported_toolchains = ["ARM","GCC_ARM","IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"kl26z",
-        }
-
-class KL43Z(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Freescale', 'KLXX']
-        self.supported_toolchains = ["GCC_ARM", "ARM"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.progen = {
-            "target":"frdm-kl43z",
-        }
-
-class KL46Z(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Freescale', 'KLXX']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.detect_code = ["0220"]
-        self.progen = {
-            "target":"frdm-kl46z",
-        }
-
-class K20D50M(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4"
-        self.extra_labels = ['Freescale', 'K20XX']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "IAR"]
-        self.is_disk_virtual = True
-        self.detect_code = ["0230"]
-        self.progen = {
-            "target":"frdm-k20d50m",
-        }
-
-class K22F(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM', 'KPSDK_MCUS', 'KPSDK_CODE']
-        self.macros = ["CPU_MK22FN512VLH12", "FSL_RTOS_MBED"]
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.detect_code = ["0231"]
-        self.progen = {
-            "target":"frdm-k22f",
-        }
-
-class KL27Z(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM']
-        self.macros = ["CPU_MKL27Z64VLH4", "FSL_RTOS_MBED"]
-        self.supported_toolchains = ["ARM","GCC_ARM","IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.default_toolchain = "ARM"
-        self.detect_code = ["0261"]
-        self.progen_target = {
-            "target":"frdm-kl27z",
-        }
-
-class K64F(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'FRDM', 'KPSDK_MCUS', 'KPSDK_CODE', 'MCU_K64F']
-        self.macros = ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED"]
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.is_disk_virtual = True
-        self.default_toolchain = "ARM"
-        self.detect_code = ["0240"]
-        self.progen = {
-            "target":"frdm-k64f",
-        }
-
-class MTS_GAMBIT(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'K64F', 'KPSDK_MCUS', 'KPSDK_CODE', 'MCU_K64F']
-        self.supported_toolchains = ["ARM", "GCC_ARM"]
-        self.macros = ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"]
-        self.is_disk_virtual = True
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"mts-gambit",
-        }
-
-class HEXIWEAR(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['Freescale', 'KSDK2_MCUS', 'K64F']
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-        self.macros = ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"]
-        self.is_disk_virtual = True
-        self.default_toolchain = "ARM"
-        self.detect_code = ["0214"]
-        self.progen = {
-            "target":"hexiwear-k64f",
-        }
-
-class TEENSY3_1(Target):
-    OUTPUT_EXT = 'hex'
-
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4"
-        self.extra_labels = ['Freescale', 'K20XX', 'K20DX256']
-        self.supported_toolchains = ["GCC_ARM", "ARM"]
-        self.is_disk_virtual = True
-        self.detect_code = ["0230"]
-        self.progen = {
-            "target":"teensy-31",
-        }
-
-    def init_hooks(self, hook, toolchain_name):
-        if toolchain_name in ['ARM_STD', 'ARM_MICRO', 'GCC_ARM']:
-            hook.hook_add_binary("post", self.binary_hook)
-
+class TEENSY3_1Code:
     @staticmethod
     def binary_hook(t_self, resources, elf, binf):
         from intelhex import IntelHex
@@ -745,471 +276,10 @@ class TEENSY3_1(Target):
         with open(binf.replace(".bin", ".hex"), "w") as f:
             binh.tofile(f, format='hex')
 
-### STMicro ###
-
-class NUCLEO_F030R8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F030R8']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0725"]
-        self.progen = {
-            "target":"nucleo-f030r8",
-        }
-
-class NUCLEO_F031K6(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F031K6']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["0791"]
-        self.progen = {
-            "target":"nucleo-f031k6",
-        }
-
-class NUCLEO_F042K6(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F042K6']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["0785"]
-        self.progen = {
-            "target":"nucleo-f042k6",
-        }
-
-class NUCLEO_F070RB(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F070RB']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0755"]
-        self.progen = {
-            "target":"nucleo-f070rb",
-        }
-
-class NUCLEO_F072RB(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F072RB']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0730"]
-        self.progen = {
-            "target":"nucleo-f072rb",
-        }
-
-class NUCLEO_F091RC(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F091RC']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0750"]
-        self.progen = {
-            "target":"nucleo-f091rc",
-        }
-
-class NUCLEO_F103RB(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['STM', 'STM32F1', 'STM32F103RB']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0700"]
-        self.progen = {
-            "target":"nucleo-f103rb",
-        }
-
-class NUCLEO_F302R8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F3', 'STM32F302R8']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0705"]
-        self.progen = {
-            "target":"nucleo-f302r8",
-        }
-
-class NUCLEO_F303K8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F3', 'STM32F303K8']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["0775"]
-        self.progen = {
-            "target":"nucleo-f303k8",
-        }
-
-class NUCLEO_F303RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F3', 'STM32F303RE']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0745"]
-        self.progen = {
-            "target":"nucleo-f303re",
-        }
-
-class NUCLEO_F334R8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F3', 'STM32F334R8']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0735"]
-        self.progen = {
-            "target":"nucleo-f334r8",
-        }
-
-class NUCLEO_F401RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F401RE']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0720"]
-        self.progen = {
-            "target":"nucleo-f401re",
-        }
-
-class NUCLEO_F410RB(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F410RB']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0740"]
-        self.progen = {
-            "target":"nucleo-f410rb",
-        }
-
-class NUCLEO_F411RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F411RE']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0740"]
-        self.progen = {
-            "target":"nucleo-f411re",
-        }
-
-class ELMO_F411RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F411RE']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["----"]
-
-class NUCLEO_F446RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F446RE']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0777"]
-        self.progen = {
-            "target":"nucleo-f446re",
-        }
-
-class B96B_F446VE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F446VE']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0840"]
-
-class NUCLEO_F746ZG(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M7F"
-        self.extra_labels = ['STM', 'STM32F7', 'STM32F746', 'STM32F746ZG']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.detect_code = ["0816"]
-        self.progen = {
-            "target":"nucleo-f746zg",
-            "iar": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'iar_nucleo_f746zg.ewp.tmpl')],
-            }
-        }
-
-class NUCLEO_L031K6(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32L0', 'STM32L031K6']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["0790"]
-        self.progen = {
-            "target":"nucleo-l031k6",
-        }
-
-class NUCLEO_L053R8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['STM', 'STM32L0', 'STM32L053R8']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0715"]
-        self.progen = {
-            "target":"nucleo-l053r8",
-        }
-
-class NUCLEO_L073RZ(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['STM', 'STM32L0', 'STM32L073RZ']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0760"]
-        self.progen = {
-            "target":"nucleo-l073rz",
-        }
-
-
-class NUCLEO_L152RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['STM', 'STM32L1', 'STM32L152RE']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0710"]
-        self.progen = {
-            "target":"nucleo-l152re",
-        }
-
-class NUCLEO_L476RG(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32L4', 'STM32L476RG']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO", "MORPHO"]
-        self.detect_code = ["0765"]
-        self.progen = {
-            "target":"nucleo-l476rg",
-        }
-
-class STM32F3XX(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4"
-        self.extra_labels = ['STM', 'STM32F3XX']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-
-class STM32F407(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F4XX']
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-
-class ARCH_MAX(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F407', 'STM32F407VG']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.macros = ['LSI_VALUE=32000']
-        self.progen = {
-            "target":"lpc1768",
-        }
-    def program_cycle_s(self):
-        return 2
-
-class DISCO_F051R8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['STM', 'STM32F0', 'STM32F051', 'STM32F051R8']
-        self.supported_toolchains = ["GCC_ARM"]
-        self.default_toolchain = "uARM"
-
-class DISCO_F100RB(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['STM', 'STM32F1', 'STM32F100RB']
-        self.supported_toolchains = ["GCC_ARM"]
-        self.default_toolchain = "uARM"
-
-class DISCO_F303VC(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F3', 'STM32F303', 'STM32F303VC']
-        self.supported_toolchains = ["GCC_ARM"]
-        self.default_toolchain = "uARM"
-
-class DISCO_F334C8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F3', 'STM32F334C8']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.detect_code = ["0810"]
-        self.progen = {
-            "target":"disco-f334c8",
-        }
-
-class DISCO_F407VG(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F407', 'STM32F407VG']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.progen = {
-            "target":"disco-f407vg",
-        }
-        self.default_toolchain = "ARM"
-
-class DISCO_F429ZI(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F429', 'STM32F429ZI']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"disco-f429zi",
-        }
-
-class DISCO_F469NI(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F469', 'STM32F469NI']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.detect_code = ["0788"]
-        self.progen = {
-            "target":"disco-f469ni",
-        }
-
-class DISCO_L053C8(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['STM', 'STM32L0', 'STM32L053C8']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"disco-l053c8",
-        }
-
-class DISCO_F746NG(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M7F"
-        self.extra_labels = ['STM', 'STM32F7', 'STM32F746', 'STM32F746NG']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.detect_code = ["0815"]
-        self.progen = {
-            "target":"disco-f746ng",
-        }
-
-class DISCO_L476VG(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32L4', 'STM32L476VG']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.detect_code = ["0820"]
-        self.progen = {
-            "target":"disco-l476vg",
-        }
-
-class MTS_MDOT_F405RG(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F405RG']
-        self.macros = ['HSE_VALUE=26000000', 'OS_CLOCK=48000000']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.is_disk_virtual = True
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"mts-mdot-f405rg",
-        }
-
-class MTS_MDOT_F411RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F411RE']
-        self.macros = ['HSE_VALUE=26000000', 'OS_CLOCK=96000000', 'USE_PLL_HSE_EXTC=0', 'VECT_TAB_OFFSET=0x00010000']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"mts-mdot-f411re",
-        }
-
-    def init_hooks(self, hook, toolchain_name):
-        if toolchain_name in ['GCC_ARM', 'ARM_STD', 'ARM_MICRO']:
-            hook.hook_add_binary("post", self.combine_bins)
-
-    # combine application binary with bootloader
-    # bootloader + padding to 64kB + application + md5sum (16 bytes)
+class MTSCode:
     @staticmethod
-    def combine_bins(t_self, resources, elf, binf):
-        loader = os.path.join(TOOLS_BOOTLOADERS, "MTS_MDOT_F411RE", "bootloader.bin")
+    def _combine_bins_helper(target_name, t_self, resources, elf, binf):
+        loader = os.path.join(TOOLS_BOOTLOADERS, target_name, "bootloader.bin")
         target = binf + ".tmp"
         if not os.path.exists(loader):
             print "Can't find bootloader binary: " + loader
@@ -1233,147 +303,15 @@ class MTS_MDOT_F411RE(Target):
         os.remove(binf)
         os.rename(target, binf)
 
-class MTS_DRAGONFLY_F411RE(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F411RE']
-        self.macros = ['HSE_VALUE=26000000', 'VECT_TAB_OFFSET=0x08010000']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"mts-dragonfly-f411re",
-        }
-
-    def init_hooks(self, hook, toolchain_name):
-        if toolchain_name in ['GCC_ARM', 'ARM_STD', 'ARM_MICRO']:
-            hook.hook_add_binary("post", self.combine_bins)
-
-    # combine application binary with bootloader
-    # bootloader + padding to 64kB + application + md5sum (16 bytes)
     @staticmethod
-    def combine_bins(t_self, resources, elf, binf):
-        loader = os.path.join(TOOLS_BOOTLOADERS, "MTS_DRAGONFLY_F411RE", "bootloader.bin")
-        target = binf + ".tmp"
-        if not os.path.exists(loader):
-            print "Can't find bootloader binary: " + loader
-            return
-        outbin = open(target, 'w+b')
-        part = open(loader, 'rb')
-        data = part.read()
-        outbin.write(data)
-        outbin.write('\xFF' * (64*1024 - len(data)))
-        part.close()
-        part = open(binf, 'rb')
-        data = part.read()
-        outbin.write(data)
-        part.close()
-        outbin.seek(0, 0)
-        data = outbin.read()
-        outbin.seek(0, 1)
-        crc = struct.pack('<I', binascii.crc32(data) & 0xFFFFFFFF)
-        outbin.write(crc)
-        outbin.close()
-        os.remove(binf)
-        os.rename(target, binf)
+    def combine_bins_mts_dot(t_self, resources, elf, binf):
+        MTSCode._combine_bins_helper("MTS_MDOT_F411RE", t_self, resources, elf, binf)
 
-class MOTE_L152RC(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['STM', 'STM32L1', 'STM32L152RC']
-        self.supported_toolchains = ["ARM", "uARM", "IAR", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.detect_code = ["4100"]
-        self.progen = {
-            "target":"stm32l151rc",
-        }
-class DISCO_F401VC(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F401', 'STM32F401VC']
-        self.supported_toolchains = ["GCC_ARM"]
-        self.default_toolchain = "GCC_ARM"
+    @staticmethod
+    def combine_bins_mts_dragonfly(t_self, resources, elf, binf):
+        MTSCode._combine_bins_helper("MTS_DRAGONFLY_F411RE", t_self, resources, elf, binf)
 
-class UBLOX_C029(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['STM', 'STM32F4', 'STM32F439', 'STM32F439ZI']
-        self.macros = ['HSE_VALUE=24000000', 'HSE_STARTUP_TIMEOUT=5000']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "uARM"
-        self.supported_form_factors = ["ARDUINO"]
-
-class NZ32_SC151(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['STM', 'STM32L1', 'STM32L151RC']
-        self.supported_toolchains = ["ARM", "uARM", "GCC_ARM"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"stm32l151rc",
-        }
-    # After flashing device, how long to delay until we assume program is running
-    def program_cycle_s(self):
-        return 1.5
-
-
-### Nordic ###
-
-class MCU_NRF51(Target):
-    # the following is a list of possible Nordic softdevices in decreasing order
-    # of preference.
-    EXPECTED_SOFTDEVICES_WITH_OFFSETS = [
-        {
-            'name'   : 's130_nrf51_1.0.0_softdevice.hex',
-            'boot'   : 's130_nrf51_1.0.0_bootloader.hex',
-            'offset' : 0x1C000
-        },
-        {
-            'name'   : 's110_nrf51822_8.0.0_softdevice.hex',
-            'boot'   : 's110_nrf51822_8.0.0_bootloader.hex',
-            'offset' : 0x18000
-        },
-        {
-            'name'   : 's110_nrf51822_7.1.0_softdevice.hex',
-            'boot'   : 's110_nrf51822_7.1.0_bootloader.hex',
-            'offset' : 0x16000
-        },
-        {
-            'name'   : 's110_nrf51822_7.0.0_softdevice.hex',
-            'boot'   : 's110_nrf51822_7.0.0_bootloader.hex',
-            'offset' : 0x16000
-        },
-        {
-            'name'   : 's110_nrf51822_6.0.0_softdevice.hex',
-            'boot'   : 's110_nrf51822_6.0.0_bootloader.hex',
-            'offset' : 0x14000
-        }
-    ]
-    OVERRIDE_BOOTLOADER_FILENAME = "nrf51822_bootloader.hex"
-    OUTPUT_EXT = 'hex'
-    MERGE_SOFT_DEVICE = True
-    MERGE_BOOTLOADER = False
-
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ["NORDIC", "MCU_NRF51", "MCU_NRF51822"]
-        self.macros = ['NRF51', 'TARGET_NRF51822']
-        self.supported_toolchains = ["ARM", "GCC_ARM"]
-        self.is_disk_virtual = True
-        self.detect_code = ["1070"]
-
-    def program_cycle_s(self):
-        return 6
-
-    def init_hooks(self, hook, toolchain_name):
-        if toolchain_name in ['ARM_STD', 'GCC_ARM']:
-            hook.hook_add_binary("post", self.binary_hook)
-
+class MCU_NRF51Code:
     @staticmethod
     def binary_hook(t_self, resources, elf, binf):
 
@@ -1423,924 +361,18 @@ class MCU_NRF51(Target):
         with open(binf.replace(".bin", ".hex"), "w") as f:
             binh.tofile(f, format='hex')
 
+########################################################################################################################
 
-# 16KB Nordic targets are tight on SRAM using S130 (default) so we
-# introduce two possible options:
-# 1) Use S130 (default) - for this derive from MCU_NRF51_16K
-# 2) Use S110  - for this derive from MCU_NRF51_16K_S110
-# Note that the 'default' option will track the default choice
-# for other Nordic targets, and so can take advantage of other
-# future SoftDevice improvements
-
-# The *_BASE targets should *not* be inherited from, as they do not
-# specify enough for building a target
-
-# 16KB MCU version, e.g. Nordic nRF51822, Seeed Arch BLE, etc.
-class MCU_NRF51_16K_BASE(MCU_NRF51):
-    def __init__(self):
-        MCU_NRF51.__init__(self)
-        self.extra_labels += ['MCU_NORDIC_16K', 'MCU_NRF51_16K']
-        self.macros += ['TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K']
-
-# derivative class used to create softdevice+bootloader enabled images
-class MCU_NRF51_16K_BOOT_BASE(MCU_NRF51_16K_BASE):
-    def __init__(self):
-        MCU_NRF51_16K_BASE.__init__(self)
-        self.extra_labels += ['MCU_NRF51_16K_BOOT']
-        self.macros += ['TARGET_MCU_NRF51_16K_BOOT', 'TARGET_OTA_ENABLED']
-        self.MERGE_SOFT_DEVICE = True
-        self.MERGE_BOOTLOADER = True
-
-# derivative class used to create program only images for use with FOTA
-class MCU_NRF51_16K_OTA_BASE(MCU_NRF51_16K_BASE):
-    def __init__(self):
-        MCU_NRF51_16K_BASE.__init__(self)
-        self.extra_labels += ['MCU_NRF51_16K_OTA']
-        self.macros += ['TARGET_MCU_NRF51_16K_OTA', 'TARGET_OTA_ENABLED']
-        self.MERGE_SOFT_DEVICE = False
-
-class MCU_NRF51_16K(MCU_NRF51_16K_BASE):
-    def __init__(self):
-        MCU_NRF51_16K_BASE.__init__(self)
-        self.extra_labels += ['MCU_NRF51_16K_S130']
-        self.macros += ['TARGET_MCU_NRF51_16K_S130']
-
-class MCU_NRF51_S110:
-    """ Interface for overwriting the default SoftDevices """
-    def __init__(self):
-        self.EXPECTED_SOFTDEVICES_WITH_OFFSETS = [
-            {
-                'name'   : 's110_nrf51822_8.0.0_softdevice.hex',
-                'boot'   : 's110_nrf51822_8.0.0_bootloader.hex',
-                'offset' : 0x18000
-            },
-            {
-                'name'   : 's110_nrf51822_7.1.0_softdevice.hex',
-                'boot'   : 's110_nrf51822_7.1.0_bootloader.hex',
-                'offset' : 0x16000
-            }
-        ]
-        self.extra_labels += ['MCU_NRF51_16K_S110']
-        self.macros += ['TARGET_MCU_NRF51_16K_S110']
-
-class MCU_NRF51_16K_S110(MCU_NRF51_16K_BASE, MCU_NRF51_S110):
-    def __init__(self):
-        MCU_NRF51_16K_BASE.__init__(self)
-        MCU_NRF51_S110.__init__(self)
-
-class MCU_NRF51_16K_BOOT(MCU_NRF51_16K_BOOT_BASE):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT_BASE.__init__(self)
-        self.extra_labels += ['MCU_NRF51_16K_S130']
-        self.macros += ['TARGET_MCU_NRF51_16K_S130']
-
-class MCU_NRF51_16K_BOOT_S110(MCU_NRF51_16K_BOOT_BASE, MCU_NRF51_S110):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT_BASE.__init__(self)
-        MCU_NRF51_S110.__init__(self)
-
-class MCU_NRF51_16K_OTA(MCU_NRF51_16K_OTA_BASE):
-    def __init__(self):
-        MCU_NRF51_16K_OTA_BASE.__init__(self)
-        self.extra_labels += ['MCU_NRF51_16K_S130']
-        self.macros += ['TARGET_MCU_NRF51_16K_S130']
-
-class MCU_NRF51_16K_OTA_S110(MCU_NRF51_16K_OTA_BASE, MCU_NRF51_S110):
-    def __init__(self):
-        MCU_NRF51_16K_OTA_BASE.__init__(self)
-        MCU_NRF51_S110.__init__(self)
-
-
-# 32KB MCU version, e.g. Nordic nRF51-DK, nRF51-Dongle, etc.
-class MCU_NRF51_32K(MCU_NRF51):
-    def __init__(self):
-        MCU_NRF51.__init__(self)
-        self.extra_labels += ['MCU_NORDIC_32K', 'MCU_NRF51_32K']
-        self.macros += ['TARGET_MCU_NORDIC_32K', 'TARGET_MCU_NRF51_32K']
-
-class MCU_NRF51_32K_BOOT(MCU_NRF51_32K):
-    def __init__(self):
-        MCU_NRF51_32K.__init__(self)
-        self.extra_labels += ['MCU_NRF51_32K_BOOT']
-        self.macros += ['TARGET_MCU_NRF51_32K_BOOT', 'TARGET_OTA_ENABLED']
-        self.MERGE_SOFT_DEVICE = True
-        self.MERGE_BOOTLOADER = True
-
-class MCU_NRF51_32K_OTA(MCU_NRF51_32K):
-    def __init__(self):
-        MCU_NRF51_32K.__init__(self)
-        self.extra_labels += ['MCU_NRF51_32K_OTA']
-        self.macros += ['TARGET_MCU_NRF51_32K_OTA', 'TARGET_OTA_ENABLED']
-        self.MERGE_SOFT_DEVICE = False
-
-#
-# nRF51 based development kits
-#
-
-# This one is special for legacy reasons
-class NRF51822(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.extra_labels += ['NRF51822', 'NRF51822_MKIT']
-        self.macros += ['TARGET_NRF51822_MKIT']
-        self.progen = {
-            "target":"mkit",
-        }
-class NRF51822_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['NRF51822', 'NRF51822_MKIT']
-        self.macros += ['TARGET_NRF51822_MKIT']
-
-class NRF51822_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['NRF51822', 'NRF51822_MKIT']
-        self.macros += ['TARGET_NRF51822_MKIT']
-
-class ARCH_BLE(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"arch-ble",
-        }
-
-class ARCH_BLE_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['ARCH_BLE']
-        self.macros += ['TARGET_ARCH_BLE']
-        self.supported_form_factors = ["ARDUINO"]
-
-class ARCH_BLE_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['ARCH_BLE']
-        self.macros += ['TARGET_ARCH_BLE']
-        self.supported_form_factors = ["ARDUINO"]
-
-class ARCH_LINK(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.extra_labels += ['ARCH_BLE']
-        self.macros += ['TARGET_ARCH_BLE']
-        self.supported_form_factors = ["ARDUINO"]
-
-class ARCH_LINK_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['ARCH_BLE', 'ARCH_LINK']
-        self.macros += ['TARGET_ARCH_BLE', 'TARGET_ARCH_LINK']
-        self.supported_form_factors = ["ARDUINO"]
-
-class ARCH_LINK_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['ARCH_BLE', 'ARCH_LINK']
-        self.macros += ['TARGET_ARCH_BLE', 'TARGET_ARCH_LINK']
-        self.supported_form_factors = ["ARDUINO"]
-
-class SEEED_TINY_BLE(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.progen = {
-            "target":"seed-tinyble",
-        }
-
-class SEEED_TINY_BLE_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['SEEED_TINY_BLE']
-        self.macros += ['TARGET_SEEED_TINY_BLE']
-
-class SEEED_TINY_BLE_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['SEEED_TINY_BLE']
-        self.macros += ['TARGET_SEEED_TINY_BLE']
-
-class HRM1017(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.macros += ['TARGET_NRF_LFCLK_RC']
-        self.progen = {
-            "target":"hrm1017",
-        }
-class HRM1017_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['HRM1017']
-        self.macros += ['TARGET_HRM1017', 'TARGET_NRF_LFCLK_RC']
-
-class HRM1017_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['HRM1017']
-        self.macros += ['TARGET_HRM1017', 'TARGET_NRF_LFCLK_RC']
-
-class RBLAB_NRF51822(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"rblab-nrf51822",
-        }
-
-class RBLAB_NRF51822_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['RBLAB_NRF51822']
-        self.macros += ['TARGET_RBLAB_NRF51822']
-        self.supported_form_factors = ["ARDUINO"]
-
-class RBLAB_NRF51822_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['RBLAB_NRF51822']
-        self.macros += ['TARGET_RBLAB_NRF51822']
-        self.supported_form_factors = ["ARDUINO"]
-
-class RBLAB_BLENANO(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-
-class RBLAB_BLENANO_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['RBLAB_BLENANO']
-        self.macros += ['TARGET_RBLAB_BLENANO']
-
-class RBLAB_BLENANO_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['RBLAB_BLENANO']
-        self.macros += ['TARGET_RBLAB_BLENANO']
-
-class NRF51822_Y5_MBUG(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-
-class WALLBOT_BLE(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-
-class WALLBOT_BLE_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['WALLBOT_BLE']
-        self.macros += ['TARGET_WALLBOT_BLE']
-
-class WALLBOT_BLE_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['WALLBOT_BLE']
-        self.macros += ['TARGET_WALLBOT_BLE']
-
-class DELTA_DFCM_NNN40(MCU_NRF51_32K):
-    def __init__(self):
-        MCU_NRF51_32K.__init__(self)
-        self.macros += ['TARGET_NRF_LFCLK_RC']
-        self.progen = {
-            "target":"dfcm-nnn40",
-        }
-    def program_cycle_s(self):
-        return 10
-
-class DELTA_DFCM_NNN40_BOOT(MCU_NRF51_32K_BOOT):
-    def __init__(self):
-        MCU_NRF51_32K_BOOT.__init__(self)
-        self.extra_labels += ['DELTA_DFCM_NNN40']
-        self.macros += ['TARGET_DELTA_DFCM_NNN40', 'TARGET_NRF_LFCLK_RC']
-    def program_cycle_s(self):
-        return 10
-
-class DELTA_DFCM_NNN40_OTA(MCU_NRF51_32K_OTA):
-    def __init__(self):
-        MCU_NRF51_32K_OTA.__init__(self)
-        self.extra_labels += ['DELTA_DFCM_NNN40']
-        self.macros += ['TARGET_DELTA_DFCM_NNN40', 'TARGET_NRF_LFCLK_RC']
-    def program_cycle_s(self):
-        return 10
-
-class NRF51_DK(MCU_NRF51_32K):
-    def __init__(self):
-        MCU_NRF51_32K.__init__(self)
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"nrf51-dk",
-        }
-
-class NRF51_DK_BOOT(MCU_NRF51_32K_BOOT):
-    def __init__(self):
-        MCU_NRF51_32K_BOOT.__init__(self)
-        self.extra_labels += ['NRF51_DK']
-        self.macros += ['TARGET_NRF51_DK']
-        self.supported_form_factors = ["ARDUINO"]
-
-class NRF51_DK_OTA(MCU_NRF51_32K_OTA):
-    def __init__(self):
-        MCU_NRF51_32K_OTA.__init__(self)
-        self.extra_labels += ['NRF51_DK']
-        self.macros += ['TARGET_NRF51_DK']
-        self.supported_form_factors = ["ARDUINO"]
-
-class NRF51_DONGLE(MCU_NRF51_32K):
-    def __init__(self):
-        MCU_NRF51_32K.__init__(self)
-        self.progen = {
-            "target":"nrf51-dongle",
-        }
-
-class NRF51_DONGLE_BOOT(MCU_NRF51_32K_BOOT):
-    def __init__(self):
-        MCU_NRF51_32K_BOOT.__init__(self)
-        self.extra_labels += ['NRF51_DONGLE']
-        self.macros += ['TARGET_NRF51_DONGLE']
-
-class NRF51_DONGLE_OTA(MCU_NRF51_32K_OTA):
-    def __init__(self):
-        MCU_NRF51_32K_OTA.__init__(self)
-        self.extra_labels += ['NRF51_DONGLE']
-        self.macros += ['TARGET_NRF51_DONGLE']
-
-class NRF51_MICROBIT(MCU_NRF51_16K_S110):
-    def __init__(self):
-        MCU_NRF51_16K_S110.__init__(self)
-        self.macros += ['TARGET_NRF_LFCLK_RC']
-
-class NRF51_MICROBIT_BOOT(MCU_NRF51_16K_BOOT_S110):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT_S110.__init__(self)
-        self.extra_labels += ['NRF51_MICROBIT']
-        self.macros += ['TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
-
-class NRF51_MICROBIT_OTA(MCU_NRF51_16K_OTA_S110):
-    def __init__(self):
-        MCU_NRF51_16K_OTA_S110.__init__(self)
-        self.extra_labels += ['NRF51_MICROBIT']
-        self.macros += ['TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
-
-class NRF51_MICROBIT_B(MCU_NRF51_16K):
-    def __init__(self):
-        MCU_NRF51_16K.__init__(self)
-        self.extra_labels += ['NRF51_MICROBIT']
-        self.macros += ['TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
-
-class NRF51_MICROBIT_B_BOOT(MCU_NRF51_16K_BOOT):
-    def __init__(self):
-        MCU_NRF51_16K_BOOT.__init__(self)
-        self.extra_labels += ['NRF51_MICROBIT']
-        self.macros += ['TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
-
-class NRF51_MICROBIT_B_OTA(MCU_NRF51_16K_OTA):
-    def __init__(self):
-        MCU_NRF51_16K_OTA.__init__(self)
-        self.extra_labels += ['NRF51_MICROBIT']
-        self.macros += ['TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
-
-class TY51822R3(MCU_NRF51_32K):
-    def __init__(self):
-        MCU_NRF51_32K.__init__(self)
-        self.macros += ['TARGET_NRF_32MHZ_XTAL']
-        self.supported_toolchains = ["ARM", "GCC_ARM"]
-
-class TY51822R3_BOOT(MCU_NRF51_32K_BOOT):
-    def __init__(self):
-        MCU_NRF51_32K_BOOT.__init__(self)
-        self.extra_labels += ['TY51822R3']
-        self.macros += ['TARGET_TY51822R3', 'TARGET_NRF_32MHZ_XTAL']
-        self.supported_toolchains = ["ARM", "GCC_ARM"]
-
-class TY51822R3_OTA(MCU_NRF51_32K_OTA):
-    def __init__(self):
-        MCU_NRF51_32K_OTA.__init__(self)
-        self.extra_labels += ['NRF51_DK']
-        self.macros += ['TARGET_TY51822R3', 'TARGET_NRF_32MHZ_XTAL']
-        self.supported_toolchains = ["ARM", "GCC_ARM"]
-
-
-### ARM ###
-
-class ARM_MPS2_Target(Target):
-    def __init__(self):
-        Target.__init__(self)
-
-class ARM_MPS2_M0(ARM_MPS2_Target):
-    def __init__(self):
-        ARM_MPS2_Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['ARM_SSG', 'MPS2', 'MPS2_M0']
-        self.macros = ['CMSDK_CM0']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class ARM_MPS2_M0P(ARM_MPS2_Target):
-    def __init__(self):
-        ARM_MPS2_Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['ARM_SSG', 'MPS2', 'MPS2_M0P']
-        self.macros = ['CMSDK_CM0plus']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class ARM_MPS2_M1(ARM_MPS2_Target):
-    def __init__(self):
-        ARM_MPS2_Target.__init__(self)
-        self.core = "Cortex-M1"
-        self.extra_labels = ['ARM_SSG', 'MPS2', 'MPS2_M1']
-        self.macros = ['CMSDK_CM1']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class ARM_MPS2_M3(ARM_MPS2_Target):
-    def __init__(self):
-        ARM_MPS2_Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['ARM_SSG', 'MPS2', 'MPS2_M3']
-        self.macros = ['CMSDK_CM3']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class ARM_MPS2_M4(ARM_MPS2_Target):
-    def __init__(self):
-        ARM_MPS2_Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['ARM_SSG', 'MPS2', 'MPS2_M4']
-        self.macros = ['CMSDK_CM4']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class ARM_MPS2_M7(ARM_MPS2_Target):
-    def __init__(self):
-        ARM_MPS2_Target.__init__(self)
-        self.core = "Cortex-M7"
-        self.extra_labels = ['ARM_SSG', 'MPS2', 'MPS2_M7']
-        self.macros = ['CMSDK_CM7']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-class ARM_IOTSS_Target(Target):
-    def __init__(self):
-        Target.__init__(self)
-class ARM_IOTSS_BEID(ARM_IOTSS_Target):
-    def __init__(self):
-        ARM_IOTSS_Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['ARM_SSG', 'IOTSS', 'IOTSS_BEID']
-        self.macros = ['CMSDK_BEID']
-        self.supported_toolchains = ["ARM"]
-        self.default_toolchain = "ARM"
-
-
-### Renesas ###
-
-class RZ_A1H(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-A9"
-        self.extra_labels = ['RENESAS', 'MBRZA1H']
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-        self.supported_form_factors = ["ARDUINO"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target": "gr-peach",
-            "iar": {
-                # rewrite generic template, this device needs futher support for FPU in progendef
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'iar_rz_a1h.ewp.tmpl')],
-            }
-        }
-
-    def program_cycle_s(self):
-        return 2
-
-class VK_RZ_A1H(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-A9"
-        self.extra_labels = ['RENESAS', 'VKRZA1H']
-        self.supported_toolchains = ["ARM", "GCC_ARM", "IAR"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target": "vk-rza1h",
-            "iar": {
-                # rewrite generic template, this device needs futher support for FPU in progendef
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'iar_rz_a1h.ewp.tmpl')],
-            }
-        }
-
-    def program_cycle_s(self):
-        return 2
-
-### Maxim Integrated ###
-
-class MAXWSNENV(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['Maxim', 'MAX32610']
-        self.macros = ['__SYSTEM_HFX=24000000']
-        self.supported_toolchains = ["GCC_ARM", "IAR", "ARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target": "maxwsnenv",
-        }
-
-class MAX32600MBED(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['Maxim', 'MAX32600']
-        self.macros = ['__SYSTEM_HFX=24000000']
-        self.supported_toolchains = ["GCC_ARM", "IAR", "ARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target": "max32600mbed",
-        }
-
-### Silicon Labs ###
-
-class EFM32GG_STK3700(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['Silicon_Labs', 'EFM32']
-        self.macros = ['EFM32GG990F1024']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"efm32gg_stk3700", #TODO: add to progen
-        }
-
-
-
-class EFM32LG_STK3600(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M3"
-        self.extra_labels = ['Silicon_Labs', 'EFM32']
-        self.macros = ['EFM32LG990F256']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"efm32lg_stk3600", #TODO: add to progen
-        }
-
-
-
-class EFM32WG_STK3800(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['Silicon_Labs', 'EFM32']
-        self.macros = ['EFM32WG990F256']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"efm32wg_stk3800", #TODO: add to progen
-        }
-
-
-
-class EFM32ZG_STK3200(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Silicon_Labs', 'EFM32']
-        self.macros = ['EFM32ZG222F32']
-        self.supported_toolchains = ["GCC_ARM", "uARM"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"efm32zg_stk3200", #TODO: add to progen
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-
-class EFM32HG_STK3400(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Silicon_Labs', 'EFM32']
-        self.macros = ['EFM32HG322F64']
-        self.supported_toolchains = ["GCC_ARM", "uARM"]
-        self.default_toolchain = "uARM"
-        self.progen = {
-            "target":"efm32hg_stk3400", #TODO: add to progen
-            "uvision": {
-                "template": [os.path.join(os.path.dirname(__file__), 'export', 'uvision_microlib.uvproj.tmpl')],
-            }
-        }
-
-
-class EFM32PG_STK3401(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4F"
-        self.extra_labels = ['Silicon_Labs', 'EFM32']
-        self.macros = ['EFM32PG1B200F256GM48']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM", "IAR"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"efm32pg_stk3401", #TODO: add to progen
-        }
-
-
-
-##WIZnet
-
-class WIZWIKI_W7500(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['WIZNET', 'W7500x', 'WIZwiki_W7500']
-        self.supported_toolchains = ["uARM", "ARM"]
-        self.default_toolchain = "ARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"wizwiki_w7500",
-        }
-
-class WIZWIKI_W7500P(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['WIZNET', 'W7500x', 'WIZwiki_W7500P']
-        self.supported_toolchains = ["uARM", "ARM"]
-        self.default_toolchain = "ARM"
-        self.supported_form_factors = ["ARDUINO"]
-        self.progen = {
-            "target":"wizwiki_w7500p", # TODO: add to progen
-        }
-
-class WIZWIKI_W7500ECO(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0"
-        self.extra_labels = ['WIZNET', 'W7500x', 'WIZwiki_W7500ECO']
-        self.supported_toolchains = ["uARM", "ARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"wizwiki_w7500eco", # TODO: add to progen
-        }
-
-
-class SAMR21G18A(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Atmel', 'SAM_CortexM0P', 'SAMR21']
-        self.macros = ['__SAMR21G18A__', 'I2C_MASTER_CALLBACK_MODE=true', 'EXTINT_CALLBACK_MODE=true', 'USART_CALLBACK_MODE=true', 'TC_ASYNC=true']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"samr21g18a",
-        }
-
-class SAMD21J18A(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Atmel', 'SAM_CortexM0P', 'SAMD21']
-        self.macros = ['__SAMD21J18A__', 'I2C_MASTER_CALLBACK_MODE=true', 'EXTINT_CALLBACK_MODE=true', 'USART_CALLBACK_MODE=true', 'TC_ASYNC=true']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"samd21j18a",
-        }
-
-class SAMD21G18A(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Atmel', 'SAM_CortexM0P', 'SAMD21']
-        self.macros = ['__SAMD21G18A__', 'I2C_MASTER_CALLBACK_MODE=true', 'EXTINT_CALLBACK_MODE=true', 'USART_CALLBACK_MODE=true', 'TC_ASYNC=true']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"samd21g18a",
-        }
-
-class SAML21J18A(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M0+"
-        self.extra_labels = ['Atmel', 'SAM_CortexM0P', 'SAML21']
-        self.macros = ['__SAML21J18A__', 'I2C_MASTER_CALLBACK_MODE=true', 'EXTINT_CALLBACK_MODE=true', 'USART_CALLBACK_MODE=true', 'TC_ASYNC=true']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"samr21j18a",
-        }
-        self.progen_target ='samr21j18a'
-
-class SAMG55J19(Target):
-    def __init__(self):
-        Target.__init__(self)
-        self.core = "Cortex-M4"
-        self.extra_labels = ['Atmel', 'SAM_CortexM4', 'SAMG55']
-        self.macros = ['__SAMG55J19__', 'BOARD=75', 'I2C_MASTER_CALLBACK_MODE=true', 'EXTINT_CALLBACK_MODE=true', 'USART_CALLBACK_MODE=true', 'TC_ASYNC=true']
-        self.supported_toolchains = ["GCC_ARM", "ARM", "uARM"]
-        self.default_toolchain = "ARM"
-        self.progen = {
-            "target":"samg55j19",
-        }
-        self.progen_target ='samg55j19'
-
-# Get a single instance for each target
-TARGETS = [
-
-    ### NXP ###
-    LPC11C24(),
-    LPC11U24(),
-    OC_MBUINO(),        # LPC11U24
-    LPC11U24_301(),
-    LPC11U34_421(),
-    MICRONFCBOARD(),    # LPC11U34_421
-    LPC11U35_401(),
-    LPC11U35_501(),     # LPC11U35_501
-    LPC11U35_501_IBDAP(), # LPC11U35_501
-    XADOW_M0(),         # LPC11U35_501
-    LPC11U35_Y5_MBUG(), # LPC11U35_501
-    LPC11U37_501(),
-    LPCCAPPUCCINO(),    # LPC11U37_501
-    ARCH_GPRS(),        # LPC11U37_501
-    LPC11U68(),
-    LPC1114(),
-    LPC1347(),
-    LPC1549(),
-    LPC1768(),          # LPC1768
-    ARCH_PRO(),         # LPC1768
-    UBLOX_C027(),       # LPC1768
-    XBED_LPC1768(),     # LPC1768
-    LPC2368(),
-    LPC2460(),
-    LPC810(),
-    LPC812(),
-    LPC824(),
-    SSCI824(),          # LPC824
-    LPC4088(),
-    LPC4088_DM(),
-    LPC4330_M4(),
-    LPC4330_M0(),
-    LPC4337(),
-    LPC11U37H_401(),
-
-    ### Freescale ###
-    KL05Z(),
-    KL25Z(),
-    KL26Z(),
-    KL43Z(),
-    KL46Z(),
-    K20D50M(),
-    K22F(),
-    KL27Z(),
-    K64F(),       # FRDM K64F
-    MTS_GAMBIT(),
-    HEXIWEAR(),
-    TEENSY3_1(),
-
-    ### STMicro ###
-    B96B_F446VE(),
-    NUCLEO_F030R8(),
-    NUCLEO_F031K6(),
-    NUCLEO_F042K6(),
-    NUCLEO_F070RB(),
-    NUCLEO_F072RB(),
-    NUCLEO_F091RC(),
-    NUCLEO_F103RB(),
-    NUCLEO_F302R8(),
-    NUCLEO_F303K8(),
-    NUCLEO_F303RE(),
-    NUCLEO_F334R8(),
-    NUCLEO_F401RE(),
-    NUCLEO_F410RB(),
-    NUCLEO_F411RE(),
-    NUCLEO_F746ZG(),
-    ELMO_F411RE(),
-    NUCLEO_F446RE(),
-    NUCLEO_L031K6(),
-    NUCLEO_L053R8(),
-    NUCLEO_L073RZ(),
-    NUCLEO_L152RE(),
-    NUCLEO_L476RG(),
-    STM32F3XX(),
-    STM32F407(),
-    DISCO_F051R8(),
-    DISCO_F100RB(),
-    DISCO_F303VC(),
-    DISCO_F334C8(),
-    DISCO_F746NG(),
-    DISCO_F407VG(),     # STM32F407
-    ARCH_MAX(),         # STM32F407
-    DISCO_F429ZI(),
-    DISCO_F469NI(),
-    DISCO_L053C8(),
-    DISCO_L476VG(),
-    MTS_MDOT_F405RG(),
-    MTS_MDOT_F411RE(),
-    MOTE_L152RC(),
-    MTS_DRAGONFLY_F411RE(),
-    DISCO_F401VC(),
-    UBLOX_C029(),       # STM32F439
-    NZ32_SC151(),       # STM32L151
-
-    ### Nordic ###
-    NRF51822(),             # nRF51_16K
-    NRF51822_BOOT(),        # nRF51_16K
-    NRF51822_OTA(),         # nRF51_16K
-    ARCH_BLE(),             # nRF51_16K
-    ARCH_BLE_BOOT(),        # nRF51_16K
-    ARCH_BLE_OTA(),         # nRF51_16K
-    ARCH_LINK(),            # nRF51_16K
-    ARCH_LINK_BOOT(),       # nRF51_16K
-    ARCH_LINK_OTA(),        # nRF51_16K
-    SEEED_TINY_BLE(),       # nRF51_16K
-    SEEED_TINY_BLE_BOOT(),  # nRF51_16K
-    SEEED_TINY_BLE_OTA(),   # nRF51_16K
-    HRM1017(),              # nRF51_16K
-    HRM1017_BOOT(),         # nRF51_16K
-    HRM1017_OTA(),          # nRF51_16K
-    RBLAB_NRF51822(),       # nRF51_16K
-    RBLAB_NRF51822_BOOT(),  # nRF51_16K
-    RBLAB_NRF51822_OTA(),   # nRF51_16K
-    RBLAB_BLENANO(),        # nRF51_16K
-    RBLAB_BLENANO_BOOT(),   # nRF51_16K
-    RBLAB_BLENANO_OTA(),    # nRF51_16K
-    NRF51822_Y5_MBUG(),     # nRF51_16K
-    WALLBOT_BLE(),          # nRF51_16K
-    WALLBOT_BLE_BOOT(),     # nRF51_16K
-    WALLBOT_BLE_OTA(),      # nRF51_16K
-    DELTA_DFCM_NNN40(),     # nRF51_16K
-    DELTA_DFCM_NNN40_BOOT(),# nRF51_16K
-    DELTA_DFCM_NNN40_OTA(), # nRF51_16K
-    NRF51_DK(),             # nRF51_32K
-    NRF51_DK_BOOT(),        # nRF51_32K
-    NRF51_DK_OTA(),         # nRF51_32K
-    NRF51_DONGLE(),         # nRF51_32K
-    NRF51_DONGLE_BOOT(),    # nRF51_32K
-    NRF51_DONGLE_OTA(),     # nRF51_32K
-    NRF51_MICROBIT(),       # nRF51_16K - S110
-    NRF51_MICROBIT_BOOT(),  # nRF51_16K - S110
-    NRF51_MICROBIT_OTA(),   # nRF51_16K - S110
-    NRF51_MICROBIT_B(),     # nRF51_16K - default
-    NRF51_MICROBIT_B_BOOT(),# nRF51_16K - default
-    NRF51_MICROBIT_B_OTA(), # nRF51_16K - default
-    TY51822R3(),            # nRF51_32K
-    TY51822R3_BOOT(),       # nRF51_32K
-    TY51822R3_OTA(),        # nRF51_32K
-
-
-    ### ARM ###
-    ARM_MPS2_M0(),
-    ARM_MPS2_M0P(),
-    ARM_MPS2_M1(),
-    ARM_MPS2_M3(),
-    ARM_MPS2_M4(),
-    ARM_MPS2_M7(),
-
-    ARM_IOTSS_BEID(),
-
-    ### Renesas ###
-    RZ_A1H(),
-    VK_RZ_A1H(),
-
-    ### Maxim Integrated ###
-    MAXWSNENV(),
-    MAX32600MBED(),
-
-    ### Silicon Labs ###
-    EFM32GG_STK3700(),
-    EFM32LG_STK3600(),
-    EFM32WG_STK3800(),
-    EFM32ZG_STK3200(),
-    EFM32HG_STK3400(),
-	EFM32PG_STK3401(),
-
-    ### WIZnet ###
-    WIZWIKI_W7500(),
-    WIZWIKI_W7500P(),
-    WIZWIKI_W7500ECO(),
-
-    ### Atmel ###
-    SAMR21G18A(),
-    SAMD21J18A(),
-    SAMD21G18A(),
-    SAML21J18A(),
-    SAMG55J19(),
-
-]
+# Instantiate all public targets
+TARGETS = [Target(name) for name, value in Target.get_json_target_data().items() if value.get("public", True)]
 
 # Map each target name to its unique instance
-TARGET_MAP = {}
-for t in TARGETS:
-    TARGET_MAP[t.name] = t
+TARGET_MAP = dict([(t.name, t) for t in TARGETS])
 
 TARGET_NAMES = TARGET_MAP.keys()
 
 # Some targets with different name have the same exporters
-EXPORT_MAP = { }
+EXPORT_MAP = {}
 
 # Detection APIs
 def get_target_detect_codes():


### PR DESCRIPTION
(long commit message ahead. Sorry about that, it can't be helped.)

This commit changs targets definition from Python to JSON format, as
part of the configuration mechanism implementation. There is a new file
under workspace_tools/ called "targets.json" which contains the target
definitions. "targets.py" remains, but becomes a wrapper on top of
"targets.json", with the same interface as before. This has the
advantage of not requiring code changes outside "targets.py".

Most of the JSON definitions of targets were automatically generated by a
script (available upon request since it doesn't make a lot of sense to
include it here), only those targets that had more than one parent in
the Python implementation were converted by hand. The target definitions
should be pretty self-explanatory. A number of things are different in
the JSON implementation (this is just a summary, check docs/mbed_targets.md
(also part of this PR) for a more complete description):

- "program_cycle_s" is now a value (as opposed to a function in the
Python implementation), since it only returned a number in all the
Python target implementations. The main definition that actually contains
some code (in class "Target") remains in target.py
- array values in "macros" and "extra_labels" can be modified
dynamically. Values can be added using "macros_add" and
"extra_labels_add" or removed using "macros_remove" and
"extra_labels_remove". This mechanism is available for all attributes
with a list type, but it's currently enabled only for "macros" and
"extra_labels" to keep things simple.
- "init_hooks"/"binary_hook" are now implemented in terms of a single
JSON key valled "post_binary_hook". The corresponding code is also in
"targets.py", under the various TargetCode classes (see for example
LPC4088Code in targets.py).

Just like in the Python implementation, a target can inherit from zero,
one or more targets. The resolution order for the target's attributes
follows the one used by the Python code (I used
http://makina-corpus.com/blog/metier/2014/python-tutorial-understanding-python-mro-class-search-path as a reference for the implementation of resolution order).

This is obviously a very dangerous commit, since it affects all targets.
I tested compilation for a number of targets (K64F, LPC1768, NRF51822)
but there's definitely a lot more to be done in terms of testing.

I also tried to test in a different way: I wrote a script that imports the
old (Python) and the new (JSON) implementations and verifies that the
attributes in the old implementations exist and have the same values
in the new implementations (it also verifies that the attribute
resolution order is the same in the two implementations). If you're
interested, the script is here:

https://gist.github.com/bogdanm/c9d8cf34214109a4b9079befed6b3c0c

And the results of running the script are below (note that the script
outputs only the target names that were found to be problematic):

```
NRF51_MICROBIT_BOOT:
    Resolution order is different in old and new
        old: ['NRF51_MICROBIT_BOOT', 'MCU_NRF51_16K_BOOT_S110', 'MCU_NRF51_16K_BOOT_BASE', 'MCU_NRF51_16K_BASE', 'MCU_NRF51', 'Target', 'MCU_NRF51_S110']
        new: ['NRF51_MICROBIT_BOOT', 'MCU_NRF51_16K_BOOT_S110', 'MCU_NRF51_S110', 'MCU_NRF51_16K_BOOT_BASE', 'MCU_NRF51_16K_BASE', 'MCU_NRF51', 'Target']
    'extra_labels' has different values in old and new
        old: ['NORDIC', 'MCU_NRF51', 'MCU_NRF51822', 'MCU_NORDIC_16K', 'MCU_NRF51_16K', 'MCU_NRF51_16K_BOOT', 'MCU_NRF51_16K_S110', 'NRF51_MICROBIT']
        new: ['NORDIC', 'MCU_NRF51', 'MCU_NRF51822', 'MCU_NORDIC_16K', 'MCU_NRF51_16K', 'MCU_NRF51_16K_S110', 'MCU_NRF51_16K_BOOT', 'NRF51_MICROBIT']
    'macros' has different values in old and new
        old: ['NRF51', 'TARGET_NRF51822', 'TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K', 'TARGET_MCU_NRF51_16K_BOOT', 'TARGET_OTA_ENABLED', 'TARGET_MCU_NRF51_16K_S110', 'TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
        new: ['NRF51', 'TARGET_NRF51822', 'TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K', 'TARGET_MCU_NRF51_16K_S110', 'TARGET_MCU_NRF51_16K_BOOT', 'TARGET_OTA_ENABLED', 'TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
NRF51_MICROBIT:
    Resolution order is different in old and new
        old: ['NRF51_MICROBIT', 'MCU_NRF51_16K_S110', 'MCU_NRF51_16K_BASE', 'MCU_NRF51', 'Target', 'MCU_NRF51_S110']
        new: ['NRF51_MICROBIT', 'MCU_NRF51_16K_S110', 'MCU_NRF51_S110', 'MCU_NRF51_16K_BASE', 'MCU_NRF51', 'Target']
    'extra_labels' has different values in old and new
        old: ['NORDIC', 'MCU_NRF51', 'MCU_NRF51822', 'MCU_NORDIC_16K', 'MCU_NRF51_16K', 'MCU_NRF51_16K_S110']
        new: ['NORDIC', 'MCU_NRF51', 'MCU_NRF51822', 'MCU_NRF51_16K_S110', 'MCU_NORDIC_16K', 'MCU_NRF51_16K']
    'macros' has different values in old and new
        old: ['NRF51', 'TARGET_NRF51822', 'TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K', 'TARGET_MCU_NRF51_16K_S110', 'TARGET_NRF_LFCLK_RC']
        new: ['NRF51', 'TARGET_NRF51822', 'TARGET_MCU_NRF51_16K_S110', 'TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K', 'TARGET_NRF_LFCLK_RC']
NRF51_MICROBIT_OTA:
    Resolution order is different in old and new
        old: ['NRF51_MICROBIT_OTA', 'MCU_NRF51_16K_OTA_S110', 'MCU_NRF51_16K_OTA_BASE', 'MCU_NRF51_16K_BASE', 'MCU_NRF51', 'Target', 'MCU_NRF51_S110']
        new: ['NRF51_MICROBIT_OTA', 'MCU_NRF51_16K_OTA_S110', 'MCU_NRF51_S110', 'MCU_NRF51_16K_OTA_BASE', 'MCU_NRF51_16K_BASE', 'MCU_NRF51', 'Target']
    'extra_labels' has different values in old and new
        old: ['NORDIC', 'MCU_NRF51', 'MCU_NRF51822', 'MCU_NORDIC_16K', 'MCU_NRF51_16K', 'MCU_NRF51_16K_OTA', 'MCU_NRF51_16K_S110', 'NRF51_MICROBIT']
        new: ['NORDIC', 'MCU_NRF51', 'MCU_NRF51822', 'MCU_NORDIC_16K', 'MCU_NRF51_16K', 'MCU_NRF51_16K_S110', 'MCU_NRF51_16K_OTA', 'NRF51_MICROBIT']
    'macros' has different values in old and new
        old: ['NRF51', 'TARGET_NRF51822', 'TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K', 'TARGET_MCU_NRF51_16K_OTA', 'TARGET_OTA_ENABLED', 'TARGET_MCU_NRF51_16K_S110', 'TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
        new: ['NRF51', 'TARGET_NRF51822', 'TARGET_MCU_NORDIC_16K', 'TARGET_MCU_NRF51_16K', 'TARGET_MCU_NRF51_16K_S110', 'TARGET_MCU_NRF51_16K_OTA', 'TARGET_OTA_ENABLED', 'TARGET_NRF51_MICROBIT', 'TARGET_NRF_LFCLK_RC']
NOT OK: ['NRF51_MICROBIT', 'NRF51_MICROBIT_BOOT', 'NRF51_MICROBIT_OTA']
```

The reasons for the above output are subtle and related to the
extremely weird way in which we defined target data in the Python
implementation: we used both class attributes and instance attributes.
This can complicate resolution order quite a bit and those two levels
don't exist in JSON: there's only one attribute type (equivalent to
Python's instance attributes). To make that work, I had to change the
inheritance order of the above targets (that use multiple inheritance)
which in turn changed the order of some macros and extra_labels (and of
course the resolution order). No harm done: the values are the same,
only their ordering is different. I don't believe this causes any
problems for 'extra_labels' and 'macros'.

This method of testing has its limitations though; in particular, it
can't test the hooks. I'm opened to ideas about how to test this better,
but I think that we need to remember that this commit might break some
targets and keep an eye out for "weird errors" in the future.