### PR TITLE
Fix GCC malloc lock

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -646,22 +646,22 @@ extern "C" WEAK void __rtos_malloc_unlock( struct _reent *_r ) {}
 extern "C" WEAK void __rtos_env_lock( struct _reent *_r ) {}
 extern "C" WEAK void __rtos_env_unlock( struct _reent *_r ) {}
 
-void __malloc_lock( struct _reent *_r )
+extern "C" void __malloc_lock( struct _reent *_r )
 {
     __rtos_malloc_lock(_r);
 }
 
-void __malloc_unlock( struct _reent *_r )
+extern "C" void __malloc_unlock( struct _reent *_r )
 {
     __rtos_malloc_unlock(_r);
 }
 
-void __env_lock( struct _reent *_r )
+extern "C" void __env_lock( struct _reent *_r )
 {
     __rtos_env_lock(_r);
 }
 
-void __env_unlock( struct _reent *_r )
+extern "C" void __env_unlock( struct _reent *_r )
 {
     __rtos_env_unlock(_r);
 }


### PR DESCRIPTION
The malloc lock functions were not declared as extern "C" so they
are not getting linked to the standard library.  Add extern "C" to
fix this.

This bug was introduced in the commit:
d0b7b3b497ae1824bb8cb07603c90f5105d7818d -
Fix duplicate symbols for malloc lock and unlock