### PR TITLE
Fix support for InterruptManager on KSDK 2

### DIFF
--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/cmsis_nvic.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/cmsis_nvic.h
@@ -32,6 +32,9 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
+#define NVIC_NUM_VECTORS      (16 + 74)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
 #include "cmsis.h"
 
 #ifdef __cplusplus

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/cmsis_nvic.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/cmsis_nvic.h
@@ -32,6 +32,9 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
+#define NVIC_NUM_VECTORS      (16 + 86)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
 #include "cmsis.h"
 
 #ifdef __cplusplus

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/cmsis_nvic.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/cmsis_nvic.h
@@ -32,6 +32,9 @@
 #ifndef MBED_CMSIS_NVIC_H
 #define MBED_CMSIS_NVIC_H
 
+#define NVIC_NUM_VECTORS      (16 + 32)   // CORE + MCU Peripherals
+#define NVIC_USER_IRQ_OFFSET  16
+
 #include "cmsis.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION
Add the define NVIC_NUM_VECTORS for KSDK 2 targets so InterruptManager
is supported.