### PR TITLE
Fix pin mode for STM32F1 target. 

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/pinmap.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/pinmap.c
@@ -177,12 +177,12 @@ void pin_mode(PinName pin, PinMode mode)
             if (pin_index < 8) {
                 if ((gpio->CRL & (0x03 << (pin_index * 4))) == 0) { // MODE bits = Input mode
                     gpio->CRL |= (0x08 << (pin_index * 4)); // Set pull-up / pull-down
-                    gpio->CRL &= ~(0x08 << ((pin_index * 4)-1)); // ENSURES GPIOx_CRL.CNFx.bit0 = 0
+                    gpio->CRL &= ~(0x04 << (pin_index * 4)); // ENSURES GPIOx_CRL.CNFx.bit0 = 0
                 }
             } else {
                 if ((gpio->CRH & (0x03 << ((pin_index % 8) * 4))) == 0) { // MODE bits = Input mode
                     gpio->CRH |= (0x08 << ((pin_index % 8) * 4)); // Set pull-up / pull-down
-                    gpio->CRH &= ~(0x08 << (((pin_index % 8) * 4)-1)); // ENSURES GPIOx_CRH.CNFx.bit0 = 0
+                    gpio->CRH &= ~(0x04 << ((pin_index % 8) * 4)); // ENSURES GPIOx_CRH.CNFx.bit0 = 0
                 }
             }
             // Now it's time to setup properly if pullup or pulldown. This is done in ODR register:


### PR DESCRIPTION
Failed for pin_index 0 (PA_0, PB_0,PC_0).
Usecase:
```cpp
DigitalIn pa0(PA_0, PullUp);
//or
gpio_t gpio;
gpio_init(&gpio, C9);
gpio_dir(&gpio, PIN_INPUT);
gpio_mode(&gpio, PullDown);
```

in both cases GPIO registers are corrupted.