### PR TITLE
Add lifetime management to threads

### DIFF
--- a/rtos/rtos/Thread.cpp
+++ b/rtos/rtos/Thread.cpp
@@ -34,7 +34,7 @@ namespace rtos {
 
 Thread::Thread(osPriority priority,
         uint32_t stack_size, unsigned char *stack_pointer):
-        _tid(NULL), _dynamic_stack(stack_pointer == NULL) {
+        _tid(0), _dynamic_stack(stack_pointer == NULL) {
 #if defined(__MBED_CMSIS_RTOS_CA9) || defined(__MBED_CMSIS_RTOS_CM)
     _thread_def.tpriority = priority;
     _thread_def.stacksize = stack_size;
@@ -44,7 +44,7 @@ Thread::Thread(osPriority priority,
 
 Thread::Thread(void (*task)(void const *argument), void *argument,
         osPriority priority, uint32_t stack_size, unsigned char *stack_pointer):
-        _tid(NULL), _dynamic_stack(stack_pointer == NULL) {
+        _tid(0), _dynamic_stack(stack_pointer == NULL) {
 #if defined(__MBED_CMSIS_RTOS_CA9) || defined(__MBED_CMSIS_RTOS_CM)
     _thread_def.tpriority = priority;
     _thread_def.stacksize = stack_size;

--- a/rtos/rtos/Thread.h
+++ b/rtos/rtos/Thread.h
@@ -30,6 +30,15 @@ namespace rtos {
 /** The Thread class allow defining, creating, and controlling thread functions in the system. */
 class Thread {
 public:
+    /** Allocate a new thread without starting execution
+      @param   priority       initial priority of the thread function. (default: osPriorityNormal).
+      @param   stack_size      stack size (in bytes) requirements for the thread function. (default: DEFAULT_STACK_SIZE).
+      @param   stack_pointer  pointer to the stack area to be used by this thread (default: NULL).
+    */
+    Thread(osPriority priority=osPriorityNormal,
+           uint32_t stack_size=DEFAULT_STACK_SIZE,
+           unsigned char *stack_pointer=NULL);
+
     /** Create a new thread, and start it executing the specified function.
       @param   task           function to be executed by this thread.
       @param   argument       pointer that is passed to the thread function as start argument. (default: NULL).
@@ -41,6 +50,19 @@ public:
            osPriority priority=osPriorityNormal,
            uint32_t stack_size=DEFAULT_STACK_SIZE,
            unsigned char *stack_pointer=NULL);
+
+    /** Starts a thread executing the specified function.
+      @param   task           function to be executed by this thread.
+      @param   argument       pointer that is passed to the thread function as start argument. (default: NULL).
+      @return  status code that indicates the execution status of the function.
+    */
+    osStatus start(void (*task)(void const *argument), void *argument=NULL);
+
+    /** Wait for thread to terminate
+      @return  status code that indicates the execution status of the function.
+      @note not callable from interrupt
+    */
+    osStatus join();
 
     /** Terminate execution of a thread and remove it from Active Threads
       @return  status code that indicates the execution status of the function.
@@ -113,17 +135,20 @@ public:
       @param   signals   wait until all specified signal flags set or 0 for any single signal flag.
       @param   millisec  timeout value or 0 in case of no time-out. (default: osWaitForever).
       @return  event flag information or error code.
+      @note not callable from interrupt
     */
     static osEvent signal_wait(int32_t signals, uint32_t millisec=osWaitForever);
 
     /** Wait for a specified time period in millisec:
       @param   millisec  time delay value
       @return  status code that indicates the execution status of the function.
+      @note not callable from interrupt
     */
     static osStatus wait(uint32_t millisec);
 
     /** Pass control to next thread that is in state READY.
       @return  status code that indicates the execution status of the function.
+      @note not callable from interrupt
     */
     static osStatus yield();
 


### PR DESCRIPTION
Problem:
- Threads begin running when constructed, allocation and execution are unnecessarily coupled
- Errors on starting threads can not be easily propagated
- Exacerbates issues with rtos initialization
- Threads lack join method, encouraging termination which can lead to very strange bugs

Proposed solution:
- Add Thread::start for explicitly starting threads and handling errors
- Defer to Thread::start from constructor if function is provided, **keeping backwards compatibility**
- Add Thread::join for gracefully merging threads

Thread::start in other languages: [c++](http://www.cplusplus.com/reference/thread/thread/operator=/), [c](http://man7.org/linux/man-pages/man3/pthread_create.3.html), [java](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html#start%28%29), [python](https://docs.python.org/2/library/threading.html#threading.Thread.start)
Thread::join in other languages: [c++](http://www.cplusplus.com/reference/thread/thread/join/), [c](http://man7.org/linux/man-pages/man3/pthread_join.3.html), [java](https://docs.oracle.com/javase/7/docs/api/java/lang/Thread.html#join%28%29), [python](https://docs.python.org/2/library/threading.html#threading.Thread.join)

cc @niklas-arm, @sg-, @c1728p9, @0xc0170 
mv [#79](https://github.com/ARMmbed/mbed-os/pull/79)