### PR TITLE
[STM32F4] Add ADC2 support to F4 family

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_ARCH_MAX/PeripheralNames.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef enum {
     ADC_1 = (int)ADC1_BASE,
+    ADC_2 = (int)ADC2_BASE,
     ADC_3 = (int)ADC3_BASE
 } ADCName;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/PeripheralNames.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef enum {
     ADC_1 = (int)ADC1_BASE,
+    ADC_2 = (int)ADC2_BASE,
     ADC_3 = (int)ADC3_BASE
 } ADCName;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F407VG/PeripheralNames.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef enum {
     ADC_1 = (int)ADC1_BASE,
+    ADC_2 = (int)ADC2_BASE,
     ADC_3 = (int)ADC3_BASE
 } ADCName;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/PeripheralNames.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef enum {
     ADC_1 = (int)ADC1_BASE,
+    ADC_2 = (int)ADC2_BASE,
     ADC_3 = (int)ADC3_BASE
 } ADCName;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/PeripheralNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/PeripheralNames.h
@@ -38,6 +38,7 @@ extern "C" {
 
 typedef enum {
     ADC_1 = (int)ADC1_BASE,
+    ADC_2 = (int)ADC2_BASE,
     ADC_3 = (int)ADC3_BASE
 } ADCName;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/analogin_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/analogin_api.c
@@ -43,6 +43,9 @@ void analogin_init(analogin_t *obj, PinName pin)
 #if defined(ADC1)
     static int adc1_inited = 0;
 #endif
+#if defined(ADC2)
+    static int adc2_inited = 0;
+#endif
 #if defined(ADC3)
     static int adc3_inited = 0;
 #endif
@@ -68,6 +71,13 @@ void analogin_init(analogin_t *obj, PinName pin)
     if (obj->adc == ADC_1) {
         __ADC1_CLK_ENABLE();
         adc1_inited = 1;
+    }
+#endif
+#if defined(ADC2)
+    if ((obj->adc == ADC_2) && adc2_inited) return;
+    if (obj->adc == ADC_2) {
+        __ADC2_CLK_ENABLE();
+        adc2_inited = 1;
     }
 #endif
 #if defined(ADC3)


### PR DESCRIPTION
Introducing ADC2 support for NUCLEO_F446ZE implies to have the support
in the core part for all F4 chipsets that possibly support it (even if
not supported on all boards).