### PR TITLE
Add a serial transmission complete test

### DIFF
--- a/libraries/tests/mbed/serial_complete/main.cpp
+++ b/libraries/tests/mbed/serial_complete/main.cpp
@@ -1,0 +1,17 @@
+#include "mbed.h"
+#include "test_env.h"
+
+Serial *pc = new Serial(USBTX, USBRX);
+
+int main() {
+    MBED_HOSTTEST_TIMEOUT(20);
+    MBED_HOSTTEST_SELECT(serial_complete_auto);
+    MBED_HOSTTEST_DESCRIPTION(Serial Complete);
+    MBED_HOSTTEST_START("MBED_39");
+
+    pc->printf("123456789");
+
+    while (1) {
+        deepsleep();
+    }
+}

--- a/tools/host_tests/__init__.py
+++ b/tools/host_tests/__init__.py
@@ -33,6 +33,7 @@ from udpecho_client_auto import UDPEchoClientTest
 from wfi_auto import WFITest
 from serial_nc_rx_auto import SerialNCRXTest
 from serial_nc_tx_auto import SerialNCTXTest
+from serial_complete_auto import SerialCompleteTest
 
 # Populate registry with supervising objects
 HOSTREGISTRY = HostRegistry()
@@ -52,6 +53,7 @@ HOSTREGISTRY.register_host_test("udpecho_client_auto", UDPEchoClientTest())
 HOSTREGISTRY.register_host_test("wfi_auto", WFITest())
 HOSTREGISTRY.register_host_test("serial_nc_rx_auto", SerialNCRXTest())
 HOSTREGISTRY.register_host_test("serial_nc_tx_auto", SerialNCTXTest())
+HOSTREGISTRY.register_host_test("serial_complete_auto", SerialCompleteTest())
 
 ###############################################################################
 # Functional interface for test supervisor registry

--- a/tools/host_tests/serial_complete_auto.py
+++ b/tools/host_tests/serial_complete_auto.py
@@ -1,0 +1,43 @@
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+import sys
+import uuid
+import time
+import string
+from sys import stdout
+
+class SerialCompleteTest():
+
+    def test(self, selftest):
+        strip_chars = string.whitespace + "\0"
+        out_str = selftest.mbed.serial_readline()
+        selftest.notify("HOST: " + out_str)
+
+        if not out_str:
+            selftest.notify("HOST: No output detected")
+            return selftest.RESULT_IO_SERIAL
+
+        out_str_stripped = out_str.strip(strip_chars)
+
+        if out_str_stripped != "123456789":
+            selftest.notify("HOST: Unexpected output. '123456789' Expected. but received '%s'" % out_str_stripped)
+            return selftest.RESULT_FAILURE
+
+        else:
+            return selftest.RESULT_SUCCESS
+

--- a/tools/tests.py
+++ b/tools/tests.py
@@ -653,6 +653,12 @@ TESTS = [
         "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
         "automated": True
     },
+    {
+        "id": "MBED_39", "description": "Serial Complete",
+        "source_dir": join(TEST_DIR, "mbed", "serial_complete"),
+        "dependencies": [MBED_LIBRARIES, TEST_MBED_LIB],
+        "automated": True
+    },
 
     # CMSIS RTOS tests
     {


### PR DESCRIPTION
This automated test makes sure that the serial
syncrhonous API ensures a full transmission before
the function returns. The complete string sent by
printf shall be completely transferred before printf
returns and the sleep modes are called.

mbed Issue #1849