### PR TITLE
Removing K64F_UVISOR target

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -596,10 +596,6 @@
         "detect_code": ["0240"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "STORAGE"]
     },
-    "K64F_UVISOR": {
-        "inherits": ["K64F"],
-        "extra_labels_add": ["K64F", "UVISOR_SUPPORTED"]
-    },
     "MTS_GAMBIT": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",


### PR DESCRIPTION
uVisor is now enabled by features, not through targets. Removing the old K64F_UVISOR target.