### PR TITLE
Don't pull KSDK FSL libraries into apps

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/gpio_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/gpio_api.c
@@ -17,6 +17,9 @@
 #include "gpio_api.h"
 #include "pinmap.h"
 #include "fsl_port.h"
+#include "fsl_gpio.h"
+
+static GPIO_Type * const gpio_addrs[] = GPIO_BASE_PTRS;
 
 uint32_t gpio_set(PinName pin) {
     MBED_ASSERT(pin != (PinName)NC);
@@ -41,7 +44,6 @@ void gpio_mode(gpio_t *obj, PinMode mode) {
 void gpio_dir(gpio_t *obj, PinDirection direction) {
     MBED_ASSERT(obj->pin != (PinName)NC);
     uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
-    GPIO_Type *gpio_addrs[] = GPIO_BASE_PTRS;
     uint32_t pin_num = obj->pin & 0xFF;
     GPIO_Type *base = gpio_addrs[port];
 
@@ -53,4 +55,20 @@ void gpio_dir(gpio_t *obj, PinDirection direction) {
             base->PDDR |= (1U << pin_num);
             break;
     }
+}
+
+void gpio_write(gpio_t *obj, int value) {
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
+    uint32_t pin = obj->pin & 0xFF;
+
+    GPIO_WritePinOutput(gpio_addrs[port], pin, value);
+}
+
+int gpio_read(gpio_t *obj) {
+    MBED_ASSERT(obj->pin != (PinName)NC);
+    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
+    uint32_t pin = obj->pin & 0xFF;
+
+    return (int)GPIO_ReadPinInput(gpio_addrs[port], pin);
 }

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/gpio_object.h
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/gpio_object.h
@@ -16,9 +16,6 @@
 #ifndef MBED_GPIO_OBJECT_H
 #define MBED_GPIO_OBJECT_H
 
-#include "mbed_assert.h"
-#include "fsl_gpio.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -26,24 +23,6 @@ extern "C" {
 typedef struct {
     PinName pin;
 } gpio_t;
-
-static inline void gpio_write(gpio_t *obj, int value) {
-    MBED_ASSERT(obj->pin != (PinName)NC);
-    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
-    uint32_t pin = obj->pin & 0xFF;
-    GPIO_Type *gpio_addrs[] = GPIO_BASE_PTRS;
-
-    GPIO_WritePinOutput(gpio_addrs[port], pin, value);
-}
-
-static inline int gpio_read(gpio_t *obj) {
-    MBED_ASSERT(obj->pin != (PinName)NC);
-    uint32_t port = obj->pin >> GPIO_PORT_SHIFT;
-    uint32_t pin = obj->pin & 0xFF;
-    GPIO_Type *gpio_addrs[] = GPIO_BASE_PTRS;
-
-    return (int)GPIO_ReadPinInput(gpio_addrs[port], pin);
-}
 
 static inline int gpio_is_connected(const gpio_t *obj) {
     return obj->pin != (PinName)NC;


### PR DESCRIPTION
Freescale KSDK2 gpio_object.h pulled in Freescale libraries to inline
some GPIO operations.

The resulting namespace pollution (status_t) doesn't seem to be worth
the function call overhead. Hopefully making the base address array
non-automatic will offset that loss.