### PR TITLE
Refactors many exporters to use toolchain flags

### DIFF
--- a/tools/export/atmelstudio.py
+++ b/tools/export/atmelstudio.py
@@ -71,6 +71,7 @@ class AtmelStudio(Exporter):
             'solution_uuid': solution_uuid.upper(),
             'project_uuid': project_uuid.upper()
         }
+        ctx.update(self.progen_flags)
         target = self.target.lower()
         self.gen_file('atmelstudio6_2.atsln.tmpl', ctx, '%s.atsln' % self.program_name)
         self.gen_file('atmelstudio6_2.cppproj.tmpl', ctx, '%s.cppproj' % self.program_name)

--- a/tools/export/atmelstudio6_2.cppproj.tmpl
+++ b/tools/export/atmelstudio6_2.cppproj.tmpl
@@ -60,7 +60,7 @@
   <armgcc.compiler.optimization.level>Optimize for size (-Os)</armgcc.compiler.optimization.level>
   <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
   <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
-  <armgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -MMD -MP</armgcc.compiler.miscellaneous.OtherFlags>
+  <armgcc.compiler.miscellaneous.OtherFlags>{{c_flags|join(" ")}} {{common_flags|join(" ")}} -MMD -MP</armgcc.compiler.miscellaneous.OtherFlags>
   <armgcccpp.compiler.symbols.DefSymbols>
     <ListValues>
       <Value>NDEBUG</Value>
@@ -77,7 +77,7 @@
   <armgcccpp.compiler.optimization.level>Optimize for size (-Os)</armgcccpp.compiler.optimization.level>
   <armgcccpp.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcccpp.compiler.optimization.PrepareFunctionsForGarbageCollection>
   <armgcccpp.compiler.warnings.AllWarnings>True</armgcccpp.compiler.warnings.AllWarnings>
-  <armgcccpp.compiler.miscellaneous.OtherFlags>-std=gnu++98 -fno-rtti -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -MMD -MP</armgcccpp.compiler.miscellaneous.OtherFlags>
+  <armgcccpp.compiler.miscellaneous.OtherFlags>{{cxx_flags|join(" ")}} {{common_flags|join(" ")}} -MMD -MP</armgcccpp.compiler.miscellaneous.OtherFlags>
   <armgcccpp.linker.libraries.Libraries>
     <ListValues>
       <Value>libm</Value>
@@ -88,7 +88,7 @@
     </ListValues>
   </armgcccpp.linker.libraries.LibrarySearchPaths>
   <armgcccpp.linker.optimization.GarbageCollectUnusedSections>True</armgcccpp.linker.optimization.GarbageCollectUnusedSections>
-  <armgcccpp.linker.miscellaneous.LinkerFlags>{% for p in library_paths %}-L../{{p}} {% endfor %} {% for f in object_files %}../{{f}} {% endfor %} {% for lib in libraries %}-l{{lib}} {% endfor %} -T../{{linker_script}} -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float -Wl,--wrap,main -Wl,--cref -lstdc++ -lsupc++ -lm -lgcc -Wl,--start-group -lc -lc -lnosys -Wl,--end-group </armgcccpp.linker.miscellaneous.LinkerFlags>
+  <armgcccpp.linker.miscellaneous.LinkerFlags>{% for p in library_paths %}-L../{{p}} {% endfor %} {% for f in object_files %}../{{f}} {% endfor %} {% for lib in libraries %}-l{{lib}} {% endfor %} -T../{{linker_script}} {{ld_flags|join(" ")}} {{common_flags|join(" ")}}</armgcccpp.linker.miscellaneous.LinkerFlags>
   <armgcccpp.preprocessingassembler.general.IncludePaths>
     <ListValues>
       {% for i in include_paths %}<Value>../{{i}}</Value> 
@@ -123,7 +123,7 @@
   <armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcc.compiler.optimization.PrepareFunctionsForGarbageCollection>
   <armgcc.compiler.optimization.DebugLevel>Maximum (-g3)</armgcc.compiler.optimization.DebugLevel>
   <armgcc.compiler.warnings.AllWarnings>True</armgcc.compiler.warnings.AllWarnings>
-  <armgcc.compiler.miscellaneous.OtherFlags>-std=gnu99 -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -MMD -MP</armgcc.compiler.miscellaneous.OtherFlags>    
+  <armgcc.compiler.miscellaneous.OtherFlags>{{c_flags|join(" ")}} {{common_flags|join(" ")}} -MMD -MP</armgcc.compiler.miscellaneous.OtherFlags>    
   <armgcccpp.compiler.symbols.DefSymbols>
     <ListValues>
       <Value>DEBUG</Value>
@@ -141,7 +141,7 @@
   <armgcccpp.compiler.optimization.PrepareFunctionsForGarbageCollection>True</armgcccpp.compiler.optimization.PrepareFunctionsForGarbageCollection>
   <armgcccpp.compiler.optimization.DebugLevel>Maximum (-g3)</armgcccpp.compiler.optimization.DebugLevel>
   <armgcccpp.compiler.warnings.AllWarnings>True</armgcccpp.compiler.warnings.AllWarnings>
-  <armgcccpp.compiler.miscellaneous.OtherFlags>-std=gnu++98 -fno-rtti -fno-common -fmessage-length=0 -Wall -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -MMD -MP</armgcccpp.compiler.miscellaneous.OtherFlags>
+  <armgcccpp.compiler.miscellaneous.OtherFlags>{{cxx_flags|join(" ")}} {{common_flags|join(" ")}} -MMD -MP</armgcccpp.compiler.miscellaneous.OtherFlags>
   <armgcccpp.linker.libraries.Libraries>
     <ListValues>
       <Value>libm</Value>
@@ -152,7 +152,7 @@
     </ListValues>
   </armgcccpp.linker.libraries.LibrarySearchPaths>
   <armgcccpp.linker.optimization.GarbageCollectUnusedSections>True</armgcccpp.linker.optimization.GarbageCollectUnusedSections>
-  <armgcccpp.linker.miscellaneous.LinkerFlags>{% for p in library_paths %}-L../{{p}} {% endfor %} {% for f in object_files %}../{{f}} {% endfor %} {% for lib in libraries %}-l{{lib}} {% endfor %} -T../{{linker_script}} -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float -Wl,--wrap,main -Wl,--cref -lstdc++ -lsupc++ -lm -lgcc -Wl,--start-group -lc -lc -lnosys -Wl,--end-group </armgcccpp.linker.miscellaneous.LinkerFlags>
+  <armgcccpp.linker.miscellaneous.LinkerFlags>{% for p in library_paths %}-L../{{p}} {% endfor %} {% for f in object_files %}../{{f}} {% endfor %} {% for lib in libraries %}-l{{lib}} {% endfor %} -T../{{linker_script}} {{ld_flags|join(" ")}} {{common_flags|join(" ")}}</armgcccpp.linker.miscellaneous.LinkerFlags>
   <armgcccpp.assembler.debugging.DebugLevel>Default (-g)</armgcccpp.assembler.debugging.DebugLevel>
   <armgcccpp.preprocessingassembler.general.IncludePaths>
     <ListValues>

--- a/tools/export/codered.py
+++ b/tools/export/codered.py
@@ -53,5 +53,6 @@ class CodeRed(Exporter):
             'libraries': libraries,
             'symbols': self.get_symbols()
         }
+        ctx.update(self.progen_flags)
         self.gen_file('codered_%s_project.tmpl' % self.target.lower(), ctx, '.project')
         self.gen_file('codered_%s_cproject.tmpl' % self.target.lower(), ctx, '.cproject')

--- a/tools/export/codered_cproject_common.tmpl
+++ b/tools/export/codered_cproject_common.tmpl
@@ -34,7 +34,7 @@
                                     <listOptionValue builtIn="false" value="{{s}}"/>
                                   {% endfor %}
                                 </option>
-                                <option id="gnu.cpp.compiler.option.other.other.1100343989" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti" valueType="string"/>
+                                <option id="gnu.cpp.compiler.option.other.other.1100343989" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" value="-c {{cxx_flags|join(" ")}} {{common_flags|join(" ")}}" valueType="string"/>
 
                                 <option id="gnu.cpp.compiler.option.include.paths.1011871574" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" valueType="includePath">
                                     {% for path in include_paths %}
@@ -56,7 +56,7 @@
                                     <listOptionValue builtIn="false" value="{{s}}"/>
                                   {% endfor %}
                                 </option>
-                                <option id="gnu.c.compiler.option.misc.other.1521041525" name="Other flags" superClass="gnu.c.compiler.option.misc.other" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti" valueType="string"/>
+                                <option id="gnu.c.compiler.option.misc.other.1521041525" name="Other flags" superClass="gnu.c.compiler.option.misc.other" value="-c {{c_flags|join(" ")}} {{common_flags|join(" ")}}" valueType="string"/>
 
                                 <option id="gnu.c.compiler.option.include.paths.1293117680" name="Include paths (-I)" superClass="gnu.c.compiler.option.include.paths" valueType="includePath">
                                     {% for path in include_paths %}
@@ -69,7 +69,7 @@
                             <tool id="com.crt.advproject.gas.exe.debug.1277199919" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.debug">
                                 <option id="com.crt.advproject.gas.arch.1079400011" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.{{ self.core() }}" valueType="enumerated"/>
                                 <option id="com.crt.advproject.gas.thumb.1976113150" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" value="true" valueType="boolean"/>
-                                <option id="gnu.both.asm.option.flags.crt.1501250871" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__NEWLIB__  -DDEBUG -D__CODE_RED " valueType="string"/>
+                                <option id="gnu.both.asm.option.flags.crt.1501250871" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c {{asm_flags|join(" ")}} {{common_flags|join(" ")}} -D__NEWLIB__  -DDEBUG -D__CODE_RED " valueType="string"/>
                                 <option id="com.crt.advproject.gas.hdrlib.473313643" name="Use headers for C library" superClass="com.crt.advproject.gas.hdrlib" value="com.crt.advproject.gas.hdrlib.newlib" valueType="enumerated"/>
                                 <inputType id="com.crt.advproject.assembler.input.910682278" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
                             </tool>
@@ -949,7 +949,7 @@
                                     <listOptionValue builtIn="false" value="{{s}}"/>
                                   {% endfor %}
                                 </option>
-                                <option id="gnu.cpp.compiler.option.other.other.1338090461" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti" valueType="string"/>
+                                <option id="gnu.cpp.compiler.option.other.other.1338090461" name="Other flags" superClass="gnu.cpp.compiler.option.other.other" value="-c {{cxx_flags|join(" ")}} {{common_flags|join(" ")}}" valueType="string"/>
                                 <option id="gnu.cpp.compiler.option.optimization.flags.475225500" name="Other optimization flags" superClass="gnu.cpp.compiler.option.optimization.flags" value="-Os" valueType="string"/>
 
                                 <option id="gnu.cpp.compiler.option.include.paths.17539784" name="Include paths (-I)" superClass="gnu.cpp.compiler.option.include.paths" valueType="includePath">
@@ -972,14 +972,14 @@
                                     <listOptionValue builtIn="false" value="{{s}}"/>
                                   {% endfor %}
                                 </option>
-                                <option id="gnu.c.compiler.option.misc.other.2015545820" name="Other flags" superClass="gnu.c.compiler.option.misc.other" value="-c -fmessage-length=0 -fno-builtin -ffunction-sections -fdata-sections -fno-exceptions -fno-rtti" valueType="string"/>
+                                <option id="gnu.c.compiler.option.misc.other.2015545820" name="Other flags" superClass="gnu.c.compiler.option.misc.other" value="-c {{c_flags|join(" ")}} {{common_flags|join(" ")}}" valueType="string"/>
                                 <option id="gnu.c.compiler.option.optimization.flags.675461365" name="Other optimization flags" superClass="gnu.c.compiler.option.optimization.flags" value="-Os" valueType="string"/>
                                 <inputType id="com.crt.advproject.compiler.input.1938378962" superClass="com.crt.advproject.compiler.input"/>
                             </tool>
                             <tool id="com.crt.advproject.gas.exe.release.579950187" name="MCU Assembler" superClass="com.crt.advproject.gas.exe.release">
                                 <option id="com.crt.advproject.gas.arch.1401271875" name="Architecture" superClass="com.crt.advproject.gas.arch" value="com.crt.advproject.gas.target.{{ self.core() }}" valueType="enumerated"/>
                                 <option id="com.crt.advproject.gas.thumb.1024544278" name="Thumb mode" superClass="com.crt.advproject.gas.thumb" value="true" valueType="boolean"/>
-                                <option id="gnu.both.asm.option.flags.crt.637466836" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c -x assembler-with-cpp -D__NEWLIB__  -DNDEBUG -D__CODE_RED " valueType="string"/>
+                                <option id="gnu.both.asm.option.flags.crt.637466836" name="Assembler flags" superClass="gnu.both.asm.option.flags.crt" value="-c {{asm_flags|join(" ")}} {{common_flags|join(" ")}} -D__NEWLIB__  -DNDEBUG -D__CODE_RED " valueType="string"/>
                                 <option id="com.crt.advproject.gas.hdrlib.492600365" name="Use headers for C library" superClass="com.crt.advproject.gas.hdrlib" value="com.crt.advproject.gas.hdrlib.newlib" valueType="enumerated"/>
                                 <inputType id="com.crt.advproject.assembler.input.812068162" name="Additional Assembly Source Files" superClass="com.crt.advproject.assembler.input"/>
                             </tool>

--- a/tools/export/emblocks.py
+++ b/tools/export/emblocks.py
@@ -69,9 +69,9 @@ class IntermediateFile(Exporter):
             'symbols': self.get_symbols(),
             'object_files': self.resources.objects,
             'sys_libs': self.toolchain.sys_libs,
-            'cc_org': self.toolchain.cc[1:],
-            'ld_org': self.toolchain.ld[1:],
-            'cppc_org': self.toolchain.cppc[1:]
+            'cc_org': self.flags['common'] + self.flags['c'],
+            'ld_org': self.flags['common'] + self.flags['ld'],
+            'cppc_org': self.flags['common'] + self.flags['cxx']
         }
 
         # EmBlocks intermediate file template

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -39,6 +39,16 @@ class Exporter(object):
     def get_toolchain(self):
         return self.TOOLCHAIN
 
+    @property
+    def flags(self):
+        return self.toolchain.flags
+
+    @property
+    def progen_flags(self):
+        if not hasattr(self, "_progen_flag_cache") :
+            self._progen_flag_cache = dict([(key + "_flags", value) for key,value in self.flags.iteritems()])
+        return self._progen_flag_cache
+
     def __scan_and_copy(self, src_path, trg_path):
         resources = self.toolchain.scan_resources(src_path)
 

--- a/tools/export/gcc_arm_common.tmpl
+++ b/tools/export/gcc_arm_common.tmpl
@@ -34,17 +34,12 @@ endif
 {%- endblock %}
 
 CPU = {% block cpu %}{% for cf in cpu_flags %}{{cf|replace("-mfloat-abi=softfp","-mfloat-abi=$(FLOAT_ABI)")}} {% endfor %}{% endblock %}
-CC_FLAGS = {% block cc_flags %}$(CPU) -c -g -fno-common -fmessage-length=0 -Wall -Wextra -fno-exceptions -ffunction-sections -fdata-sections -fomit-frame-pointer -MMD -MP{% endblock %}
+CC_FLAGS = {% block cc_flags %}{{common_flags|join(" ")}} {{c_flags|join(" ")}} -MMD -MP{% endblock %}
+CPPC_FLAGS = {% block cppc_flags %}{{common_flags|join(" ")}} {{cxx_flags|join(" ")}} -MMD -MP{% endblock %}
+ASM_FLAGS = {% block asm_flags %}{{asm_flags|join(" ")}} {{common_flags|join(" ")}}{% endblock %}
 CC_SYMBOLS = {% block cc_symbols %}{% for s in symbols %}-D{{s}} {% endfor %}{% endblock %}
 
-LD_FLAGS = {%- block ld_flags -%}
-{%- if "-mcpu=cortex-m0" in cpu_flags or "-mcpu=cortex-m0plus" in cpu_flags -%}
-{{ ' ' }}$(CPU) -Wl,--gc-sections --specs=nano.specs -Wl,--wrap,main -Wl,-Map=$(PROJECT).map,--cref
-#LD_FLAGS += -u _printf_float -u _scanf_float
-{%- else -%}
-{{ ' ' }}$(CPU) -Wl,--gc-sections --specs=nano.specs -u _printf_float -u _scanf_float -Wl,--wrap,main -Wl,-Map=$(PROJECT).map,--cref
-{%- endif -%}
-{% endblock %}
+LD_FLAGS = {%- block ld_flags -%} {{ld_flags|join(" ")}} {% endblock %}
 LD_SYS_LIBS = {% block ld_sys_libs %}-lstdc++ -lsupc++ -lm -lc -lgcc -lnosys{% endblock %}
 {% endblock %}
 
@@ -66,17 +61,17 @@ clean:
 {% endblock %}
 
 .asm.o:
-	$(CC) $(CPU) -c -x assembler-with-cpp -o $@ $<
+	$(CC) $(CPU) -c $(ASM_FLAGS) -o $@ $<
 .s.o:
-	$(CC) $(CPU) -c -x assembler-with-cpp -o $@ $<
+	$(CC) $(CPU) -c $(ASM_FLAGS) -o $@ $<
 .S.o:
-	$(CC) $(CPU) -c -x assembler-with-cpp -o $@ $<
+	$(CC) $(CPU) -c $(ASM_FLAGS) -o $@ $<
 
 .c.o:
-	$(CC)  $(CC_FLAGS) $(CC_SYMBOLS) -std=gnu99   $(INCLUDE_PATHS) -o $@ $<
+	$(CC)  $(CC_FLAGS) $(CC_SYMBOLS) $(INCLUDE_PATHS) -o $@ $<
 
 .cpp.o:
-	$(CPP) $(CC_FLAGS) $(CC_SYMBOLS) -std=gnu++98 -fno-rtti $(INCLUDE_PATHS) -o $@ $<
+	$(CPP) $(CPPC_FLAGS) $(CC_SYMBOLS) $(INCLUDE_PATHS) -o $@ $<
 
 
 {% block target_project_elf %}

--- a/tools/export/gccarm.py
+++ b/tools/export/gccarm.py
@@ -147,4 +147,5 @@ class GccArm(Exporter):
             'symbols': self.get_symbols(),
             'cpu_flags': self.toolchain.cpu
         }
+        ctx.update(self.progen_flags)
         self.gen_file('gcc_arm_%s.tmpl' % self.target.lower(), ctx, 'Makefile')

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -66,6 +66,8 @@ class IAREmbeddedWorkbench(Exporter):
             }
 
         project_data['tool_specific'] = {}
+        project_data['tool_specific'].setdefault("iar", {})
+        project_data['tool_specific']['iar'].update(self.progen_flags)
         project_data['tool_specific'].update(tool_specific)
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
         self.progen_gen_file('iar_arm', project_data)

--- a/tools/export/simplicityv3.py
+++ b/tools/export/simplicityv3.py
@@ -169,6 +169,7 @@ class SimplicityV3(Exporter):
             'kit': self.KITS[self.target],
             'loopcount': 0
         }
+        ctx.update(self.progen_flags)
 
         ## Strip main folder from include paths because ssproj is not capable of handling it
         if '.' in ctx['include_paths']:

--- a/tools/export/simplicityv3_slsproj.tmpl
+++ b/tools/export/simplicityv3_slsproj.tmpl
@@ -71,13 +71,13 @@
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe" optionId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript" value="true"/>
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe" optionId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script" value="${workspace_loc:/${ProjName}/{{ linker_script }}}"/>
 {# Make sure to wrap main in order to get clock initialization done right #}
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base" optionId="gnu.c.link.option.ldflags" value="-Wl,--wrap=main"/>
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base" optionId="gnu.cpp.link.option.flags" value="-Wl,--wrap=main"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base" optionId="gnu.c.link.option.ldflags" value="{{ld_flags|join(" ")}}"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base" optionId="gnu.cpp.link.option.flags" value="{{ld_flags|join(" ")}}"/>
 {# For debug build, don't apply optimizations #}
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base" optionId="gnu.c.compiler.option.optimization.level" value="gnu.c.optimization.level.none"/>
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base" optionId="gnu.c.compiler.option.misc.other" value="-c -fmessage-length=0 -fno-rtti -fno-exceptions -fno-common -fomit-frame-pointer"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base" optionId="gnu.c.compiler.option.misc.other" value="-c {{common_flags|join(" ")}} {{c_flags|join(" ")}}"/>
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="gnu.cpp.compiler.option.optimization.level" value="gnu.cpp.compiler.optimization.level.none"/>
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="gnu.cpp.compiler.option.other.other" value="-c -fmessage-length=0 -fno-rtti -fno-exceptions -fno-common -fomit-frame-pointer"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="gnu.cpp.compiler.option.other.other" value="-c {{common_flags|join(" ")}} {{cxx_flags|join(" ")}}"/>
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect" value="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.default"/>
   </configuration>
   <configuration name="com.silabs.ide.si32.gcc.release#com.silabs.ide.si32.gcc:4.8.3.20131129" label="GNU ARM v4.8.3 - Release" stockConfigCompatibility="com.silabs.ide.toolchain.core.release">
@@ -128,13 +128,13 @@
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe" optionId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.usescript" value="true"/>
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.toolchain.exe" optionId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.script" value="${workspace_loc:/${ProjName}/{{ linker_script }}}"/>
 {# Make sure to wrap main in order to get clock initialization done right #}
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base" optionId="gnu.c.link.option.ldflags" value="-Wl,--wrap=main"/>
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base" optionId="gnu.cpp.link.option.flags" value="-Wl,--wrap=main"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.linker.base" optionId="gnu.c.link.option.ldflags" value="{{ld_flags|join(" ")}}"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.linker.base" optionId="gnu.cpp.link.option.flags" value="{{ld_flags|join(" ")}}"/>
 {# Use optimize for size on release build #}
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base" optionId="gnu.c.compiler.option.optimization.level" value="gnu.c.optimization.level.size"/>
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base" optionId="gnu.c.compiler.option.misc.other" value="-c -fmessage-length=0 -fno-rtti -fno-exceptions -fno-common -fomit-frame-pointer"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.c.compiler.base" optionId="gnu.c.compiler.option.misc.other" value="-c {{common_flags|join(" ")}} {{c_flags|join(" ")}}"/>
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="gnu.cpp.compiler.option.optimization.level" value="gnu.cpp.compiler.optimization.level.size"/>
-    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="gnu.cpp.compiler.option.other.other" value="-c -fmessage-length=0 -fno-rtti -fno-exceptions -fno-common -fomit-frame-pointer"/>
+    <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="gnu.cpp.compiler.option.other.other" value="-c {{common_flags|join(" ")}} {{cxx_flags|join(" ")}}"/>
     <toolOption toolId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.base" optionId="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect" value="com.silabs.ide.si32.gcc.cdt.managedbuild.tool.gnu.cpp.compiler.misc.dialect.default"/>
   </configuration>
 </project>

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -24,6 +24,7 @@ from types import ListType
 from shutil import copyfile
 from os.path import join, splitext, exists, relpath, dirname, basename, split, abspath
 from inspect import getmro
+from copy import deepcopy
 
 from multiprocessing import Pool, cpu_count
 from tools.utils import run_cmd, mkdir, rel_path, ToolException, NotSupportedException, split_path
@@ -242,6 +243,7 @@ class mbedToolchain:
 
         if 'UVISOR_PRESENT=1' in self.macros:
             self.target.core = re.sub(r"F$", '', self.target.core)
+        self.flags = deepcopy(self.DEFAULT_FLAGS)
 
     def get_output(self):
         return self.output

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -56,7 +56,6 @@ class ARM(mbedToolchain):
 
         main_cc = join(ARM_BIN, "armcc")
 
-        self.flags = copy.deepcopy(self.DEFAULT_FLAGS)
         self.flags['common'] += ["--cpu=%s" % cpu]
         if "save-asm" in self.options:
             self.flags['common'].extend(["--asm", "--interleave"])

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -33,7 +33,7 @@ class GCC(mbedToolchain):
         'common': ["-c", "-Wall", "-Wextra",
             "-Wno-unused-parameter", "-Wno-missing-field-initializers",
             "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
-            "-ffunction-sections", "-fdata-sections",
+            "-ffunction-sections", "-fdata-sections", "-funsigned-char",
             "-MMD", "-fno-delete-null-pointer-checks", "-fomit-frame-pointer"
             ],
         'asm': ["-x", "assembler-with-cpp"],

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -29,6 +29,19 @@ class GCC(mbedToolchain):
     STD_LIB_NAME = "lib%s.a"
     DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|error): (?P<message>.+)')
 
+    DEFAULT_FLAGS = {
+        'common': ["-c", "-Wall", "-Wextra",
+            "-Wno-unused-parameter", "-Wno-missing-field-initializers",
+            "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
+            "-ffunction-sections", "-fdata-sections",
+            "-MMD", "-fno-delete-null-pointer-checks", "-fomit-frame-pointer"
+            ],
+        'asm': ["-x", "assembler-with-cpp"],
+        'c': ["-std=gnu99"],
+        'cxx': ["-std=gnu++98", "-fno-rtti"],
+        'ld': ["-Wl,--gc-sections", "-Wl,--wrap,main"],
+    }
+
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, tool_path="", extra_verbose=False):
         mbedToolchain.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
 
@@ -63,33 +76,31 @@ class GCC(mbedToolchain):
 
         # Note: We are using "-O2" instead of "-Os" to avoid this known GCC bug:
         # http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46762
-        common_flags = ["-c", "-Wall", "-Wextra",
-            "-Wno-unused-parameter", "-Wno-missing-field-initializers",
-            "-fmessage-length=0", "-fno-exceptions", "-fno-builtin",
-            "-ffunction-sections", "-fdata-sections",
-            "-fno-delete-null-pointer-checks", "-fomit-frame-pointer"
-            ] + self.cpu
+        self.flags["common"] += self.cpu
 
         if "save-asm" in self.options:
-            common_flags.append("-save-temps")
+            self.flags["common"].append("-save-temps")
 
         if "debug-info" in self.options:
-            common_flags.append("-g")
-            common_flags.append("-O0")
+            self.flags["common"].append("-g")
+            self.flags["common"].append("-O0")
         else:
-            common_flags.append("-O2")
+            self.flags["common"].append("-O2")
 
         main_cc = join(tool_path, "arm-none-eabi-gcc")
         main_cppc = join(tool_path, "arm-none-eabi-g++")
-        self.asm = [main_cc, "-x", "assembler-with-cpp"] + common_flags
+        self.asm = [main_cc] + self.flags['asm'] + self.flags["common"]
         if not "analyze" in self.options:
-            self.cc  = [main_cc, "-std=gnu99"] + common_flags
-            self.cppc =[main_cppc, "-std=gnu++98", "-fno-rtti"] + common_flags
+            self.cc  = [main_cc]
+            self.cppc =[main_cppc]
         else:
-            self.cc  = [join(GOANNA_PATH, "goannacc"), "--with-cc=" + main_cc.replace('\\', '/'), "-std=gnu99", "--dialect=gnu", '--output-format="%s"' % self.GOANNA_FORMAT] + common_flags
-            self.cppc= [join(GOANNA_PATH, "goannac++"), "--with-cxx=" + main_cppc.replace('\\', '/'), "-std=gnu++98", "-fno-rtti", "--dialect=gnu", '--output-format="%s"' % self.GOANNA_FORMAT] + common_flags
+            self.cc  = [join(GOANNA_PATH, "goannacc"), "--with-cc=" + main_cc.replace('\\', '/'), "--dialect=gnu", '--output-format="%s"' % self.GOANNA_FORMAT]
+            self.cppc= [join(GOANNA_PATH, "goannac++"), "--with-cxx=" + main_cppc.replace('\\', '/'),  "--dialect=gnu", '--output-format="%s"' % self.GOANNA_FORMAT]
+        self.cc += self.flags['c'] + self.flags['common']
+        self.cppc += self.flags['cxx'] + self.flags['common']
 
-        self.ld = [join(tool_path, "arm-none-eabi-gcc"), "-Wl,--gc-sections", "-Wl,--wrap,main"] + self.cpu
+        self.flags['ld'] += self.cpu
+        self.ld = [join(tool_path, "arm-none-eabi-gcc")] + self.flags['ld']
         self.sys_libs = ["stdc++", "supc++", "m", "c", "gcc"]
 
         self.ar = join(tool_path, "arm-none-eabi-ar")

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -42,7 +42,7 @@ class IAR(mbedToolchain):
         'asm': [],
         'c': [],
         'cxx': ["--c++",  "--no_rtti", "--no_exceptions", "--guard_calls"],
-        'ld': [],
+        'ld': ["--skip_dynamic_initialization", "--threaded_lib"],
     }
 
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
@@ -194,6 +194,10 @@ class IAR(mbedToolchain):
             remove(lib_path)
 
         self.default_cmd([self.ar, lib_path, '-f', archive_files])
+
+    def link(self, output, objects, libraries, lib_dirs, mem_map):
+        args = [self.ld, "-o", output, "--config", mem_map] + self.flags['ld']
+        self.default_cmd(self.hook.get_cmdline_linker(args + objects + libraries))
 
     @hook_tool
     def binary(self, resources, elf, bin):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -30,47 +30,56 @@ class IAR(mbedToolchain):
 
     DIAGNOSTIC_PATTERN = re.compile('"(?P<file>[^"]+)",(?P<line>[\d]+)\s+(?P<severity>Warning|Error)(?P<message>.+)')
 
+    DEFAULT_FLAGS = {
+        'common': [
+            "--no_wrap_diagnostics",
+            # Pa050: No need to be notified about "non-native end of line sequence"
+            # Pa084: Pointless integer comparison -> checks for the values of an enum, but we use values outside of the enum to notify errors (ie: NC).
+            # Pa093: Implicit conversion from float to integer (ie: wait_ms(85.4) -> wait_ms(85))
+            # Pa082: Operation involving two values from two registers (ie: (float)(*obj->MR)/(float)(LPC_PWM1->MR0))
+            "-e", # Enable IAR language extension
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082"],
+        'asm': [],
+        'c': [],
+        'cxx': ["--c++",  "--no_rtti", "--no_exceptions", "--guard_calls"],
+        'ld': [],
+    }
+
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
         mbedToolchain.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
         if target.core == "Cortex-M7F":
             cpuchoice = "Cortex-M7"
         else:
             cpuchoice = target.core
-        c_flags = [
+        self.flags["common"] += [
             "--cpu=%s" % cpuchoice, "--thumb",
             "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h"),
-            "-e", # Enable IAR language extension
-            "--no_wrap_diagnostics",
-            # Pa050: No need to be notified about "non-native end of line sequence"
-            # Pa084: Pointless integer comparison -> checks for the values of an enum, but we use values outside of the enum to notify errors (ie: NC).
-            # Pa093: Implicit conversion from float to integer (ie: wait_ms(85.4) -> wait_ms(85))
-            # Pa082: Operation involving two values from two registers (ie: (float)(*obj->MR)/(float)(LPC_PWM1->MR0))
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082",
         ]
 
         if target.core == "Cortex-M7F":
-            c_flags.append("--fpu=VFPv5_sp")
-                
+            self.flags["common"].append("--fpu=VFPv5_sp")
 
         if "debug-info" in self.options:
-            c_flags.append("-r")
-            c_flags.append("-On")
+            self.flags["common"].append("-r")
+            self.flags["common"].append("-On")
         else:
-            c_flags.append("-Oh")
+            self.flags["common"].append("-Oh")
 
         IAR_BIN = join(IAR_PATH, "bin")
         main_cc = join(IAR_BIN, "iccarm")
-        
+
+        self.flags["asm"] += ["--cpu", cpuchoice]
         if target.core == "Cortex-M7F":
-            self.asm  = [join(IAR_BIN, "iasmarm")] + ["--cpu", cpuchoice] + ["--fpu", "VFPv5_sp"]
-        else:
-            self.asm  = [join(IAR_BIN, "iasmarm")] + ["--cpu", cpuchoice]
+            self.flags["asm"] += ["--fpu", "VFPv5_sp"]
+        self.asm  = [join(IAR_BIN, "iasmarm")] + self.flags["asm"]
         if not "analyze" in self.options:
-            self.cc = [main_cc, "--vla"] + c_flags
-            self.cppc = [main_cc, "--c++",  "--no_rtti", "--no_exceptions"] + c_flags
+            self.cc   = [main_cc]
+            self.cppc = [main_cc]
         else:
-            self.cc = [join(GOANNA_PATH, "goannacc"), '--with-cc="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT, "--vla"] + c_flags
-            self.cppc = [join(GOANNA_PATH, "goannac++"), '--with-cxx="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT] + ["--c++", "--no_rtti", "--no_exceptions"] + c_flags
+            self.cc   = [join(GOANNA_PATH, "goannacc"), '--with-cc="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT]
+            self.cppc = [join(GOANNA_PATH, "goannac++"), '--with-cxx="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT]
+        self.cc += self.flags["common"] + self.flags["c"]
+        self.cppc += self.flags["common"] + self.flags["cxx"]
         self.ld   = join(IAR_BIN, "ilinkarm")
         self.ar = join(IAR_BIN, "iarchive")
         self.elf2bin = join(IAR_BIN, "ielftool")


### PR DESCRIPTION
Toolchains are now expected to have an up to date flags attribute. These flags are used by the tools when building from the scripts and by the exporters when exporting projects.

Partially resolves #1671 and #1525 

I say partially because some of the exporters have yet to be updated to pull from the toolchains.