### PR TITLE
Adjust the main stack of nrf51 targets to the call stack of thesoftdevice.

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -97,8 +97,10 @@
 #      define OS_MAINSTKSIZE    128
 #  elif defined(TARGET_STM32F334R8) || defined(TARGET_STM32F303RE) ||  defined(TARGET_STM32F303K8) ||  defined(TARGET_STM32F334C8) \
    || defined(TARGET_STM32L031K6) || defined(TARGET_STM32L053R8) || defined(TARGET_STM32L053C8) || defined(TARGET_STM32L073RZ) \
-   || defined(TARGET_EFM32HG_STK3400) || defined(TARGET_MCU_NRF51822)
+   || defined(TARGET_EFM32HG_STK3400)
 #      define OS_MAINSTKSIZE    112
+#  elif defined(TARGET_MCU_NRF51822)
+#      define OS_MAINSTKSIZE    512
 #  else
 #    error "no target defined"
 #  endif


### PR DESCRIPTION
The call stack of the soft device can be 0x600 (1536) bytes deep. By
adjusting the stack to a value of 2048 bytes, their is enough room for
the softdevice and RTX kernel to live together in the main stack.

Random issues due to stack overflow were visible with the previous value.

**Important** most RTOS tests on NRF51822 target are expected to fail because their is not enough space left for other threads. Tests are fine on NRF51_DK.