### PR TITLE
Add newline conversion for stdout

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -88,6 +88,7 @@ FileHandle::~FileHandle() {
 #if DEVICE_SERIAL
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
+static char stdio_prev;
 #endif
 
 static void init_serial() {
@@ -227,7 +228,11 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
 #if DEVICE_SERIAL
         if (!stdio_uart_inited) init_serial();
         for (unsigned int i = 0; i < length; i++) {
+            if (buffer[i] == '\n' && stdio_prev != '\r') {
+                 serial_putc(&stdio_uart, '\r');
+            }
             serial_putc(&stdio_uart, buffer[i]);
+            stdio_prev = buffer[i];
         }
 #endif
         n = length;

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -88,7 +88,7 @@ FileHandle::~FileHandle() {
 #if DEVICE_SERIAL
 extern int stdio_uart_inited;
 extern serial_t stdio_uart;
-#ifdef MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
+#if MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
 static char stdio_in_prev;
 static char stdio_out_prev;
 #endif
@@ -230,7 +230,7 @@ extern "C" int PREFIX(_write)(FILEHANDLE fh, const unsigned char *buffer, unsign
     if (fh < 3) {
 #if DEVICE_SERIAL
         if (!stdio_uart_inited) init_serial();
-#ifdef MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
+#if MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
         for (unsigned int i = 0; i < length; i++) {
             if (buffer[i] == '\n' && stdio_out_prev != '\r') {
                  serial_putc(&stdio_uart, '\r');
@@ -268,7 +268,7 @@ extern "C" int PREFIX(_read)(FILEHANDLE fh, unsigned char *buffer, unsigned int 
         // only read a character at a time from stdin
 #if DEVICE_SERIAL
         if (!stdio_uart_inited) init_serial();
-#ifdef MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
+#if MBED_CONF_CORE_STDIO_CONVERT_NEWLINES
         while (true) {
             char c = serial_getc(&stdio_uart);
             if ((c == '\r' && stdio_in_prev != '\n') ||

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -1,0 +1,8 @@
+{
+    "name": "core",
+    "config": {
+        "stdio-convert-newlines": {
+            "help": "Enable conversion to standard newlines on stdin/stdout"
+        }
+    }
+}

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -2,7 +2,8 @@
     "name": "core",
     "config": {
         "stdio-convert-newlines": {
-            "help": "Enable conversion to standard newlines on stdin/stdout"
+            "help": "Enable conversion to standard newlines on stdin/stdout",
+            "value": false
         }
     }
 }


### PR DESCRIPTION
As noted by @kjbracey-arm, mbed currently prints \r and \n unmodified to stdout and most serial terminals default to requiring a \r\n sequence to actually create a newline. This results in non-standard io for many setups, since the C standard states that \n will be converted to the underlying newline sequence[[1]](https://en.wikipedia.org/wiki/Newline#In_programming_languages). Annoyingly, this has resulted in the \r\n being used in many programs.

In this patch, stdout/stdin do the following conversions greedily (without delays):

on write:
```
\n   -> \r\n
\r\n -> \r\n
\r   -> \r
\n\r -> \n\r
```
on read:
```
\n   -> \n
\r\n -> \n
\r   -> \n
\n\r -> \n
```

Serial.output provides support for unmodified binary output (and still requires \r\n). This conversion remains backwards compatibly for all \r\n sequences and only impacts stdio that uses \n or \r in isolation.

cc @kjbracey-arm, @bogdanm 
mv [#91](https://github.com/ARMmbed/mbed-os/issues/91), [#93](https://github.com/ARMmbed/mbed-os/pull/93)