### PR TITLE
[build tools] Added support for cumulative attributes in configs directly

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -226,6 +226,11 @@ class Config:
                 for attr in Target._Target__cumulative_attributes:
                     attrs = getattr(self.target_instance, attr)
 
+                    if attr in overrides:
+                        del attrs[:]
+                        attrs.extend(overrides[attr])
+                        del overrides[attr]
+
                     if attr+'_add' in overrides:
                         attrs.extend(overrides[attr+'_add'])
                         del overrides[attr+'_add']

--- a/tools/config.py
+++ b/tools/config.py
@@ -143,12 +143,8 @@ class Config:
     # Allowed keys in configuration dictionaries
     # (targets can have any kind of keys, so this validation is not applicable to them)
     __allowed_keys = {
-        "library": set(["name", "config", "target_overrides", "macros", "__config_path"]
-                + [a+'_add'    for a in Target._Target__cumulative_attributes]
-                + [a+'_remove' for a in Target._Target__cumulative_attributes]),
-        "application": set(["config", "custom_targets", "target_overrides", "macros", "__config_path"]
-                + [a+'_add'    for a in Target._Target__cumulative_attributes]
-                + [a+'_remove' for a in Target._Target__cumulative_attributes]),
+        "library": set(["name", "config", "target_overrides", "macros", "__config_path"]),
+        "application": set(["config", "custom_targets", "target_overrides", "macros", "__config_path"])
     }
 
     # The initialization arguments for Config are:
@@ -226,6 +222,22 @@ class Config:
         for label, overrides in data.get("target_overrides", {}).items():
             # If the label is defined by the target or it has the special value "*", process the overrides
             if (label == '*') or (label in self.target_labels):
+                # Parse out cumulative attributes
+                for attr in Target._Target__cumulative_attributes:
+                    attrs = getattr(self.target_instance, attr)
+
+                    if attr+'_add' in overrides:
+                        attrs.extend(overrides[attr+'_add'])
+                        del overrides[attr+'_add']
+
+                    if attr+'_remove' in overrides:
+                        for a in overrides[attr+'_remove']:
+                            attrs.remove(a)
+                        del overrides[attr+'_remove']
+
+                    setattr(self.target_instance, attr, attrs)
+
+                # Consider the others as overrides
                 for name, v in overrides.items():
                     # Get the full name of the parameter
                     full_name = ConfigParameter.get_full_name(name, unit_name, unit_kind, label)
@@ -277,20 +289,6 @@ class Config:
                 raise ConfigException("Macro '%s' defined in both '%s' and '%s' with incompatible values" % (m.macro_name, macros[m.macro_name].defined_by, full_unit_name))
             macros[m.macro_name] = m
 
-    # Helper function: process target attributes in config files
-    # data: dict of cumulative attributes
-    # unit_name: the unit (library/application) that defines this macro
-    # unit_kind: the kind of the unit ("library" or "application")
-    def _process_attributes(self, data, unit_name, unit_kind):
-        for attr in Target._Target__cumulative_attributes:
-            attrs = getattr(self.target_instance, attr)
-
-            attrs.extend(data.get(attr+'_add', []))
-            for a in data.get(attr+'_remove', []):
-                attrs.remove(a)
-
-            setattr(self.target_instance, attr, attrs)
-
     # Read and interpret configuration data defined by libs
     # It is assumed that "add_config_files" above was already called and the library configuration data
     # exists in self.lib_config_data
@@ -301,7 +299,6 @@ class Config:
             if unknown_keys:
                 raise ConfigException("Unknown key(s) '%s' in %s" % (",".join(unknown_keys), lib_name))
             all_params.update(self._process_config_and_overrides(lib_data, {}, lib_name, "library"))
-            self._process_attributes(lib_data, lib_name, "library")
             self._process_macros(lib_data.get("macros", []), macros, lib_name, "library")
         return all_params, macros
 
@@ -313,8 +310,6 @@ class Config:
         app_cfg = self.app_config_data
         # The application can have a "config_parameters" and a "target_config_overrides" section just like a library
         self._process_config_and_overrides(app_cfg, params, "app", "application")
-        # The application can also defined attributes
-        self._process_attributes(app_cfg, "app", "application")
         # The application can also defined macros
         self._process_macros(app_cfg.get("macros", []), macros, "app", "application")
 


### PR DESCRIPTION
Example in your mbed_lib.json:
``` json
Attributes now get the filtering provided by target_overrides: 
{                                                              
    "name": "cmsis-nodejs-SQL-x86",                            
    "target_overrides": {                                      
        "*": {                                                 
            "device_has": ["SILLY_STRING", "FIRE"]             
        },                                                     
        "SHOE": {                                              
            "features_add": ["SMELLS_FUNNY"],                  
            "features_remove": ["SMELLS_NICE"]           
        }                                                      
    }                                                          
}                                                                          
```

This shares the previous logic in custom_targets but avoids the need to instantiate a target. We may want to look into removing duplicate logic between the config and target systems at a later date.

cc @screamerbg, @bogdanm, @bridadan 