### PR TITLE
Checking if ignored dir is in the dir list before removing

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -455,7 +455,8 @@ class mbedToolchain:
                     (d.startswith('TARGET_') and d[7:] not in labels['TARGET']) or
                     (d.startswith('TOOLCHAIN_') and d[10:] not in labels['TOOLCHAIN']) or
                     (d == 'TESTS')):
-                    dirs.remove(d)
+                    if d in dirs:
+                        dirs.remove(d)
 
                 if (d.startswith('FEATURE_')):
                     resources.features[d[8:]] = self.scan_resources(dir_path, base_path=base_path)
@@ -465,12 +466,13 @@ class mbedToolchain:
                 # to avoid travelling into them and to prevent them
                 # on appearing in include path.
                 if self.is_ignored(join(dir_path,"")):
-                    dirs.remove(d)
+                    if d in dirs: 
+                        dirs.remove(d)
 
                 if exclude_paths:
                     for exclude_path in exclude_paths:
                         rel_path = relpath(dir_path, exclude_path)
-                        if not (rel_path.startswith('..')):
+                        if not (rel_path.startswith('..')) and d in dirs:
                             dirs.remove(d)
                             break
 


### PR DESCRIPTION
This addresses an issue regarding ignored directories. When traversing the source tree, the `.mbedignore` files dictate which directories should be "removed" from the traversal list. If this directory hasn't been added to this list before attempting to remove it, an Exception occurs and a traceback is printed to the user.

This PR adds checks before removing dirs from the traversal list in the cases where the added directories are not being looped over exclusively.