### PR TITLE
Turn on C99 VLAs in IAR

### DIFF
--- a/tools/export/iar_template.ewp.tmpl
+++ b/tools/export/iar_template.ewp.tmpl
@@ -402,7 +402,7 @@
         </option>
         <option>
           <name>IccAllowVLA</name>
-          <state>0</state>
+          <state>1</state>
         </option>
         <option>
           <name>IccCppDialect</name>

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -38,7 +38,7 @@ class ARM(mbedToolchain):
             "--brief_diagnostics", "--restrict", "--multibyte_chars", "-I \""+ARM_INC+"\""],
         'asm': [],
         'c': ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
-        'cxx': ["--cpp", "--no_rtti"],
+        'cxx': ["--cpp", "--no_rtti", "--no_vla"],
         'ld': [],
     }
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -38,7 +38,7 @@ class GCC(mbedToolchain):
             ],
         'asm': ["-x", "assembler-with-cpp"],
         'c': ["-std=gnu99"],
-        'cxx': ["-std=gnu++98", "-fno-rtti"],
+        'cxx': ["-std=gnu++98", "-fno-rtti", "-Wvla"],
         'ld': ["-Wl,--gc-sections", "-Wl,--wrap,main",
             "-Wl,--wrap,_malloc_r", "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r"],
     }

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -40,7 +40,7 @@ class IAR(mbedToolchain):
             "-e", # Enable IAR language extension
             "--diag_suppress=Pa050,Pa084,Pa093,Pa082"],
         'asm': [],
-        'c': [],
+        'c': ["--vla"],
         'cxx': ["--guard_calls"],
         'ld': ["--skip_dynamic_initialization", "--threaded_lib"],
     }


### PR DESCRIPTION
IAR defaults to C99 mode, but doesn't enable VLAs by default. Enable them
to make it more conformant.

We don't have much if any code using actual variable-length arrays, but
variably-modified types are occasionally used. The same switch controls
both.