### PR TITLE
[rtos] Fixed registers clobbered SVC_Handler in IAR

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_CMSIS.c
@@ -302,7 +302,7 @@ static inline  t __##f (t1 a1, t2 a2, t3 a3, t4 a4) {                          \
 #define SVC_Setup(f)                                                           \
   __asm(                                                                       \
     "mov r12,%0\n"                                                             \
-    :: "r"(&f): "r12"                                                          \
+    :: "r"(&f): "r0", "r1", "r2", "r3", "r12"                                  \
   );
 
 #define SVC_Ret3()                                                             \


### PR DESCRIPTION
The rtx SVC_Handler for IAR clobbers r0-r3 despite the number of
arguments. However, in the SVC calls, the __swi function is declared
with fewer arguments. IAR doesn't understand that the other registers are
clobbered and stores variables in r0-r3 when multiple SVCs are
dispatched in a single function.

This bug was noticed in osThreadExit, which hard-faults on IAR,
preventing any threads from exiting.