### PR TITLE
[NUCLEO_F103RB] Revert and update path for 16-bit timer

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
@@ -43,10 +43,9 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
-extern volatile uint16_t cnt_val;
 
 void timer_irq_handler(void) {
-    cnt_val= TIM_MST->CNT;
+    uint16_t cval = TIM_MST->CNT;
 
     TimMasterHandle.Instance = TIM_MST;
 
@@ -65,7 +64,7 @@ void timer_irq_handler(void) {
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cnt_val; // To finish the counter loop the next time
+                oc_rem_part = cval; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/hal_tick.c
@@ -43,9 +43,10 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
+extern volatile uint16_t cnt_val;
 
 void timer_irq_handler(void) {
-    uint16_t cval = TIM_MST->CNT;
+    cnt_val = TIM_MST->CNT;
 
     TimMasterHandle.Instance = TIM_MST;
 
@@ -64,7 +65,7 @@ void timer_irq_handler(void) {
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
+                oc_rem_part = cnt_val; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();


### PR DESCRIPTION
Due to directory structure change, modification in e93878078 was made wrong
after rebasing the code.

This reverts commit e938780788532504f6197fefb5aa909bf3c00583 and updates the path
to the correct file.

Note:
Current value of TIM_MST->CNT is read in interrupt context only.
This avoids master timer overflow without SlaveCounter update.

Continuation of patch: 07b841b08f2b173253e9268403738dbeb8df82ea