### PR TITLE
Fixed uninitialized port in lwip dragged in by KSDK2

### DIFF
--- a/libraries/net/eth/lwip-eth/arch/TARGET_Freescale/hardware_init_MK64F12.c
+++ b/libraries/net/eth/lwip-eth/arch/TARGET_Freescale/hardware_init_MK64F12.c
@@ -41,6 +41,7 @@ void k64f_init_eth_hardware(void)
     MPU->CESR &= ~MPU_CESR_VLD_MASK;
 
     CLOCK_EnableClock(kCLOCK_PortC);
+    CLOCK_EnableClock(kCLOCK_PortB);
     /* Affects PORTC_PCR16 register */
     PORT_SetPinMux(PORTC, 16u, kPORT_MuxAlt4);
     /* Affects PORTC_PCR17 register */


### PR DESCRIPTION
It seems that a clock-enable was missed for port B in lwip-eth. This bug does not appear if printfs flush before bringing up the ethernet, making the issue rare.

cc @0xc0170, @bridadan 