### PR TITLE
[STM32L0XX] SlaveCounter type correction

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/hal_tick.c
@@ -40,7 +40,7 @@ uint32_t PreviousVal = 0;
 void us_ticker_irq_handler(void);
 void set_compare(uint16_t count);
 
-extern volatile uint32_t SlaveCounter;
+extern volatile uint16_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
 
@@ -138,8 +138,8 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
 /**
   * @}
   */
-  
+
 /**
   * @}
-  */    
+  */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/hal_tick.c
@@ -40,7 +40,7 @@ uint32_t PreviousVal = 0;
 void us_ticker_irq_handler(void);
 void set_compare(uint16_t count);
 
-extern volatile uint32_t SlaveCounter;
+extern volatile uint16_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
 
@@ -138,8 +138,8 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
 /**
   * @}
   */
-  
+
 /**
   * @}
-  */    
+  */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/hal_tick.c
@@ -40,7 +40,7 @@ uint32_t PreviousVal = 0;
 void us_ticker_irq_handler(void);
 void set_compare(uint16_t count);
 
-extern volatile uint32_t SlaveCounter;
+extern volatile uint16_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
 
@@ -138,8 +138,8 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
 /**
   * @}
   */
-  
+
 /**
   * @}
-  */    
+  */
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/


### PR DESCRIPTION
After the PR #1743 there were some misalignment between `hal_tick.c` and `us_ticker.c` for SlaveCounter type.