### PR TITLE
Tools/project - project dir should be the list

### DIFF
--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -68,10 +68,10 @@ class Uvision4(Exporter):
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision']['misc'] = {}
         project_data['tool_specific']['uvision']['misc']['asm_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['asm']))
-        project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c']))
+        # cxx flags included, as uvision have them all in one tab
+        project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
-        project_data['tool_specific']['uvision']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common']))
         project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -71,7 +71,7 @@ class Uvision4(Exporter):
         project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
-        project_data['tool_specific']['uvision']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['ld']))
+        project_data['tool_specific']['uvision']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common']))
         project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -19,6 +19,7 @@ from project_generator_definitions.definitions import ProGenDef
 
 from tools.export.exporters import Exporter
 from tools.targets import TARGET_MAP, TARGET_NAMES
+from tools.settings import ARM_INC
 
 # If you wish to add a new target, add it to project_generator_definitions, and then
 # define progen_target name in the target class (`` self.progen_target = 'my_target_name' ``)
@@ -67,11 +68,14 @@ class Uvision4(Exporter):
 
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision']['misc'] = {}
-        project_data['tool_specific']['uvision']['misc']['asm_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['asm']))
+        # asm flags only, common are not valid within uvision project, they are armcc specific
+        project_data['tool_specific']['uvision']['misc']['asm_flags'] = list(set(self.toolchain.flags['asm']))
         # cxx flags included, as uvision have them all in one tab
         project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
+        # ARM_INC is by default as system inclusion, not required for exported project
+        project_data['tool_specific']['uvision']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -68,10 +68,10 @@ class Uvision5(Exporter):
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision5']['misc'] = {}
         project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['asm']))
-        project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c']))
+        # cxx flags included, as uvision have them all in one tab
+        project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
-        project_data['tool_specific']['uvision5']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common']))
         project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -71,7 +71,7 @@ class Uvision5(Exporter):
         project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
-        project_data['tool_specific']['uvision5']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['ld']))
+        project_data['tool_specific']['uvision5']['misc']['cxx_flags'] = list(set(self.toolchain.flags['common']))
         project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.toolchain.flags['ld']
 
         i = 0

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -67,7 +67,8 @@ class Uvision5(Exporter):
 
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision5']['misc'] = {}
-        project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['asm']))
+        # asm flags only, common are not valid within uvision project, they are armcc specific
+        project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.toolchain.flags['asm']))
         # cxx flags included, as uvision have them all in one tab
         project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
         # not compatible with c99 flag set in the template

--- a/tools/project.py
+++ b/tools/project.py
@@ -205,12 +205,12 @@ if __name__ == '__main__':
 
             # Build the project with the same directory structure of the mbed online IDE
             project_name = test.id
-            project_dir = join(EXPORT_WORKSPACE, project_name)
+            project_dir = [join(EXPORT_WORKSPACE, project_name)]
             project_temp = EXPORT_TMP
-            setup_user_prj(project_dir, test.source_dir, test.dependencies)
+            setup_user_prj(project_dir[0], test.source_dir, test.dependencies)
 
         # Export to selected toolchain
-        tmp_path, report = export(project_dir, project_name, ide, mcu, project_dir, project_temp, clean=clean, zip=zip, extra_symbols=lib_symbols, relative=sources_relative)
+        tmp_path, report = export(project_dir, project_name, ide, mcu, project_dir[0], project_temp, clean=clean, zip=zip, extra_symbols=lib_symbols, relative=sources_relative)
         if report['success']:
             zip_path = join(EXPORT_DIR, "%s_%s_%s.zip" % (project_name, ide, mcu))
             if zip:

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -35,7 +35,7 @@ class ARM(mbedToolchain):
     DEFAULT_FLAGS = {
         'common': ["-c", "--gnu",
             "-Otime", "--split_sections", "--apcs=interwork",
-            "--brief_diagnostics", "--restrict", "--multibyte_chars", "-I", "\""+ARM_INC+"\""],
+            "--brief_diagnostics", "--restrict", "--multibyte_chars", "-I \""+ARM_INC+"\""],
         'asm': [],
         'c': ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         'cxx': ["--cpp", "--no_rtti"],


### PR DESCRIPTION
The project dir if using just project.py shall be a list of directories.

Using ``project.py -m KL25Z -t IAR`` works with this fix. I'll continue testing this patch, as there are some other problems.

cc @screamerbg 