### PR TITLE
Fix timer #816 issue for STM32F0 and STM32F1

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
@@ -43,6 +43,7 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
+extern volatile uint16_t cnt_val;
 
 // Used to increment the slave counter
 void timer_update_irq_handler(void)
@@ -59,7 +60,7 @@ void timer_update_irq_handler(void)
 // Used for mbed timeout (channel 1) and HAL tick (channel 2)
 void timer_oc_irq_handler(void)
 {
-    uint16_t cval = TIM_MST->CNT;
+    cnt_val = TIM_MST->CNT;
     TimMasterHandle.Instance = TIM_MST;
 
     // Channel 1 for mbed timeout
@@ -71,7 +72,7 @@ void timer_oc_irq_handler(void)
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
+                oc_rem_part = cnt_val; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
@@ -43,6 +43,7 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
+extern volatile uint16_t cnt_val;
 
 // Used to increment the slave counter
 void timer_update_irq_handler(void)
@@ -59,7 +60,7 @@ void timer_update_irq_handler(void)
 // Used for mbed timeout (channel 1) and HAL tick (channel 2)
 void timer_oc_irq_handler(void)
 {
-    uint16_t cval = TIM_MST->CNT;
+    cnt_val = TIM_MST->CNT;
     TimMasterHandle.Instance = TIM_MST;
 
     // Channel 1 for mbed timeout
@@ -71,7 +72,7 @@ void timer_oc_irq_handler(void)
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
+                oc_rem_part = cnt_val; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
@@ -43,9 +43,10 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
+extern volatile uint16_t cnt_val;
 
 void timer_irq_handler(void) {
-    uint16_t cval = TIM_MST->CNT;
+    cnt_val= TIM_MST->CNT;
 
     TimMasterHandle.Instance = TIM_MST;
 
@@ -64,7 +65,7 @@ void timer_irq_handler(void) {
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
+                oc_rem_part = cnt_val; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/us_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/us_ticker.c
@@ -41,6 +41,7 @@ static int us_ticker_inited = 0;
 volatile uint32_t SlaveCounter = 0;
 volatile uint32_t oc_int_part = 0;
 volatile uint16_t oc_rem_part = 0;
+volatile uint16_t cnt_val = 0;
 
 void set_compare(uint16_t count) {
     TimMasterHandle.Instance = TIM_MST;
@@ -58,24 +59,15 @@ void us_ticker_init(void) {
 }
 
 uint32_t us_ticker_read() {
-    uint32_t counter, counter2;
+    uint32_t counter;
     if (!us_ticker_inited) us_ticker_init();
-    // A situation might appear when Master overflows right after Slave is read and before the
-    // new (overflowed) value of Master is read. Which would make the code below consider the
-    // previous (incorrect) value of Slave and the new value of Master, which would return a
-    // value in the past. Avoid this by computing consecutive values of the timer until they
-    // are properly ordered.
+
+    //Current value of TIM_MST->CNT is stored in cnt_val and is
+    //updated in interrupt context
     counter = (uint32_t)(SlaveCounter << 16);
-    counter += TIM_MST->CNT;
-    while (1) {
-        counter2 = (uint32_t)(SlaveCounter << 16);
-        counter2 += TIM_MST->CNT;
-        if (counter2 > counter) {
-            break;
-        }
-        counter = counter2;
-    }
-    return counter2;
+    counter += cnt_val;
+
+    return counter;
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/us_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/us_ticker.c
@@ -38,6 +38,7 @@ static int us_ticker_inited = 0;
 volatile uint32_t SlaveCounter = 0;
 volatile uint32_t oc_int_part = 0;
 volatile uint16_t oc_rem_part = 0;
+volatile uint16_t cnt_val = 0;
 
 void set_compare(uint16_t count)
 {
@@ -58,24 +59,15 @@ void us_ticker_init(void)
 
 uint32_t us_ticker_read()
 {
-    uint32_t counter, counter2;
+    uint32_t counter;
     if (!us_ticker_inited) us_ticker_init();
-    // A situation might appear when Master overflows right after Slave is read and before the
-    // new (overflowed) value of Master is read. Which would make the code below consider the
-    // previous (incorrect) value of Slave and the new value of Master, which would return a
-    // value in the past. Avoid this by computing consecutive values of the timer until they
-    // are properly ordered.
+
+    //Current value of TIM_MST->CNT is stored in cnt_val and is
+    //updated in interrupt context
     counter = (uint32_t)(SlaveCounter << 16);
-    counter += TIM_MST->CNT;
-    while (1) {
-        counter2 = (uint32_t)(SlaveCounter << 16);
-        counter2 += TIM_MST->CNT;
-        if (counter2 > counter) {
-            break;
-        }
-        counter = counter2;
-    }
-    return counter2;
+    counter += cnt_val;
+
+    return counter;
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp)


### PR DESCRIPTION
This pull request fixes issue [#816](https://github.com/mbedmicro/mbed/issues/816) plus it changes the previously implemented 16-bit timer for F0xx family.