### PR TITLE
Update function get_interrupts_disabled() to return a bool value rather

### DIFF
--- a/hal/api/critical.h
+++ b/hal/api/critical.h
@@ -24,6 +24,18 @@
 extern "C" {
 #endif
 
+
+/** Determine the current interrupts disabled state
+  *
+  * This function can be called to determine whether or not interrupts are currently disabled.
+  * \note
+  * NOTE:
+  * This function works for both cortex-A and cortex-M, although the underlyng implementation
+  * differs.
+  * @return true if interrupts are disabled, false otherwise
+  */
+bool get_interrupts_disabled(void);
+
 /** Mark the start of a critical section
   *
   * This function should be called to mark the start of a critical section of code.

--- a/hal/api/critical.h
+++ b/hal/api/critical.h
@@ -34,7 +34,7 @@ extern "C" {
   * differs.
   * @return true if interrupts are enabled, false otherwise
   */
-bool are_interrupts_enabled(void);
+bool core_util_are_interrupts_enabled(void);
 
 /** Mark the start of a critical section
   *

--- a/hal/api/critical.h
+++ b/hal/api/critical.h
@@ -25,16 +25,16 @@ extern "C" {
 #endif
 
 
-/** Determine the current interrupts disabled state
+/** Determine the current interrupts enabled state
   *
-  * This function can be called to determine whether or not interrupts are currently disabled.
+  * This function can be called to determine whether or not interrupts are currently enabled.
   * \note
   * NOTE:
   * This function works for both cortex-A and cortex-M, although the underlyng implementation
   * differs.
-  * @return true if interrupts are disabled, false otherwise
+  * @return true if interrupts are enabled, false otherwise
   */
-bool get_interrupts_disabled(void);
+bool are_interrupts_enabled(void);
 
 /** Mark the start of a critical section
   *

--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -29,19 +29,18 @@
 static volatile uint32_t interrupt_enable_counter = 0;
 static volatile bool critical_interrupts_disabled = false;
 
-bool get_interrupts_disabled(void)
+bool are_interrupts_enabled(void)
 {
 #if defined(__CORTEX_A9)
-    bool interrupts_disabled = (bool)(((__get_CPSR() & 0x80) >> 7) & 0x1);
+    return ((__get_CPSR() & 0x80) == 0);
 #else
-    bool interrupts_disabled = (bool)(__get_PRIMASK() & 0x1);
+    return ((__get_PRIMASK() & 0x1) == 0);
 #endif
-    return interrupts_disabled;
 }
 
 void core_util_critical_section_enter()
 {
-    bool interrupts_disabled = get_interrupts_disabled();
+    bool interrupts_disabled = !are_interrupts_enabled();
     __disable_irq();
 
     /* Save the interrupt disabled state as it was prior to any nested critical section lock use */
@@ -71,7 +70,7 @@ void core_util_critical_section_exit()
 
 // FIXME
 #ifndef   FEATURE_UVISOR
-        bool interrupts_disabled = get_interrupts_disabled(); /* get the current interrupt disabled state */
+        bool interrupts_disabled = !are_interrupts_enabled(); /* get the current interrupt disabled state */
 
         MBED_ASSERT(interrupts_disabled); /* Interrupts must be disabled on invoking an exit from a critical section */
 #else

--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -29,7 +29,7 @@
 static volatile uint32_t interrupt_enable_counter = 0;
 static volatile bool critical_interrupts_disabled = false;
 
-bool are_interrupts_enabled(void)
+bool core_util_are_interrupts_enabled(void)
 {
 #if defined(__CORTEX_A9)
     return ((__get_CPSR() & 0x80) == 0);
@@ -40,7 +40,7 @@ bool are_interrupts_enabled(void)
 
 void core_util_critical_section_enter()
 {
-    bool interrupts_disabled = !are_interrupts_enabled();
+    bool interrupts_disabled = !core_util_are_interrupts_enabled();
     __disable_irq();
 
     /* Save the interrupt disabled state as it was prior to any nested critical section lock use */
@@ -70,7 +70,7 @@ void core_util_critical_section_exit()
 
 // FIXME
 #ifndef   FEATURE_UVISOR
-        bool interrupts_disabled = !are_interrupts_enabled(); /* get the current interrupt disabled state */
+        bool interrupts_disabled = !core_util_are_interrupts_enabled(); /* get the current interrupt disabled state */
 
         MBED_ASSERT(interrupts_disabled); /* Interrupts must be disabled on invoking an exit from a critical section */
 #else


### PR DESCRIPTION
than an integer. This removes the need for all users to mask the returned
value with 0x1 to determine interrupt status.
Expose this function externally to allow other users to check interrupt
status in a manner which will work for both cortex-A and cortex-M .
Usage:
bool disabled = get_interrupts_disabled();