### PR TITLE
Add config option for stdio baud rate

### DIFF
--- a/hal/common/board.c
+++ b/hal/common/board.c
@@ -80,7 +80,12 @@ void mbed_error_vfprintf(const char * format, va_list arg) {
     int size = vsprintf(buffer, format, arg);
     if (size > 0) {
         if (!stdio_uart_inited) {
-        serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+            serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+#if defined(STDIO_UART_BAUD_RATE)
+            serial_baud(&stdio_uart, STDIO_UART_BAUD_RATE);
+#elif defined(MBED_CONF_CORE_STDIO_BAUD_RATE)
+            serial_baud(&stdio_uart, MBED_CONF_CORE_STDIO_BAUD_RATE);
+#endif
         }
         for (int i = 0; i < size; i++) {
             serial_putc(&stdio_uart, buffer[i]);

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -98,6 +98,7 @@ static void init_serial() {
 #if DEVICE_SERIAL
     if (stdio_uart_inited) return;
     serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+    serial_baud(&stdio_uart, MBED_CONF_CORE_STDIO_BAUD_RATE);
 #endif
 }
 

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -98,7 +98,11 @@ static void init_serial() {
 #if DEVICE_SERIAL
     if (stdio_uart_inited) return;
     serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+#if defined(STDIO_UART_BAUD_RATE)
+    serial_baud(&stdio_uart, STDIO_UART_BAUD_RATE);
+#elif defined(MBED_CONF_CORE_STDIO_BAUD_RATE)
     serial_baud(&stdio_uart, MBED_CONF_CORE_STDIO_BAUD_RATE);
+#endif
 #endif
 }
 

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -4,6 +4,11 @@
         "stdio-convert-newlines": {
             "help": "Enable conversion to standard newlines on stdin/stdout",
             "value": false
+        },
+
+        "stdio-baud-rate": {
+            "help": "Baud rate for stdio",
+            "value": 9600
         }
     }
 }

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -7,8 +7,7 @@
         },
 
         "stdio-baud-rate": {
-            "help": "Baud rate for stdio",
-            "value": 9600
+            "help": "Baud rate for stdio"
         }
     }
 }


### PR DESCRIPTION
@kjbracey-arm has a good write up for the motivation behind this addition: #1969 

Adds `core.stdio-baud-rate` configuration option. Defaults to 9600 for backwards compatibility.