### PR TITLE
Added warning about stack alignment limitations on IAR

### DIFF
--- a/hal/api/toolchain.h
+++ b/hal/api/toolchain.h
@@ -50,6 +50,9 @@
 
 /** MBED_ALIGN(N)
  *  Declare a variable to be aligned on an N-byte boundary.
+ *
+ *  @note
+ *  IAR does not support alignment greater than word size on the stack
  *  
  *  @code
  *  #include "toolchain.h"


### PR DESCRIPTION
IAR only allows word size alignment in MBED_ALIGN attribute. Noted in toolchain.h.

cc @mjs-arm