### PR TITLE
RTOS - add mbed_lib.json file

### DIFF
--- a/rtos/mbed_lib.json
+++ b/rtos/mbed_lib.json
@@ -1,0 +1,6 @@
+{
+    "name": "rtos",
+    "config": {
+        "present": 1
+    }
+}


### PR DESCRIPTION
Defines that rtos is present, this resolves in the macro:
"MBED_CONF_RTOS_PRESENT=1"

By default, this macro would not be defined neither set, thus RTOS disabled, more to come soon.

@c1728p9 @sg- 