### PR TITLE
[STM32] Add SPI defaults pins to DISCO_F429ZI

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/PinNames.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/PinNames.h
@@ -212,6 +212,11 @@ typedef enum {
     SERIAL_RX   = PA_10,
     USBTX       = PA_9,
     USBRX       = PA_10,
+    SPI_MOSI    = PA_7,
+    SPI_MISO    = PA_6,
+    SPI_SCK     = PA_5,
+    SPI_CS      = PB_6,
+
     // Not connected
     NC = (int)0xFFFFFFFF
 } PinName;


### PR DESCRIPTION
The basic SPI pins definition was missing so far - this makes SPI default usage easier