### PR TITLE
[STM32F3] Use USART3_BASE instead of UART3_BASE

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/PeripheralNames.h
@@ -48,7 +48,7 @@ typedef enum {
 
 typedef enum {
     UART_1 = (int)USART1_BASE,
-    UART_2 = (int)USART2_BASE
+    UART_2 = (int)USART2_BASE,
 } UARTName;
 
 #define STDIO_UART_TX  PA_2

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/PeripheralNames.h
@@ -49,6 +49,7 @@ typedef enum {
 typedef enum {
     UART_1 = (int)USART1_BASE,
     UART_2 = (int)USART2_BASE,
+    UART_3 = (int)USART3_BASE // defined for compilation issue. UART3 is not present on STM32F303K8
 } UARTName;
 
 #define STDIO_UART_TX  PA_2

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/serial_api.c
@@ -94,7 +94,7 @@ void serial_init(serial_t *obj, PinName tx, PinName rx)
         __HAL_RCC_USART2_CONFIG(RCC_USART2CLKSOURCE_SYSCLK);
         obj->index = 1;
     }
-#if defined(UART3_BASE)
+#if defined(USART3_BASE)
     if (obj->uart == UART_3) {
         __USART3_CLK_ENABLE();
         __HAL_RCC_USART3_CONFIG(RCC_USART3CLKSOURCE_SYSCLK);
@@ -157,7 +157,7 @@ void serial_free(serial_t *obj)
         __USART2_RELEASE_RESET();
         __USART2_CLK_DISABLE();
     }
-#if defined(UART3_BASE)
+#if defined(USART3_BASE)
     if (obj->uart == UART_3) {
         __USART3_FORCE_RESET();
         __USART3_RELEASE_RESET();
@@ -252,7 +252,7 @@ static void uart2_irq(void)
     uart_irq(UART_2, 1);
 }
 
-#if defined(UART3_BASE)
+#if defined(USART3_BASE)
 static void uart3_irq(void)
 {
     uart_irq(UART_3, 2);
@@ -296,7 +296,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
         vector = (uint32_t)&uart2_irq;
     }
 
-#if defined(UART3_BASE)
+#if defined(USART3_BASE)
     if (obj->uart == UART_3) {
         irq_n = USART3_IRQn;
         vector = (uint32_t)&uart3_irq;


### PR DESCRIPTION
This change allows the use of UART3 instance.
This change fixes the following issue :
https://developer.mbed.org/questions/4937/Serial-problem-no-Tx-to-PB_10
It's been validated on NUCLEO_F302RB, for PB_9 and PB_10 pins