### PR TITLE
Update exporters to include and use mbed_conf.h

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -48,6 +48,9 @@ class Exporter(object):
     def progen_flags(self):
         if not hasattr(self, "_progen_flag_cache") :
             self._progen_flag_cache = dict([(key + "_flags", value) for key,value in self.flags.iteritems()])
+            if self.config_header:
+                self._progen_flag_cache['c_flags'] += self.toolchain.get_config_option(self.config_header)
+                self._progen_flag_cache['cxx_flags'] += self.toolchain.get_config_option(self.config_header)
         return self._progen_flag_cache
 
     def __scan_and_copy(self, src_path, trg_path):

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -35,6 +35,7 @@ class Exporter(object):
         self.jinja_environment = Environment(loader=jinja_loader)
         self.extra_symbols = extra_symbols
         self.config_macros = []
+        self.config_header = None
 
     def get_toolchain(self):
         return self.TOOLCHAIN
@@ -168,7 +169,10 @@ class Exporter(object):
 
         # And add the configuration macros to the toolchain
         self.config_macros = config.get_config_data_macros()
-                
+
+        # Add the configuration file to the target directory
+        self.config_header =  "mbed_conf.h"
+        cfg.get_config_data_header(join(trg_path, self.config_header))
         # Check the existence of a binary build of the mbed library for the desired target
         # This prevents exporting the mbed libraries from source
         # if not self.toolchain.mbed_libs:

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -114,11 +114,14 @@ class ARM(mbedToolchain):
         dep_path = base + '.d'
         return ["--depend", dep_path]
 
+    def get_config_option(self, config_header) :
+        return ['--preinclude', config_header]
+
     def get_compile_options(self, defines, includes):        
         opts = ['-D%s' % d for d in defines] + ['--via', self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + ['--preinclude', config_header]
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -172,7 +172,7 @@ class GCC(mbedToolchain):
         opts = ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + self.get_conifg_option(config_header)
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -165,11 +165,14 @@ class GCC(mbedToolchain):
         dep_path = base + '.d'
         return ["-MD", "-MF", dep_path]
 
+    def get_config_option(self, config_header):
+        return ['-include', config_header]
+
     def get_compile_options(self, defines, includes):
         opts = ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + ['-include', config_header]
+            opts = opts + self.get_conifg_option(config_header)
         return opts
 
     @hook_tool

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -126,11 +126,14 @@ class IAR(mbedToolchain):
         base, _ = splitext(object)
         return ["-l", base + '.s.txt']
 
+    def get_config_option(self, config_header):
+        return ['--preinclude', config_header]
+
     def get_compile_options(self, defines, includes):
         opts = ['-D%s' % d for d in defines] + ['-f', self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + ['--preinclude', config_header]
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool


### PR DESCRIPTION
Affected exporters:
 - gcc_arm
 - uVision4
 - IAR
 - emblocks
 - atmelstudio
 - codered
 - simplicityv3