### PR TITLE
Update K64F memory map for for larger static data

### DIFF
--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_GCC_ARM/MK64FN1M0xxx12.ld
@@ -202,7 +202,7 @@ SECTIONS
     KEEP(*(.jcr*))
     . = ALIGN(4);
     __data_end__ = .;        /* define a global symbol at data end */
-  } > m_data
+  } > m_data_2
 
   __DATA_END = __DATA_ROM + (__data_end__ - __data_start__);
   text_end = ORIGIN(m_text) + LENGTH(m_text);
@@ -225,7 +225,7 @@ SECTIONS
     . = ALIGN(4);
     __bss_end__ = .;
     __END_BSS = .;
-  } > m_data
+  } > m_data_2
 
   .heap :
   {


### PR DESCRIPTION
The KSDK2 update restricts static data to the first 64K of RAM.
This breaks some applications which require more than 64K of
static data.  This patch moves the static data sections
(bss and data) into the second ram region which is 192K.

Changes taken from similar patches here:
https://github.com/ARMmbed/target-kinetis-k64-gcc/pull/5
https://github.com/ARMmbed/target-kinetis-k64-gcc/pull/6