### PR TITLE
Modify serial nc tests init part

### DIFF
--- a/libraries/tests/mbed/serial_nc_rx/main.cpp
+++ b/libraries/tests/mbed/serial_nc_rx/main.cpp
@@ -2,12 +2,12 @@
 #include "test_env.h"
 
 int main() {
+    Serial *pc = new Serial(USBTX, USBRX);
+
     MBED_HOSTTEST_TIMEOUT(20);
     MBED_HOSTTEST_SELECT(serial_nc_rx_auto);
     MBED_HOSTTEST_DESCRIPTION(Serial NC RX);
     MBED_HOSTTEST_START("MBED_37");
-
-    Serial *pc = new Serial(NC, USBRX);
 
     char c = pc->getc();
 

--- a/libraries/tests/mbed/serial_nc_rx/main.cpp
+++ b/libraries/tests/mbed/serial_nc_rx/main.cpp
@@ -11,22 +11,28 @@ int main() {
 
     char c = pc->getc();
 
-    delete pc;
 
-    // This should be true
-    if (c == 'E') {
-      Serial *pc = new Serial(USBTX, NC);
+    // This should be true, sync the start of test
+    if (c == 'S') {
+        pc->printf("RX OK - Start NC test\r\n");
 
-      pc->printf("RX OK - Expected\r\n");
+        // disconnect TX and  get char
+        delete pc;
+        pc = new Serial(NC, USBRX);
+        c = pc->getc();
+        if (c == 'E') {
+            // ok disconnect Rx and answer to host
+            delete pc;
+            pc = new Serial(USBTX, NC);
+            pc->printf("RX OK - Expected\r\n");
 
-      c = pc->getc();
-
-      // This should be false/not get here
-      if (c == 'U') {
-        pc->printf("RX OK - Unexpected\r\n");
-      }
-
-      delete pc;
+            c = pc->getc();
+            // This should be false/not get here
+            if (c == 'U') {
+                pc->printf("RX OK - Unexpected\r\n");
+            }
+        }
+        delete pc;
     }
 
     while (1) {

--- a/libraries/tests/mbed/serial_nc_tx/main.cpp
+++ b/libraries/tests/mbed/serial_nc_tx/main.cpp
@@ -2,13 +2,14 @@
 #include "test_env.h"
 
 int main() {
+    Serial *pc = new Serial(USBTX, USBRX);
+
     MBED_HOSTTEST_TIMEOUT(20);
     MBED_HOSTTEST_SELECT(serial_nc_tx_auto);
     MBED_HOSTTEST_DESCRIPTION(Serial NC TX);
     MBED_HOSTTEST_START("MBED_38");
 
     // Wait until we receive start signal from host test
-    Serial *pc = new Serial(USBTX, USBRX);
     char c = pc->getc();
     delete pc;
 

--- a/workspace_tools/host_tests/serial_nc_rx_auto.py
+++ b/workspace_tools/host_tests/serial_nc_rx_auto.py
@@ -25,6 +25,29 @@ class SerialNCRXTest():
 
     def test(self, selftest):
         selftest.mbed.flush();
+        # Wait 0.5 seconds to ensure mbed is listening
+        time.sleep(0.5)
+
+        #handshake with target to sync test start
+        selftest.mbed.serial_write("S");
+
+        strip_chars = string.whitespace + "\0"
+
+        out_str = selftest.mbed.serial_readline()
+
+        if not out_str:
+            selftest.notify("HOST: No output detected")
+            return selftest.RESULT_IO_SERIAL
+
+        out_str_stripped = out_str.strip(strip_chars)
+
+        if out_str_stripped != "RX OK - Start NC test":
+            selftest.notify("HOST: Unexpected output. Expected 'RX OK - Expected' but received '%s'" % out_str_stripped)
+            return selftest.RESULT_FAILURE
+
+        # Wait 0.5 seconds to ensure mbed is listening
+        time.sleep(0.5)
+
         selftest.mbed.serial_write("E");
 
         strip_chars = string.whitespace + "\0"

--- a/workspace_tools/host_tests/serial_nc_tx_auto.py
+++ b/workspace_tools/host_tests/serial_nc_tx_auto.py
@@ -25,6 +25,9 @@ class SerialNCTXTest():
 
     def test(self, selftest):
         selftest.mbed.flush();
+        # Wait 0.5 seconds to ensure mbed is listening
+        time.sleep(0.5)
+
         selftest.mbed.serial_write("S");
 
         strip_chars = string.whitespace + "\0"


### PR DESCRIPTION
During initialization phase of the 2 NC serial tests,
there is a character being sent from host to target,
based on MBED_HOSTTEST_START. The problem is that
the target firmware then creates a "new" serial on the
same serial interface. the new or should, or at least may,
induce a reset of the IP, so that the character sent by host
would be lost. So we're moving the new earlier.

the real testing part happens later, to check the next
character is not received or sent.