### PR TITLE
Preventing a traceback when a library is not built during export

### DIFF
--- a/workspace_tools/export/__init__.py
+++ b/workspace_tools/export/__init__.py
@@ -143,6 +143,9 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
 # Generate project folders following the online conventions
 ###############################################################################
 def copy_tree(src, dst, clean=True):
+    """
+    Copies the 'src' directory recursively to 'dst' directory
+    """
     if exists(dst):
         if clean:
             rmtree(dst)
@@ -151,23 +154,36 @@ def copy_tree(src, dst, clean=True):
 
     copytree(src, dst)
 
-
 def setup_user_prj(user_dir, prj_path, lib_paths=None):
     """
     Setup a project with the same directory structure of the mbed online IDE
     """
+    report = {'success': True, 'errormsg':''}
+    
     mkdir(user_dir)
 
     # Project Path
-    copy_tree(prj_path, join(user_dir, "src"))
+    if exists(prj_path):
+        copy_tree(prj_path, join(user_dir, "src"))
+        
+        # Project Libraries
+        user_lib = join(user_dir, "lib")
+        mkdir(user_lib)
+    
+        if lib_paths is not None:
+            for lib_path in lib_paths:
+                if exists(lib_path):
+                    copy_tree(lib_path, join(user_lib, basename(lib_path)))
+                else:
+                    report['success'] = False
+                    report['errormsg'] = "Library path '%s' does not exist. Ensure that the library is built." % (lib_path)
+                    break
+    else:
+        report['success'] = False
+        report['errormsg'] = "Project path '%s' does not exist" % (prj_path)
+        
+    return report
 
-    # Project Libraries
-    user_lib = join(user_dir, "lib")
-    mkdir(user_lib)
-
-    if lib_paths is not None:
-        for lib_path in lib_paths:
-            copy_tree(lib_path, join(user_lib, basename(lib_path)))
 
 def mcu_ide_matrix(verbose_html=False, platform_filter=None):
     """  Shows target map using prettytable """

--- a/workspace_tools/project.py
+++ b/workspace_tools/project.py
@@ -173,16 +173,20 @@ if __name__ == '__main__':
 
         # Build the project with the same directory structure of the mbed online IDE
         project_dir = join(EXPORT_WORKSPACE, test.id)
-        setup_user_prj(project_dir, test.source_dir, test.dependencies)
-
-        # Export to selected toolchain
-        tmp_path, report = export(project_dir, test.id, ide, mcu, EXPORT_WORKSPACE, EXPORT_TMP, extra_symbols=lib_symbols)
-        if report['success']:
-            zip_path = join(EXPORT_DIR, "%s_%s_%s.zip" % (test.id, ide, mcu))
-            move(tmp_path, zip_path)
-            successes.append("%s::%s\t%s"% (mcu, ide, zip_path))
-        else:
+        
+        report = setup_user_prj(project_dir, test.source_dir, test.dependencies)
+        
+        if not report['success']:
             failures.append("%s::%s\t%s"% (mcu, ide, report['errormsg']))
+        else:        
+            # Export to selected toolchain
+            tmp_path, report = export(project_dir, test.id, ide, mcu, EXPORT_WORKSPACE, EXPORT_TMP, extra_symbols=lib_symbols)
+            if report['success']:
+                zip_path = join(EXPORT_DIR, "%s_%s_%s.zip" % (test.id, ide, mcu))
+                move(tmp_path, zip_path)
+                successes.append("%s::%s\t%s"% (mcu, ide, zip_path))
+            else:
+                failures.append("%s::%s\t%s"% (mcu, ide, report['errormsg']))
 
     # Prints export results
     print


### PR DESCRIPTION
This fixes issue #1864.

## Output before PR
```
Traceback (most recent call last):
  File "..\mbed\workspace_tools\project.py", line 176, in <module>
    setup_user_prj(project_dir, test.source_dir, test.dependencies)
  File "C:\mbed\workspace_tools\export\__init__.py", line 170, in setup_user_prj
    copy_tree(lib_path, join(user_lib, basename(lib_path)))
  File "C:\mbed\workspace_tools\export\__init__.py", line 152, in copy_tree
    copytree(src, dst)
  File "C:\Python27\lib\shutil.py", line 171, in copytree
    names = os.listdir(src)
WindowsError: [Error 3] The system cannot find the path specified: 'C:\\mbed\\.build\\rtos/*.*'
```

## Output after PR
```
$python workspace_tools\project.py -c -m NUCLEO_F746ZG -p 96 -i uvision5

Failed exports:
  * NUCLEO_F746ZG::uvision5     Library path 'C:\Users\bridan01\Documents\dev\mbed\.build\rtos' does not exist. Ensure that the library is built.
```

cc @adustm and @0xc0170 