### PR TITLE
Fix K64F-based config tests

### DIFF
--- a/tools/test/config_test/test12/mbed_app.json
+++ b/tools/test/config_test/test12/mbed_app.json
@@ -1,6 +1,14 @@
 {
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
     "target_overrides": {
-        "K64F": {
+        "test_target": {
             "lib1.p1": "v_p1_lib1_app",
             "lib2.p1": "v_p1_lib2_app"
         }

--- a/tools/test/config_test/test12/test_data.py
+++ b/tools/test/config_test/test12/test_data.py
@@ -3,7 +3,7 @@
 # named p1 from both lib1 and lib2.
 
 expected_results = {
-   "K64F": {
+   "test_target": {
         "desc": "app without its own parameters overrides parameters in other libs",
         "lib1.p1": "v_p1_lib1_app",
         "lib1.p2": "v_p2_lib1",

--- a/tools/test/config_test/test16/mbed_app.json
+++ b/tools/test/config_test/test16/mbed_app.json
@@ -1,3 +1,11 @@
 {
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
     "macros": ["APP1=10", "APP2", "LIB2_1=5"]
 }

--- a/tools/test/config_test/test16/test_data.py
+++ b/tools/test/config_test/test16/test_data.py
@@ -5,7 +5,7 @@
 # no error should be raised
 
 expected_results = {
-    "K64F": {
+    "test_target": {
         "desc": "test macro definitions",
         "expected_macros": ["APP1=10", "APP2", "LIB1_1=1","LIB1_2", "LIB2_1=5"]
     }

--- a/tools/test/config_test/test21/mbed_app.json
+++ b/tools/test/config_test/test21/mbed_app.json
@@ -1,4 +1,12 @@
 {
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
     "target_overrides": {
         "*": {
             "target.features": ["IPV4", "IPV6"]

--- a/tools/test/config_test/test21/test_data.py
+++ b/tools/test/config_test/test21/test_data.py
@@ -1,7 +1,7 @@
 # Testing basic features
 
 expected_results = {
-    "K64F": {
+    "test_target": {
         "desc": "test basic features",
         "expected_features": ["IPV4", "IPV6"]
     }

--- a/tools/test/config_test/test22/mbed_app.json
+++ b/tools/test/config_test/test22/mbed_app.json
@@ -1,7 +1,16 @@
 {
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
     "target_overrides": {
         "*": {
             "target.features_add": ["IPV6"]
         }
     }
 }
+

--- a/tools/test/config_test/test22/test_data.py
+++ b/tools/test/config_test/test22/test_data.py
@@ -1,7 +1,7 @@
 # Testing when adding two features
 
 expected_results = {
-    "K64F": {
+    "test_target": {
         "desc": "test composing features",
         "expected_features": ["IPV4", "IPV6"]
     }

--- a/tools/test/config_test/test24/mbed_app.json
+++ b/tools/test/config_test/test24/mbed_app.json
@@ -1,4 +1,12 @@
 {
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
     "target_overrides": {
         "*": {
             "target.features_add": ["IPV4"]

--- a/tools/test/config_test/test24/test_data.py
+++ b/tools/test/config_test/test24/test_data.py
@@ -1,7 +1,7 @@
 # Testing if features can enable other features
 
 expected_results = {
-    "K64F": {
+    "test_target": {
         "desc": "test recursive features",
         "expected_features": ["IPV4", "IPV6", "UVISOR"]
     }

--- a/tools/test/config_test/test26/mbed_app.json
+++ b/tools/test/config_test/test26/mbed_app.json
@@ -1,4 +1,12 @@
 {
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": [],
+            "default_build": "standard"
+        }
+    },
     "target_overrides": {
         "*": {
             "target.features_add": ["IPV4"],

--- a/tools/test/config_test/test26/test_data.py
+++ b/tools/test/config_test/test26/test_data.py
@@ -1,7 +1,7 @@
 # Testing if config settings work in recursive features
 
 expected_results = {
-    "K64F": {
+    "test_target": {
         "desc": "test recursive feature configurations",
         "lib2.test": "GOOD"
     }


### PR DESCRIPTION
PR #1974 added a new configuration parameter to K64F, which in turn made
some tests break, because they found an unexpected configuration
parameter. Fixed by defining a special target for the tests
(test_target) that can be used independently of the actual mbed targets.