### PR TITLE
Add virtual destructor to classes

### DIFF
--- a/hal/api/AnalogIn.h
+++ b/hal/api/AnalogIn.h
@@ -103,6 +103,10 @@ public:
     }
 #endif
 
+    virtual ~AnalogIn() {
+        // Do nothing
+    }
+
 protected:
 
     virtual void lock() {

--- a/hal/api/AnalogOut.h
+++ b/hal/api/AnalogOut.h
@@ -122,6 +122,10 @@ public:
     }
 #endif
 
+    virtual ~AnalogOut() {
+        // Do nothing
+    }
+
 protected:
 
     virtual void lock() {

--- a/hal/api/I2C.h
+++ b/hal/api/I2C.h
@@ -145,6 +145,10 @@ public:
      */
     virtual void unlock(void);
 
+    virtual ~I2C() {
+        // Do nothing
+    }
+
 #if DEVICE_I2C_ASYNCH
 
     /** Start non-blocking I2C transfer.

--- a/hal/api/InterruptManager.h
+++ b/hal/api/InterruptManager.h
@@ -113,13 +113,12 @@ public:
      */
     bool remove_handler(pFunctionPointer_t handler, IRQn_Type irq);
 
-protected:
-    virtual void lock();
-    virtual void unlock();
-
 private:
     InterruptManager();
     ~InterruptManager();
+
+    void lock();
+    void unlock();
 
     // We declare the copy contructor and the assignment operator, but we don't
     // implement them. This way, if someone tries to copy/assign our instance,


### PR DESCRIPTION
Add a virtual destructor to classes which have a virtual lock and
unlock.  Remove the virtual qualifier from functions in
InterruptManager since this class cannot be extended.