### PR TITLE
Fix html report exporter row tag

### DIFF
--- a/tools/test_exporters.py
+++ b/tools/test_exporters.py
@@ -195,10 +195,11 @@ class ReportExporter():
 
         unique_test_ids = self.get_all_unique_test_ids(test_result_ext)
         targets = sorted(test_result_ext.keys())
-        result += '<table><tr>'
+        result += '<table>'
         for target in targets:
             toolchains = sorted(test_result_ext[target].keys())
             for toolchain in toolchains:
+                result += '<tr>'
                 result += '<td></td>'
                 result += '<td></td>'
 


### PR DESCRIPTION
Some `<tr>` are missing if there is more than one toolchain in an html report. It is handled by most of the browsers and the render is ok but it causes errors when you want to parse the file with python for example.