### PR TITLE
the contents of Driver_Storage.h don't need to be guarded by #if DEVI…

### DIFF
--- a/hal/hal/storage_abstraction/Driver_Storage.h
+++ b/hal/hal/storage_abstraction/Driver_Storage.h
@@ -18,8 +18,6 @@
 #ifndef __DRIVER_STORAGE_H
 #define __DRIVER_STORAGE_H
 
-#if DEVICE_STORAGE
-
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus
@@ -763,7 +761,5 @@ typedef struct _ARM_DRIVER_STORAGE {
 #ifdef __cplusplus
 }
 #endif // __cplusplus
-
-#endif /* #if DEVICE_STORAGE */
 
 #endif /* __DRIVER_STORAGE_H */


### PR DESCRIPTION
…CE_STORAGE

For platforms where DEVICE_STORAGE isn't enabled, the contents of Driver_Storage.h should still be available for inclusion into code needing to use the declarations.

@0xc0170 @simonqhughes