### PR TITLE
Revert "Fix iar exporter - flags duplication and consolidations"

### DIFF
--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -20,7 +20,6 @@ from project_generator_definitions.definitions import ProGenDef
 
 from tools.export.exporters import Exporter
 from tools.targets import TARGET_MAP, TARGET_NAMES
-from tools.settings import IAR_PATH
 
 # If you wish to add a new target, add it to project_generator_definitions, and then
 # define progen_target name in the target class (`` self.progen_target = 'my_target_name' ``)
@@ -71,15 +70,6 @@ class IAREmbeddedWorkbench(Exporter):
         project_data['tool_specific']['iar'].setdefault("misc", {})
         project_data['tool_specific']['iar'].update(tool_specific['iar'])
         project_data['tool_specific']['iar']['misc'].update(self.progen_flags)
-        # progen does not have common flags, expand c flags by common one
-        project_data['tool_specific']['iar']['misc']['c_flags'] += self.progen_flags['common_flags']
-        # template sets full dlib, this would produce the error as it's duplicate
-        project_data['tool_specific']['iar']['misc']['c_flags'].remove("--dlib_config")
-        project_data['tool_specific']['iar']['misc']['c_flags'].remove(os.path.join(IAR_PATH, "inc", "c", "DLib_Config_Full.h"))
-        # these c++ flags are set by template - c++, no rtti, no exceptions
-        project_data['tool_specific']['iar']['misc']['cxx_flags'].remove("--c++")
-        project_data['tool_specific']['iar']['misc']['cxx_flags'].remove("--no_rtti")
-        project_data['tool_specific']['iar']['misc']['cxx_flags'].remove("--no_exceptions")
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
         self.progen_gen_file('iar_arm', project_data)
 

--- a/tools/export/iar_template.ewp.tmpl
+++ b/tools/export/iar_template.ewp.tmpl
@@ -622,8 +622,8 @@
         <debug>1</debug>
         <option>
           <name>OOCOutputFormat</name>
-          <version>3</version>
-          <state>3</state>
+          <version>2</version>
+          <state>2</state>
         </option>
         <option>
           <name>OCOutputOverride</name>

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -38,11 +38,9 @@ class IAR(mbedToolchain):
             # Pa093: Implicit conversion from float to integer (ie: wait_ms(85.4) -> wait_ms(85))
             # Pa082: Operation involving two values from two registers (ie: (float)(*obj->MR)/(float)(LPC_PWM1->MR0))
             "-e", # Enable IAR language extension
-            "--diag_suppress=Pa050,Pa084,Pa093,Pa082",
-            "--thumb",
-            "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h")],
+            "--diag_suppress=Pa050,Pa084,Pa093,Pa082"],
         'asm': [],
-        'c': [],
+        'c': ["--vla"],
         'cxx': ["--c++",  "--no_rtti", "--no_exceptions", "--guard_calls"],
         'ld': ["--skip_dynamic_initialization", "--threaded_lib"],
     }
@@ -53,31 +51,35 @@ class IAR(mbedToolchain):
             cpuchoice = "Cortex-M7"
         else:
             cpuchoice = target.core
+        self.flags["common"] += [
+            "--cpu=%s" % cpuchoice, "--thumb",
+            "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h"),
+        ]
 
         if target.core == "Cortex-M7F":
             self.flags["common"].append("--fpu=VFPv5_sp")
 
-        optimization = []
         if "debug-info" in self.options:
-            optimization.append("-r")
-            optimization.append("-On")
+            self.flags["common"].append("-r")
+            self.flags["common"].append("-On")
         else:
-            optimization.append("-Oh")
+            self.flags["common"].append("-Oh")
 
         IAR_BIN = join(IAR_PATH, "bin")
         main_cc = join(IAR_BIN, "iccarm")
 
+        self.flags["asm"] += ["--cpu", cpuchoice]
         if target.core == "Cortex-M7F":
             self.flags["asm"] += ["--fpu", "VFPv5_sp"]
-        self.asm  = [join(IAR_BIN, "iasmarm")] + self.flags["asm"] + ["--cpu=%s" % cpuchoice]
+        self.asm  = [join(IAR_BIN, "iasmarm")] + self.flags["asm"]
         if not "analyze" in self.options:
             self.cc   = [main_cc]
             self.cppc = [main_cc]
         else:
             self.cc   = [join(GOANNA_PATH, "goannacc"), '--with-cc="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT]
             self.cppc = [join(GOANNA_PATH, "goannac++"), '--with-cxx="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT]
-        self.cc += self.flags["common"] + self.flags["c"] + ["--cpu=%s" % cpuchoice] + optimization
-        self.cppc += self.flags["common"] + self.flags["cxx"] + ["--cpu=%s" % cpuchoice] + optimization
+        self.cc += self.flags["common"] + self.flags["c"]
+        self.cppc += self.flags["common"] + self.flags["cxx"]
         self.ld   = join(IAR_BIN, "ilinkarm")
         self.ar = join(IAR_BIN, "iarchive")
         self.elf2bin = join(IAR_BIN, "ielftool")


### PR DESCRIPTION
Reverts mbedmicro/mbed#1938

This breaks all command line builds for IAR. Do not merge patches that are not tested across all toolchains. 