### PR TITLE
Remove __enable and __disable irq calls from mbed hal common code

### DIFF
--- a/hal/common/SPI.cpp
+++ b/hal/common/SPI.cpp
@@ -14,6 +14,7 @@
  * limitations under the License.
  */
 #include "SPI.h"
+#include "critical.h"
 
 #if DEVICE_SPI
 
@@ -124,12 +125,12 @@ int SPI::queue_transfer(const void *tx_buffer, int tx_length, void *rx_buffer, i
     if (_transaction_buffer.full()) {
         return -1; // the buffer is full
     } else {
-        __disable_irq();
+        core_util_critical_section_enter();
         _transaction_buffer.push(transaction);
         if (!spi_active(&_spi)) {
             dequeue_transaction();
         }
-        __enable_irq();
+        core_util_critical_section_exit();
         return 0;
     }
 #else

--- a/hal/common/board.c
+++ b/hal/common/board.c
@@ -21,7 +21,7 @@
 
 WEAK void mbed_die(void) {
 #if !defined (NRF51_H) && !defined(TARGET_EFM32)
-		core_util_critical_section_enter();
+    core_util_critical_section_enter();
 #endif
 #if   (DEVICE_ERROR_RED == 1)
     gpio_t led_red; gpio_init_out(&led_red, LED_RED);

--- a/hal/common/board.c
+++ b/hal/common/board.c
@@ -17,10 +17,11 @@
 #include "wait_api.h"
 #include "toolchain.h"
 #include "mbed_interface.h"
+#include "critical.h"
 
 WEAK void mbed_die(void) {
 #if !defined (NRF51_H) && !defined(TARGET_EFM32)
-	__disable_irq();	// dont allow interrupts to disturb the flash pattern
+		core_util_critical_section_enter();
 #endif
 #if   (DEVICE_ERROR_RED == 1)
     gpio_t led_red; gpio_init_out(&led_red, LED_RED);

--- a/libraries/tests/libs/SerialHalfDuplex/SerialHalfDuplex.cpp
+++ b/libraries/tests/libs/SerialHalfDuplex/SerialHalfDuplex.cpp
@@ -2,6 +2,7 @@
  * Copyright (c) 2010-2011 ARM Limited. All rights reserved.
  */
 #include "SerialHalfDuplex.h"
+#include "critical.h"
 
 #if DEVICE_SERIAL
 
@@ -29,7 +30,7 @@ int SerialHalfDuplex::_putc(int c) {
     int retc;
 
     // TODO: We should not disable all interrupts
-    __disable_irq();
+    core_util_critical_section_enter();
 
     serial_pinout_tx(gpio.pin);
 
@@ -38,7 +39,7 @@ int SerialHalfDuplex::_putc(int c) {
 
     pin_function(gpio.pin, 0);
 
-    __enable_irq();
+    core_util_critical_section_exit();
 
     return retc;
 }


### PR DESCRIPTION
This is an extension of https://github.com/mbedmicro/mbed/pull/1806

Work left to be done:
hal/targets - This is partner code and should be consulted with them
rtos - We need to look here