### PR TITLE
Add alias for uvision4 exporter

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -28,6 +28,7 @@ from project_generator_definitions.definitions import ProGenDef
 
 EXPORTERS = {
     'uvision': uvision4.Uvision4,
+    'uvision4': uvision4.Uvision4,
     'uvision5': uvision5.Uvision5,
     'lpcxpresso': codered.CodeRed,
     'gcc_arm': gccarm.GccArm,


### PR DESCRIPTION
it is now called both uvision (old name) and uvision4 (new alias)

for consistency, and explicitness reasons