### PR TITLE
[STM32F0xx] LowPowerTicker implementation

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -569,7 +569,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f030r8"},
         "detect_code": ["0725"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small"
     },
     "NUCLEO_F031K6": {
@@ -605,7 +605,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f070rb"},
         "detect_code": ["0755"],
-        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small"
     },
     "NUCLEO_F072RB": {
@@ -617,7 +617,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f072rb"},
         "detect_code": ["0730"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small"
     },
     "NUCLEO_F091RC": {
@@ -629,7 +629,7 @@
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f091rc"},
         "detect_code": ["0750"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small"
     },
     "NUCLEO_F103RB": {

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/lp_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/lp_ticker.c
@@ -1,0 +1,94 @@
+/* mbed Microcontroller Library
+ *******************************************************************************
+ * Copyright (c) 2016, STMicroelectronics
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 3. Neither the name of STMicroelectronics nor the names of its contributors
+ *    may be used to endorse or promote products derived from this software
+ *    without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+ * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+ * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *******************************************************************************
+ */
+#include "device.h"
+
+#if DEVICE_LOWPOWERTIMER
+
+#include "ticker_api.h"
+#include "lp_ticker_api.h"
+#include "rtc_api.h"
+#include "rtc_api_hal.h"
+
+static uint8_t lp_ticker_inited = 0;
+static uint8_t lp_ticker_reconf_presc = 0;
+
+void lp_ticker_init() {
+    if (lp_ticker_inited) return;
+    lp_ticker_inited = 1;
+
+    rtc_init();
+    rtc_set_irq_handler((uint32_t) lp_ticker_irq_handler);
+}
+
+uint32_t lp_ticker_read() {
+    uint32_t sub_secs, milis;
+    time_t time;
+
+    lp_ticker_init();
+
+    time = rtc_read();
+    sub_secs = rtc_read_subseconds();
+    milis = 1000 - (sub_secs * 1000 / rtc_ticker_get_synch_presc());
+
+    return (time * 1000000) + (milis * 1000);
+}
+
+void lp_ticker_set_interrupt(timestamp_t timestamp) {
+    uint32_t sub_secs, delta, milis;
+    time_t secs;
+    struct tm *timeinfo;
+
+    // Reconfigure RTC prescalers whenever the timestamp is below 30ms
+    if (!lp_ticker_reconf_presc && timestamp < 30000) {
+        rtc_reconfigure_prescalers();
+        lp_ticker_reconf_presc = 1;
+    }
+
+    milis = (timestamp % 1000000) / 1000;
+
+    secs = rtc_read();
+    delta = ((timestamp / 1000000) - secs);
+
+    secs += delta;
+    sub_secs = (rtc_ticker_get_synch_presc() * (1000 - milis)) / 1000;
+    timeinfo = localtime(&secs);
+
+    rtc_set_alarm(timeinfo, sub_secs);
+}
+
+void lp_ticker_disable_interrupt() {
+    lp_ticker_reconf_presc = 0;
+    rtc_ticker_disable_irq();
+}
+
+void lp_ticker_clear_interrupt() {
+}
+
+#endif

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/rtc_api_hal.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/rtc_api_hal.h
@@ -1,0 +1,61 @@
+/* mbed Microcontroller Library
+*******************************************************************************
+* Copyright (c) 2016, STMicroelectronics
+* All rights reserved.
+*
+* Redistribution and use in source and binary forms, with or without
+* modification, are permitted provided that the following conditions are met:
+*
+* 1. Redistributions of source code must retain the above copyright notice,
+*    this list of conditions and the following disclaimer.
+* 2. Redistributions in binary form must reproduce the above copyright notice,
+*    this list of conditions and the following disclaimer in the documentation
+*    and/or other materials provided with the distribution.
+* 3. Neither the name of STMicroelectronics nor the names of its contributors
+*    may be used to endorse or promote products derived from this software
+*    without specific prior written permission.
+*
+* THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+* AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+* IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+* DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+* FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+* DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+* SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+* CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+* OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+* OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*******************************************************************************
+*/
+
+#ifndef MBED_RTC_API_HAL_H
+#define MBED_RTC_API_HAL_H
+
+#include <stdint.h>
+#include "rtc_api.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+/*
+ * Extend rtc_api.h
+ */
+
+// Prescaler values for LSE clock
+#define RTC_ASYNCH_PREDIV   0x7F
+#define RTC_SYNCH_PREDIV    0x00FF
+
+void rtc_set_irq_handler(uint32_t handler);
+
+void rtc_ticker_disable_irq();
+uint32_t rtc_ticker_get_synch_presc();
+
+void rtc_set_alarm(struct tm *ti, uint32_t subsecs);
+uint32_t rtc_read_subseconds();
+void rtc_reconfigure_prescalers();
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif


### PR DESCRIPTION
LowPowerTicker for STM32F0xx family is implemented using the RTC periodic unit
functionality. For more informations please follow this document: 

* www.st.com/resource/en/application_note/dm00025071.pdf

Supported platforms:

- NUCLEO_F072RB
- NUCLEO_F070RB
- NUCLEO_F091RC
