### PR TITLE
[Exporters] Update exporters to include and use mbed_conf.h (Was #1964)

### DIFF
--- a/tools/export/atmelstudio.py
+++ b/tools/export/atmelstudio.py
@@ -33,6 +33,8 @@ class AtmelStudio(Exporter):
 
     DOT_IN_RELATIVE_PATH = True
 
+    MBED_CONF_ACTIVE = True
+
     def generate(self):
 
         source_files = []

--- a/tools/export/atmelstudio.py
+++ b/tools/export/atmelstudio.py
@@ -33,7 +33,7 @@ class AtmelStudio(Exporter):
 
     DOT_IN_RELATIVE_PATH = True
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     def generate(self):
 

--- a/tools/export/codered.py
+++ b/tools/export/codered.py
@@ -22,7 +22,7 @@ class CodeRed(Exporter):
     NAME = 'CodeRed'
     TOOLCHAIN = 'GCC_CR'
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     TARGETS = [
         'LPC1768',

--- a/tools/export/codered.py
+++ b/tools/export/codered.py
@@ -22,6 +22,8 @@ class CodeRed(Exporter):
     NAME = 'CodeRed'
     TOOLCHAIN = 'GCC_CR'
 
+    MBED_CONF_ACTIVE = True
+
     TARGETS = [
         'LPC1768',
         'LPC4088',

--- a/tools/export/emblocks.py
+++ b/tools/export/emblocks.py
@@ -31,7 +31,7 @@ class IntermediateFile(Exporter):
     # we support all GCC targets (is handled on IDE side)
     TARGETS = gccTargets
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     FILE_TYPES = {
         'headers': 'h',

--- a/tools/export/emblocks.py
+++ b/tools/export/emblocks.py
@@ -31,6 +31,8 @@ class IntermediateFile(Exporter):
     # we support all GCC targets (is handled on IDE side)
     TARGETS = gccTargets
 
+    MBED_CONF_ACTIVE = True
+
     FILE_TYPES = {
         'headers': 'h',
         'c_sources': 'c',

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -171,12 +171,15 @@ class Exporter(object):
         # Loads the resources into the config system which might expand/modify resources based on config data
         self.resources = config.load_resources(resources)
 
-        # And add the configuration macros to the toolchain
-        self.config_macros = config.get_config_data_macros()
 
-        # Add the configuration file to the target directory
-        self.config_header =  "mbed_conf.h"
-        config.get_config_data_header(join(trg_path, self.config_header))
+        if hasattr(self, "MBED_CONF_ACTIVE") and self.MBED_CONF_ACTIVE :
+            # Add the configuration file to the target directory
+            self.config_header = "mbed_conf.h"
+            config.get_config_data_header(join(trg_path, self.config_header))
+            self.config_macros = []
+        else :
+            # And add the configuration macros to the toolchain
+            self.config_macros = config.get_config_data_macros()
         # Check the existence of a binary build of the mbed library for the desired target
         # This prevents exporting the mbed libraries from source
         # if not self.toolchain.mbed_libs:

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -176,7 +176,7 @@ class Exporter(object):
 
         # Add the configuration file to the target directory
         self.config_header =  "mbed_conf.h"
-        cfg.get_config_data_header(join(trg_path, self.config_header))
+        config.get_config_data_header(join(trg_path, self.config_header))
         # Check the existence of a binary build of the mbed library for the desired target
         # This prevents exporting the mbed libraries from source
         # if not self.toolchain.mbed_libs:

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -36,6 +36,7 @@ class Exporter(object):
         self.extra_symbols = extra_symbols
         self.config_macros = []
         self.sources_relative = sources_relative
+        self.config_header = None
 
     def get_toolchain(self):
         return self.TOOLCHAIN
@@ -169,7 +170,10 @@ class Exporter(object):
 
         # And add the configuration macros to the toolchain
         self.config_macros = config.get_config_data_macros()
-                
+
+        # Add the configuration file to the target directory
+        self.config_header =  "mbed_conf.h"
+        cfg.get_config_data_header(join(trg_path, self.config_header))
         # Check the existence of a binary build of the mbed library for the desired target
         # This prevents exporting the mbed libraries from source
         # if not self.toolchain.mbed_libs:

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -172,7 +172,7 @@ class Exporter(object):
         self.resources = config.load_resources(resources)
 
 
-        if hasattr(self, "MBED_CONF_ACTIVE") and self.MBED_CONF_ACTIVE :
+        if hasattr(self, "MBED_CONFIG_HEADER_SUPPORTED") and self.MBED_CONFIG_HEADER_SUPPORTED :
             # Add the configuration file to the target directory
             self.config_header = self.toolchain.MBED_CONFIG_FILE_NAME
             config.get_config_data_header(join(trg_path, self.config_header))

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -49,6 +49,9 @@ class Exporter(object):
     def progen_flags(self):
         if not hasattr(self, "_progen_flag_cache") :
             self._progen_flag_cache = dict([(key + "_flags", value) for key,value in self.flags.iteritems()])
+            if self.config_header:
+                self._progen_flag_cache['c_flags'] += self.toolchain.get_config_option(self.config_header)
+                self._progen_flag_cache['cxx_flags'] += self.toolchain.get_config_option(self.config_header)
         return self._progen_flag_cache
 
     def __scan_and_copy(self, src_path, trg_path):

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -174,7 +174,7 @@ class Exporter(object):
 
         if hasattr(self, "MBED_CONF_ACTIVE") and self.MBED_CONF_ACTIVE :
             # Add the configuration file to the target directory
-            self.config_header = "mbed_conf.h"
+            self.config_header = self.toolchain.MBED_CONFIG_FILE_NAME
             config.get_config_data_header(join(trg_path, self.config_header))
             self.config_macros = []
         else :

--- a/tools/export/gccarm.py
+++ b/tools/export/gccarm.py
@@ -121,6 +121,8 @@ class GccArm(Exporter):
 
     DOT_IN_RELATIVE_PATH = True
 
+    MBED_CONF_ACTIVE = True
+
     def generate(self):
         # "make" wants Unix paths
         self.resources.win_to_unix()

--- a/tools/export/gccarm.py
+++ b/tools/export/gccarm.py
@@ -121,7 +121,7 @@ class GccArm(Exporter):
 
     DOT_IN_RELATIVE_PATH = True
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     def generate(self):
         # "make" wants Unix paths

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -33,7 +33,7 @@ class IAREmbeddedWorkbench(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     # backward compatibility with our scripts
     TARGETS = []

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -33,6 +33,8 @@ class IAREmbeddedWorkbench(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
+    MBED_CONF_ACTIVE = True
+
     # backward compatibility with our scripts
     TARGETS = []
     for target in TARGET_NAMES:

--- a/tools/export/simplicityv3.py
+++ b/tools/export/simplicityv3.py
@@ -101,6 +101,8 @@ class SimplicityV3(Exporter):
 
     DOT_IN_RELATIVE_PATH = False
 
+    MBED_CONF_ACTIVE = True
+
     orderedPaths = Folder("Root")
 
     def check_and_add_path(self, path):

--- a/tools/export/simplicityv3.py
+++ b/tools/export/simplicityv3.py
@@ -101,7 +101,7 @@ class SimplicityV3(Exporter):
 
     DOT_IN_RELATIVE_PATH = False
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     orderedPaths = Folder("Root")
 

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -69,16 +69,16 @@ class Uvision4(Exporter):
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision']['misc'] = {}
         # asm flags only, common are not valid within uvision project, they are armcc specific
-        project_data['tool_specific']['uvision']['misc']['asm_flags'] = list(set(self.toolchain.flags['asm']))
+        project_data['tool_specific']['uvision']['misc']['asm_flags'] = list(set(self.progen_flags['asm_flags']))
         # cxx flags included, as uvision have them all in one tab
-        project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
+        project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.progen_flags['common_flags'] + self.progen_flags['c_flags'] + self.progen_flags['cxx_flags']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
         # ARM_INC is by default as system inclusion, not required for exported project
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         # cpp is not required as it's implicit for cpp files
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--cpp")
-        project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.toolchain.flags['ld']
+        project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.progen_flags['ld_flags']
 
         i = 0
         for macro in project_data['common']['macros']:

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -34,6 +34,8 @@ class Uvision4(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
+    MBED_CONF_ACTIVE = True
+
     # backward compatibility with our scripts
     TARGETS = []
     for target in TARGET_NAMES:

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -34,7 +34,7 @@ class Uvision4(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     # backward compatibility with our scripts
     TARGETS = []

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -34,7 +34,7 @@ class Uvision5(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
-    MBED_CONF_ACTIVE = True
+    MBED_CONFIG_HEADER_SUPPORTED = True
 
     # backward compatibility with our scripts
     TARGETS = []

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -69,16 +69,16 @@ class Uvision5(Exporter):
         # get flags from toolchain and apply
         project_data['tool_specific']['uvision5']['misc'] = {}
         # asm flags only, common are not valid within uvision project, they are armcc specific
-        project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.toolchain.flags['asm']))
+        project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.progen_flags['asm_flags']))
         # cxx flags included, as uvision have them all in one tab
-        project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.toolchain.flags['common'] + self.toolchain.flags['c'] + self.toolchain.flags['cxx']))
+        project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.progen_flags['common_flags'] + self.progen_flags['c_flags'] + self.progen_flags['cxx_flags']))
         # ARM_INC is by default as system inclusion, not required for exported project
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
         # cpp is not required as it's implicit for cpp files
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--cpp")
-        project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.toolchain.flags['ld']
+        project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.progen_flags['ld_flags']
 
         i = 0
         for macro in project_data['common']['macros']:

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -34,6 +34,8 @@ class Uvision5(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
+    MBED_CONF_ACTIVE = True
+
     # backward compatibility with our scripts
     TARGETS = []
     for target in TARGET_NAMES:

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -227,6 +227,8 @@ class mbedToolchain:
     GOANNA_FORMAT = "[Goanna] warning [%FILENAME%:%LINENO%] - [%CHECKNAME%(%SEVERITY%)] %MESSAGE%"
     GOANNA_DIAGNOSTIC_PATTERN = re.compile(r'"\[Goanna\] (?P<severity>warning) \[(?P<file>[^:]+):(?P<line>\d+)\] \- (?P<message>.*)"')
 
+    MBED_CONFIG_FILE_NAME="mbed_config.h"
+
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
         self.target = target
         self.name = self.__class__.__name__
@@ -908,7 +910,7 @@ class mbedToolchain:
     def get_config_header(self):
         if self.config_data is None:
             return None
-        config_file = join(self.build_dir, "mbed_config.h")
+        config_file = join(self.build_dir, self.MBED_CONFIG_FILE_NAME)
         if not exists(config_file):
             with open(config_file, "wt") as f:
                 f.write(Config.config_to_header(self.config_data))

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -114,11 +114,14 @@ class ARM(mbedToolchain):
         dep_path = base + '.d'
         return ["--depend", dep_path]
 
+    def get_config_option(self, config_header) :
+        return ['--preinclude', config_header]
+
     def get_compile_options(self, defines, includes):        
         opts = ['-D%s' % d for d in defines] + ['--via', self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + ['--preinclude', config_header]
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -115,7 +115,7 @@ class ARM(mbedToolchain):
         return ["--depend", dep_path]
 
     def get_config_option(self, config_header) :
-        return ['--preinclude', config_header]
+        return ['--preinclude=' + config_header]
 
     def get_compile_options(self, defines, includes):        
         opts = ['-D%s' % d for d in defines] + ['--via', self.get_inc_file(includes)]

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -172,7 +172,7 @@ class GCC(mbedToolchain):
         opts = ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + self.get_conifg_option(config_header)
+            opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -165,11 +165,14 @@ class GCC(mbedToolchain):
         dep_path = base + '.d'
         return ["-MD", "-MF", dep_path]
 
+    def get_config_option(self, config_header):
+        return ['-include', config_header]
+
     def get_compile_options(self, defines, includes):
         opts = ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if config_header is not None:
-            opts = opts + ['-include', config_header]
+            opts = opts + self.get_conifg_option(config_header)
         return opts
 
     @hook_tool

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -127,7 +127,7 @@ class IAR(mbedToolchain):
         return ["-l", base + '.s.txt']
 
     def get_config_option(self, config_header):
-        return ['--preinclude', config_header]
+        return ['--preinclude=' + config_header]
 
     def get_compile_options(self, defines, includes, for_asm=False):
         opts = ['-f', self.get_inc_file(includes)]

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -130,7 +130,7 @@ class IAR(mbedToolchain):
         return ['--preinclude=' + config_header]
 
     def get_compile_options(self, defines, includes, for_asm=False):
-        opts = ['-f', self.get_inc_file(includes)]
+        opts = ['-D%s' % d for d in defines] + ['-f', self.get_inc_file(includes)]
         config_header = self.get_config_header()
         if for_asm:
             # The assembler doesn't support '--preinclude', so we need to add

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -126,8 +126,12 @@ class IAR(mbedToolchain):
         base, _ = splitext(object)
         return ["-l", base + '.s.txt']
 
+    def get_config_option(self, config_header):
+        return ['--preinclude', config_header]
+
     def get_compile_options(self, defines, includes, for_asm=False):
-        opts = ['-D%s' % d for d in defines] + ['-f', self.get_inc_file(includes)]
+        opts = ['-f', self.get_inc_file(includes)]
+        config_header = self.get_config_header()
         if for_asm:
             # The assembler doesn't support '--preinclude', so we need to add
             # the macros directly
@@ -135,7 +139,7 @@ class IAR(mbedToolchain):
         else:
             config_header = self.get_config_header()
             if config_header is not None:
-                opts = opts + ['--preinclude', config_header]
+                opts = opts + self.get_config_option(config_header)
         return opts
 
     @hook_tool


### PR DESCRIPTION
Affected exporters:
 - gcc_arm
 - uVision4
 - IAR
 - emblocks
 - atmelstudio
 - codered
 - simplicityv3

Summary of discussion:

@0xc0170:
We should wait until the name of mbed_conf.h is set in stone.

@bogdanm:
We should introduce a configuration variable for all exporters to indicate if they export the mbed_conf.h. This will help eliminate duplication.