### PR TITLE
Fix inclusion (board.c and critical.c)

### DIFF
--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -15,7 +15,7 @@
  * limitations under the License.
  */
 
-
+#define __STDC_LIMIT_MACROS
 #include <stdint.h>
 #include <stddef.h>
 #include "cmsis.h"

--- a/hal/common/error.c
+++ b/hal/common/error.c
@@ -18,6 +18,7 @@
 #include "device.h"
 #include "toolchain.h"
 #include "mbed_error.h"
+#include "mbed_interface.h"
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif


### PR DESCRIPTION
One header missing to include in the board.c to get mbed_error_vfprintf(), plus critical.c to get UINT32_MAX constant

@c1728p9 