### PR TITLE
[NUCLEO_F746ZG] add IPV4 support for F7 in mbed

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ STMicroelectronics:
 * [Nucleo-F302R8](https://developer.mbed.org/platforms/ST-Nucleo-F302R8/) (Cortex-M4F)
 * [Nucleo-F334R8](https://developer.mbed.org/platforms/ST-Nucleo-F334R8/) (Cortex-M4F)
 * [Nucleo-F401RE](https://developer.mbed.org/platforms/ST-Nucleo-F401RE/) (Cortex-M4F)
-* Nucleo-F410RB (Cortex-M4F)
+* [Nucleo-F410RB](https://developper.mbed.org/platforms/ST-Nucleo-F410RB/) (Cortex-M4F)
 * [Nucleo-F411RE](https://developer.mbed.org/platforms/ST-Nucleo-F411RE/) (Cortex-M4F)
 * [Nucleo-L476RG](https://developer.mbed.org/platforms/ST-Nucleo-L476RG/) (Cortex-M4F)
 * STM32F4XX (Cortex-M4F)

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -833,7 +833,8 @@
             }
         },
         "detect_code": ["0816"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "features": ["IPV4"]
     },
     "NUCLEO_L031K6": {
         "inherits": ["Target"],


### PR DESCRIPTION
This modification is to allow IPV4 feature on mbed
