### PR TITLE
[STM32F0xx] Fix for #816 issue

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
@@ -43,7 +43,6 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
-extern volatile uint16_t cnt_val;
 
 // Used to increment the slave counter
 void timer_update_irq_handler(void)
@@ -60,7 +59,7 @@ void timer_update_irq_handler(void)
 // Used for mbed timeout (channel 1) and HAL tick (channel 2)
 void timer_oc_irq_handler(void)
 {
-    cnt_val = TIM_MST->CNT;
+    uint16_t cval = TIM_MST->CNT;
     TimMasterHandle.Instance = TIM_MST;
 
     // Channel 1 for mbed timeout
@@ -72,7 +71,7 @@ void timer_oc_irq_handler(void)
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cnt_val; // To finish the counter loop the next time
+                oc_rem_part = cval; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
@@ -128,8 +128,10 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Output compare channel 2 interrupt for HAL tick
     NVIC_SetVector(TIM_MST_UP_IRQ, (uint32_t)timer_update_irq_handler);
     NVIC_EnableIRQ(TIM_MST_UP_IRQ);
+    NVIC_SetPriority(TIM_MST_UP_IRQ, 0);
     NVIC_SetVector(TIM_MST_OC_IRQ, (uint32_t)timer_oc_irq_handler);
     NVIC_EnableIRQ(TIM_MST_OC_IRQ);
+    NVIC_SetPriority(TIM_MST_OC_IRQ, 1);
 
     // Enable interrupts
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_UPDATE); // For 32-bit counter

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
@@ -130,8 +130,10 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Output compare channel 2 interrupt for HAL tick
     NVIC_SetVector(TIM_MST_UP_IRQ, (uint32_t)timer_update_irq_handler);
     NVIC_EnableIRQ(TIM_MST_UP_IRQ);
+    NVIC_SetPriority(TIM_MST_UP_IRQ, 0);
     NVIC_SetVector(TIM_MST_OC_IRQ, (uint32_t)timer_oc_irq_handler);
     NVIC_EnableIRQ(TIM_MST_OC_IRQ);
+    NVIC_SetPriority(TIM_MST_OC_IRQ, 1);
 
     // Enable interrupts
     __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_UPDATE); // For 32-bit counter

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
@@ -43,7 +43,6 @@ void set_compare(uint16_t count);
 extern volatile uint32_t SlaveCounter;
 extern volatile uint32_t oc_int_part;
 extern volatile uint16_t oc_rem_part;
-extern volatile uint16_t cnt_val;
 
 // Used to increment the slave counter
 void timer_update_irq_handler(void)
@@ -60,7 +59,7 @@ void timer_update_irq_handler(void)
 // Used for mbed timeout (channel 1) and HAL tick (channel 2)
 void timer_oc_irq_handler(void)
 {
-    cnt_val = TIM_MST->CNT;
+    uint16_t cval = TIM_MST->CNT;
     TimMasterHandle.Instance = TIM_MST;
 
     // Channel 1 for mbed timeout
@@ -72,7 +71,7 @@ void timer_oc_irq_handler(void)
         } else {
             if (oc_int_part > 0) {
                 set_compare(0xFFFF);
-                oc_rem_part = cnt_val; // To finish the counter loop the next time
+                oc_rem_part = cval; // To finish the counter loop the next time
                 oc_int_part--;
             } else {
                 us_ticker_irq_handler();

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/us_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/us_ticker.c
@@ -41,7 +41,6 @@ static int us_ticker_inited = 0;
 volatile uint32_t SlaveCounter = 0;
 volatile uint32_t oc_int_part = 0;
 volatile uint16_t oc_rem_part = 0;
-volatile uint16_t cnt_val = 0;
 
 void set_compare(uint16_t count) {
     TimMasterHandle.Instance = TIM_MST;
@@ -59,15 +58,24 @@ void us_ticker_init(void) {
 }
 
 uint32_t us_ticker_read() {
-    uint32_t counter;
+    uint32_t counter, counter2;
     if (!us_ticker_inited) us_ticker_init();
-
-    //Current value of TIM_MST->CNT is stored in cnt_val and is
-    //updated in interrupt context
+    // A situation might appear when Master overflows right after Slave is read and before the
+    // new (overflowed) value of Master is read. Which would make the code below consider the
+    // previous (incorrect) value of Slave and the new value of Master, which would return a
+    // value in the past. Avoid this by computing consecutive values of the timer until they
+    // are properly ordered.
     counter = (uint32_t)(SlaveCounter << 16);
-    counter += cnt_val;
-
-    return counter;
+    counter += TIM_MST->CNT;
+    while (1) {
+        counter2 = (uint32_t)(SlaveCounter << 16);
+        counter2 += TIM_MST->CNT;
+        if (counter2 > counter) {
+            break;
+        }
+        counter = counter2;
+    }
+    return counter2;
 }
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {


### PR DESCRIPTION
This is a fix for #816 issue only for F0xx family. It contains two changes:

Partial revert of 07b841b and currently we are only reverting the
STM32F0xx family because new fix will be presented that's why we want to keep,
still the original solution only F1xx family (it will be fixed in future).

Also a solution for issue #816 when having two separate IRQ handlers
in Timers (UPDATE Irq and OutputCompare Irq). The update priority needs to
be higher to avoid undefined behaviours.

====
Tested on NUCLEO_F070RB and NUCLEO_F030R8 in multiple cases and MBED_16 is passed OK. Please find the test report below.

**NUCLEO_F070RB** 
All compilers, multiple tested times:
- 1000/1500/1000 - OK
- 500/1000/500 - OK
- 1500/2000/1500 - OK
- 600/800/600 - OK
- sampling rate in Saleae 90s

MBED_16 OK

===

**NUCLEO_F030R8** 
All compilers, multiple tested times:
- 1000/1500/1000 - OK
- 500/1000/500 - OK
- 1500/2000/1500 - OK
- 600/800/600 - OK
- sampling rate in Saleae 90s

MBED_16 OK