### PR TITLE
Correct virtualenv instructions in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,20 +144,21 @@ Skip any step where a compatible tool already exists
 3. Install virtualenv in python
 
 ```
-> git clone https://github.com/mbedmicro/mbed
 > pip install virtualenv
+> git clone https://github.com/mbedmicro/mbed
+> cd mbed
 > virtualenv venv
 > 
 ```
 
 Develop
 -------
-1. Update dependencies and start virtual environment. This should be done everytime you pull new changes
+1. Update dependencies and start virtual environment. This should be done everytime you pull new changes. Assuming you're running bash or zsh:
 
 ```
-> "venv/Scripts/activate"
+> "source venv/bin/activate"
 > pip install -r requirements.txt
 > cd workspace_tools
 > ... do things ...
-> "venv/Scripts/deactivate"
+> deactivate
 ```

--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -75,9 +75,9 @@ class GCC(mbedToolchain):
 
         if "debug-info" in self.options:
             common_flags.append("-g")
-            common_flags.append("-O0")
+            common_flags.append("-Og")
         else:
-            common_flags.append("-O2")
+            common_flags.append("-Os")
 
         main_cc = join(tool_path, "arm-none-eabi-gcc")
         main_cppc = join(tool_path, "arm-none-eabi-g++")

--- a/workspace_tools/toolchains/gcc.py
+++ b/workspace_tools/toolchains/gcc.py
@@ -75,9 +75,9 @@ class GCC(mbedToolchain):
 
         if "debug-info" in self.options:
             common_flags.append("-g")
-            common_flags.append("-Og")
+            common_flags.append("-O0")
         else:
-            common_flags.append("-Os")
+            common_flags.append("-O2")
 
         main_cc = join(tool_path, "arm-none-eabi-gcc")
         main_cppc = join(tool_path, "arm-none-eabi-g++")


### PR DESCRIPTION
I tried to follow the setup instructions in README.md but discovered that they didn't work because they referred to the non-existent venv/Scripts directory, and didn't properly source the correct file. This PR fixes those instructions.