### PR TITLE
[NUCLEO_L476RG, DISCO_L476VG]: GCC_ARM, ARM_STD fix RTOS failed

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
+__initial_sp    EQU     0x20018000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
                 PRESERVE8
                 THUMB

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
@@ -36,12 +36,11 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
+  RW_IRAM1 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
-
-  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
+ ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
+  RW_IRAM2 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -112,7 +112,7 @@ SECTIONS
         __data_end__ = .;
         _edata = .;
 
-    } > SRAM2
+    } > SRAM1
 
     .bss :
     {
@@ -124,7 +124,7 @@ SECTIONS
         . = ALIGN(4);
         __bss_end__ = .;
         _ebss = .;
-    } > SRAM2
+    } > SRAM1
 
     .heap (COPY):
     {
@@ -132,7 +132,7 @@ SECTIONS
         end = __end__;
         *(.heap*)
         __HeapLimit = .;
-    } > SRAM2
+    } > SRAM1
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -144,7 +144,7 @@ SECTIONS
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
+    __StackTop = ORIGIN(SRAM1) + LENGTH(SRAM1);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/startup_stm32l476xx.s
@@ -42,7 +42,7 @@
                 AREA    STACK, NOINIT, READWRITE, ALIGN=3
                 EXPORT  __initial_sp
 
-__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
+__initial_sp    EQU     0x20018000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
 ; <h> Heap Configuration
 ;   <o>  Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_MICRO/stm32l476xx.sct
@@ -36,12 +36,11 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
    .ANY (+RO)
   }
 
-  ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
+  RW_IRAM1 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
-
-  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
+ ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
+  RW_IRAM2 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/startup_stm32l476xx.s
@@ -39,7 +39,7 @@
 ; 
 ;*******************************************************************************
 
-__initial_sp    EQU     0x10008000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
+__initial_sp    EQU     0x20018000 ; Top of RAM, L4-ECC-SRAM2 retained in standby
 
                 PRESERVE8
                 THUMB

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_ARM_STD/stm32l476xx.sct
@@ -35,13 +35,12 @@ LR_IROM1 0x08000000 0x100000  {    ; load region size_region
    *(InRoot$$Sections)
    .ANY (+RO)
   }
-
-  ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
-  RW_IRAM1 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
+ 
+  RW_IRAM1 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
    .ANY (+RW +ZI)
   }
-
-  RW_IRAM2 0x20000000 0x00018000  { ; RW data 96k L4-SRAM1
+ ; Total: 98 vectors = 392 bytes (0x188) to be reserved in RAM
+  RW_IRAM2 (0x10000000+0x188) (0x08000-0x188)  {  ; RW data 32k L4-ECC-SRAM2 retained in standby
    .ANY (+RW +ZI)
   }
 

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/TOOLCHAIN_GCC_ARM/STM32L476XX.ld
@@ -112,7 +112,7 @@ SECTIONS
         __data_end__ = .;
         _edata = .;
 
-    } > SRAM2
+    } > SRAM1
 
     .bss :
     {
@@ -124,7 +124,7 @@ SECTIONS
         . = ALIGN(4);
         __bss_end__ = .;
         _ebss = .;
-    } > SRAM2
+    } > SRAM1
 
     .heap (COPY):
     {
@@ -132,7 +132,7 @@ SECTIONS
         end = __end__;
         *(.heap*)
         __HeapLimit = .;
-    } > SRAM2
+    } > SRAM1
 
     /* .stack_dummy section doesn't contains any symbols. It is only
      * used for linker to calculate size of stack sections, and assign
@@ -140,11 +140,11 @@ SECTIONS
     .stack_dummy (COPY):
     {
         *(.stack*)
-    } > SRAM2
+    } > SRAM1
 
     /* Set stack top to end of RAM, and stack limit move down by
      * size of stack_dummy section */
-    __StackTop = ORIGIN(SRAM2) + LENGTH(SRAM2);
+    __StackTop = ORIGIN(SRAM1) + LENGTH(SRAM1);
     _estack = __StackTop;
     __StackLimit = __StackTop - SIZEOF(.stack_dummy);
     PROVIDE(__stack = __StackTop);


### PR DESCRIPTION
aligned heap, stack config with IAR

issue: #1845