### PR TITLE
Fix NXP LPCxxxx i2c_start() handling of repeated start

### DIFF
--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11U6X/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11U6X/i2c_api.c
@@ -111,20 +111,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11UXX/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11UXX/i2c_api.c
@@ -94,20 +94,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC11XX_11CXX/i2c_api.c
@@ -104,20 +104,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC13XX/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC13XX/i2c_api.c
@@ -104,20 +104,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC23XX/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC23XX/i2c_api.c
@@ -111,20 +111,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC2460/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC2460/i2c_api.c
@@ -117,20 +117,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088/i2c_api.c
@@ -133,20 +133,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC408X/TARGET_LPC4088_DM/i2c_api.c
@@ -119,20 +119,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
+    i2c_conclr(obj, 1, 1, 0, 1);
 
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
 
     i2c_wait_SI(obj);
     status = i2c_status(obj);
 
-    // Clear start bit now transmitted, and interrupt bit
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/i2c_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC43XX/i2c_api.c
@@ -113,20 +113,26 @@ void i2c_init(i2c_t *obj, PinName sda, PinName scl) {
 
 inline int i2c_start(i2c_t *obj) {
     int status = 0;
+    int isInterrupted = I2C_CONSET(obj) & (1 << 3);
+
     // 8.1 Before master mode can be entered, I2CON must be initialised to:
     //  - I2EN STA STO SI AA - -
-    //  -  1    0   0   0  x - -
+    //  -  1    0   0   x  x - -
     // if AA = 0, it can't enter slave mode
-    i2c_conclr(obj, 1, 1, 1, 1);
-    
+    i2c_conclr(obj, 1, 1, 0, 1);
+
     // The master mode may now be entered by setting the STA bit
     // this will generate a start condition when the bus becomes free
     i2c_conset(obj, 1, 0, 0, 1);
-    
+    // Clearing SI bit when it wasn't set on entry can jump past state
+    // 0x10 or 0x08 and erroneously send uninitialized slave address.
+    if (isInterrupted)
+        i2c_clear_SI(obj);
+
     i2c_wait_SI(obj);
     status = i2c_status(obj);
-    
-    // Clear start bit now transmitted, and interrupt bit
+
+    // Clear start bit now that it's transmitted
     i2c_conclr(obj, 1, 0, 0, 0);
     return status;
 }


### PR DESCRIPTION
In repeating start scenarios, there was a bug in the I2C driver for
various NXP LPCxxxx parts which could allow an extra I/O from the
previous operation to leak through. The scenario I encountered which
triggered this bug went like so:
* The higher level application code would first do an I2C write that
  doesn't send a stop bit (use repeating start instead.)
* The higher level application code would then issues an I2C read
  operation which begins with a call to i2c_start().
* i2c_start() would clear the SI bit (interrupt flag) at the top of
  its implementation.
* i2C_start() would then get interrupted right after clearing the SI
  bit.
  * While the CPU is off running the ISR code, the I2C peripheral
    repeats the last byte written to I2CDAT and then sets the SI bit to
    indicate that the write has completed.
  * The ISR returns to allow the i2c_start() to continue execution.
* i2c_start() would then set the STA bit but it is too late.
* i2c_start() waits for the SI bit to be set but it is already set
  because of the completed byte write and not because of the repeated
  start as expected.

For me this bug would cause strange interactions between my ISRs and
the code using I2C to read from the MPU-6050 IMU. I would be getting
valid orientation data and then all of a sudden I would start receiving
what looked like random values but I think it was just reading from the
incorrect offset in the device's FIFO.

It appears that atleast one other person has seen this before but it
was never root caused since it required specific timing to reproduce:
  https://developer.mbed.org/forum/bugs-suggestions/topic/4254/

This bug can be found in most of the NXP I2C drivers and this commit
contains a fix for them all. I however only have the LPC1768 and
LPC11U24 for testing.

My fix does the following:
* No longer clears the SI bit in the i2c_conclr() call near the
  beginning of the i2c_start() function. It was this clear that
  previously caused the problem as described above.
* The second part of the fix was to instead clear the SI bit after
  the STA (start) bit has been set with the i2c_conset() call.
* The clearing of the SI bit should be skipped if there isn't an
  active interrupt when first entering i2c_start(). If you clear
  the SI bit when there isn't an active interrupt then the code
  is likely to skip over the interrupt for the start bit which was
  just sent and then allow the I2C peripheral to start sending the
  slave address before it has even been loaded into the I2CDAT
  register.

**My Repro Case**
I wrote two samples to reproduce this bug and verify that it was fixed by this change. The master sample is expected to be connected to a device which is running the slave sample.

Master test code which is a modified version of what I found in https://github.com/mbedmicro/mbed/blob/master/libraries/tests/mbed/i2c_master/main.cpp  I modified it to read registers using repeated starts like I was doing with the MPU-6050 sensor. I then schedule an ISR to trigger at a random time in the range of when I expect the repeated start to occur:
```c++
#include "mbed.h"
//#include "test_env.h"
void notify_completion(bool wasTestSuccessful) {
    printf("Test completed - %s\n", wasTestSuccessful ? "PASSED" : "FAILED");
}

#define ADDR (0x90)

#if defined(TARGET_KL25Z)
I2C i2c(PTE0, PTE1);
#elif defined(TARGET_nRF51822)
I2C i2c(p22,p20);
#elif defined(TARGET_FF_ARDUINO) || defined(TARGET_MAXWSNENV)
I2C i2c(I2C_SDA, I2C_SCL);
#elif defined(TARGET_EFM32LG_STK3600) || defined(TARGET_EFM32GG_STK3700) || defined(TARGET_EFM32WG_STK3800)
#define TEST_SDA_PIN PD6
#define TEST_SCL_PIN PD7
I2C i2c(TEST_SDA_PIN, TEST_SCL_PIN);
#elif defined(TARGET_EFM32ZG_STK3200)
#define TEST_SDA_PIN PE12
#define TEST_SCL_PIN PE13
I2C i2c(TEST_SDA_PIN, TEST_SCL_PIN);
#elif defined(TARGET_EFM32HG_STK3400)
#define TEST_SDA_PIN PD6
#define TEST_SCL_PIN PD7
I2C i2c(TEST_SDA_PIN, TEST_SCL_PIN);
#elif defined(TARGET_SAMR21G18A)
#define TEST_SDA_PIN PA16
#define TEST_SCL_PIN PA17
I2C i2c(TEST_SDA_PIN, TEST_SCL_PIN);
#elif defined(TARGET_SAMD21J18A)
#define TEST_SDA_PIN PA08
#define TEST_SCL_PIN PA09
I2C i2c(TEST_SDA_PIN, TEST_SCL_PIN);
#else
I2C i2c(p28, p27);
#endif

#define I2C_MICROSECONDS_PER_BIT (1000000 / 100000)

void isrHandler(void);

int main() {
    Timeout timeout;
    bool success = true;
    char counter = 0;
    char reg = 0xA5;
    char expectedCounter = 0x5A;
    char writeCommand[] = { reg, expectedCounter };
    char readCommand[] = { reg };

    // Initialize counter.
    i2c.write(ADDR, writeCommand, sizeof(writeCommand), false);

    for (int i = 0 ; i < 1000000 ; i++) {
        // Schedule a Timeout object to fire
        // ~(1 start bit + 8 address bits + 1 ack bit + 8 reg bits + 1 ack bit) = 2*8 + 3*1 = 16+3 = 19 I2C bit periods.
        // Attempting to fire an interrupt between ack of register byte and repeated start. This used to cause
        // problems since the I2C engine would send the register byte again rather than the repeated start due to a bug
        // in the I2C driver which would clear the SI (interrupt) bit too early in i2c_start().
        int triggerOffset = rand() % (8 * I2C_MICROSECONDS_PER_BIT);
        int triggerTime = (15 * I2C_MICROSECONDS_PER_BIT) + triggerOffset;
        timeout.attach_us(isrHandler, triggerTime);

        // Read out counter where a repeated start is used for the read after the write.
        i2c.write(ADDR, readCommand, sizeof(readCommand), true);
        i2c.read(ADDR, &counter, sizeof(counter));
        if (counter != expectedCounter) {
            success = false;
            break;
        }
        expectedCounter++;
    }

    notify_completion(success);
}

void isrHandler(void)
{
    // Waste 2 I2C bytes worth of time in this ISR handler.
    wait_us(16 * I2C_MICROSECONDS_PER_BIT);
}
```

Slave test code which is a modified version of what I found in https://github.com/mbedmicro/mbed/blob/master/libraries/tests/mbed/i2c_slave/main.cpp  I modified it to support a register read/write protocol similar to MPU-6059 sensor. A write to the register sets an 8-bit counter and a read returns an auto-incremented version of the counter.

```c++
#include "mbed.h"

#define ADDR (0x90)

#if defined(TARGET_KL25Z)
I2CSlave slave(PTE0, PTE1);
#elif defined(TARGET_LPC4088)
I2CSlave slave(p9, p10);
#elif defined(TARGET_SAMR21G18A)
I2CSlave slave(PA16, PA17);
#elif defined(TARGET_SAMD21J18A)
I2CSlave slave(PA08, PA09);
#else
I2CSlave slave(p28, p27);
#endif

int main() {
    char command[2];
    char counter = 0;

    slave.address(ADDR);

    while (1) {
        // Read register address and its new value if a write register request.
        bool wasWriteRequest = false;
        int i2cState = slave.receive();
        switch (i2cState) {
        case I2CSlave::WriteAddressed:
            memset(command, 0xFF, sizeof(command));
            wasWriteRequest = !slave.read(command, sizeof(command));
            break;
        default:
            continue;
        }

        // Handle the register write now if both register address and register value were written at once.
        if (wasWriteRequest) {
            counter = command[1];
            continue;
        }

        // Now waiting for repeated start to begin register read.
        bool registerReadDone = false;
        while (!registerReadDone) {
            i2cState = slave.receive();
            switch (i2cState) {
            case I2CSlave::ReadAddressed:
                slave.write(&counter, sizeof(counter));
                counter++;
                registerReadDone = true;
                break;
            case I2CSlave::WriteAddressed:
                registerReadDone = true;
                break;
            case I2CSlave::WriteGeneral:
                registerReadDone = true;
                break;
            }
        }
    }
}
```

I couldn't get the slave code to work without a small modification to the i2c_slave_read() function as well. I am not that confident in this change so I just list the diff here for anyone trying to run this repro case.
```diff
diff --git a/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/i2c_api.c b/external/mbed/libraries/mbed
index c7eea7c..68617d8 100644
--- a/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/i2c_api.c
+++ b/external/mbed/libraries/mbed/targets/hal/TARGET_NXP/TARGET_LPC176X/i2c_api.c
@@ -346,8 +346,8 @@ int i2c_slave_read(i2c_t *obj, char *data, int length) {
         status = i2c_status(obj);
         if((status == 0x80) || (status == 0x90)) {
             data[count] = I2C_DAT(obj) & 0xFF;
+            count++;
         }
-        count++;
     } while (((status == 0x80) || (status == 0x90) ||
             (status == 0x060) || (status == 0x70)) && (count < length));
```
