### PR TITLE
[Tools] Add environmental variables support for toolchain paths

### DIFF
--- a/tools/default_settings.py
+++ b/tools/default_settings.py
@@ -1,10 +1,13 @@
 """
 mbed SDK
-Copyright (c) 2011-2013 ARM Limited
+Copyright (c) 2016 ARM Limited
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -13,55 +16,30 @@ limitations under the License.
 """
 
 from os.path import join, abspath, dirname
-import logging
 
-ROOT = abspath(join(dirname(__file__), ".."))
-
-# These default settings have two purposes:
-#    1) Give a template for writing local "private_settings.py"
-#    2) Give default initialization fields for the "toolchains.py" constructors
+#ROOT = abspath(join(dirname(__file__), "."))
 
 ##############################################################################
 # Build System Settings
 ##############################################################################
-BUILD_DIR = abspath(join(ROOT, "build"))
+#BUILD_DIR = abspath(join(ROOT, "build"))
 
 # ARM
-ARM_PATH = "C:/Program Files/ARM"
-ARM_BIN = join(ARM_PATH, "bin")
-ARM_INC = join(ARM_PATH, "include")
-ARM_LIB = join(ARM_PATH, "lib")
-
-ARM_CPPLIB = join(ARM_LIB, "cpplib")
-MY_ARM_CLIB = join(ARM_PATH, "lib", "microlib")
+#ARM_PATH = "C:/Program Files/ARM"
 
 # GCC ARM
-GCC_ARM_PATH = ""
+#GCC_ARM_PATH = ""
 
 # GCC CodeRed
-GCC_CR_PATH = "C:/code_red/RedSuite_4.2.0_349/redsuite/Tools/bin"
+#GCC_CR_PATH = "C:/code_red/RedSuite_4.2.0_349/redsuite/Tools/bin"
 
 # IAR
-IAR_PATH = "C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0/arm"
+#IAR_PATH = "C:/Program Files (x86)/IAR Systems/Embedded Workbench 7.0/arm"
 
 # Goanna static analyser. Please overload it in private_settings.py
-GOANNA_PATH = "c:/Program Files (x86)/RedLizards/Goanna Central 3.2.3/bin"
+#GOANNA_PATH = "c:/Program Files (x86)/RedLizards/Goanna Central 3.2.3/bin"
 
-# cppcheck path (command) and output message format
-CPPCHECK_CMD = ["cppcheck", "--enable=all"]
-CPPCHECK_MSG_FORMAT = ["--template=[{severity}] {file}@{line}: {id}:{message}"]
-
-BUILD_OPTIONS = []
+#BUILD_OPTIONS = []
 
 # mbed.org username
-MBED_ORG_USER = ""
-
-##############################################################################
-# Private Settings
-##############################################################################
-try:
-    # Allow to overwrite the default settings without the need to edit the
-    # settings file stored in the repository
-    from mbed_settings import *
-except ImportError:
-    print '[WARNING] Using default settings. Define your settings in the file "./mbed_settings.py"'
+#MBED_ORG_USER = ""

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -1,10 +1,13 @@
 """
 mbed SDK
-Copyright (c) 2011-2013 ARM Limited
+Copyright (c) 2016 ARM Limited
+
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
 You may obtain a copy of the License at
-    http://www.apache.org/licenses/LICENSE-2.0
+
+http://www.apache.org/licenses/LICENSE-2.0
+
 Unless required by applicable law or agreed to in writing, software
 distributed under the License is distributed on an "AS IS" BASIS,
 WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -12,43 +15,20 @@ See the License for the specific language governing permissions and
 limitations under the License.
 """
 
-from os.path import join, abspath, dirname
+from os import getenv
+from os.path import join, abspath, dirname, exists
 import logging
 
 ROOT = abspath(join(dirname(__file__), ".."))
 
-# These default settings have two purposes:
-#    1) Give a template for writing local "mbed_settings.py"
-#    2) Give default initialization fields for the "toolchains.py" constructors
 
 ##############################################################################
-# Build System Settings
+# Toolchains and Build System Settings
 ##############################################################################
 BUILD_DIR = abspath(join(ROOT, ".build"))
 
-# ARM
-armcc = "standalone" # "keil", or "standalone", or "ds-5"
-
-if armcc == "keil":
-    ARM_PATH = "C:/Keil_v5/ARM/ARMCC"
-    ARM_BIN = join(ARM_PATH, "bin")
-    ARM_INC = join(ARM_PATH, "incldue")
-    ARM_LIB = join(ARM_PATH, "lib")
-
-elif armcc == "standalone":
-    ARM_PATH = "C:/Program Files (x86)/ARM_Compiler_5.06u1"
-    ARM_BIN = join(ARM_PATH, "bin")
-    ARM_INC = join(ARM_PATH, "include")
-    ARM_LIB = join(ARM_PATH, "lib")
-
-elif armcc == "ds-5":
-    ARM_PATH = "C:/Program Files (x86)/DS-5"
-    ARM_BIN = join(ARM_PATH, "bin")
-    ARM_INC = join(ARM_PATH, "include")
-    ARM_LIB = join(ARM_PATH, "lib")
-
-ARM_CPPLIB = join(ARM_LIB, "cpplib")
-MY_ARM_CLIB = join(ARM_PATH, "lib", "microlib")
+# ARM Compiler 5
+ARM_PATH = "C:/Keil_v5/ARM/ARMCC"
 
 # GCC ARM
 GCC_ARM_PATH = ""
@@ -71,6 +51,42 @@ BUILD_OPTIONS = []
 # mbed.org username
 MBED_ORG_USER = ""
 
+
+##############################################################################
+# User Settings (file)
+##############################################################################
+try:
+    # Allow to overwrite the default settings without the need to edit the
+    # settings file stored in the repository
+    from mbed_settings import *
+except ImportError:
+    pass
+
+
+##############################################################################
+# User Settings (env vars)
+##############################################################################
+_ENV_PATHS = ['ARM_PATH', 'GCC_ARM_PATH', 'GCC_CR_PATH', 'IAR_PATH']
+
+for _n in _ENV_PATHS:
+    if getenv(_n):
+        if exists(getenv(_n)):
+            globals()[_n] = getenv(_n)
+        else:
+            print "WARNING: %s set as environment variable but doesn't exist" % _n
+
+
+##############################################################################
+# ARM Compiler Paths
+##############################################################################
+
+ARM_BIN = join(ARM_PATH, "bin")
+ARM_INC = join(ARM_PATH, "include")
+ARM_LIB = join(ARM_PATH, "lib")
+ARM_CPPLIB = join(ARM_LIB, "cpplib")
+MY_ARM_CLIB = join(ARM_LIB, "lib", "microlib")
+
+
 ##############################################################################
 # Test System Settings
 ##############################################################################
@@ -92,13 +108,3 @@ MUTs = {
         "peripherals":  ["TMP102", "digital_loop", "port_loop", "analog_loop", "SD"]
     },
 }
-
-##############################################################################
-# Private Settings
-##############################################################################
-try:
-    # Allow to overwrite the default settings without the need to edit the
-    # settings file stored in the repository
-    from mbed_settings import *
-except ImportError:
-    print '[WARNING] Using default settings. Define your settings in the file "./mbed_settings.py"'

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -285,7 +285,10 @@ class mbedToolchain:
 
         # Build options passed by -o flag
         self.options = options if options is not None else []
+
+        # Build options passed by settings.py or mbed_settings.py
         self.options.extend(BUILD_OPTIONS)
+
         if self.options:
             self.info("Build Options: %s" % (', '.join(self.options)))
         


### PR DESCRIPTION
This PR adds the ability to set/override ARM_PATH, GCC_ARM_PATH, IAR_PATH and GCC_CR_PATH build system variables through environmental variables. If the env variable points to invalid path then it's ignored.

For backwards compatibility mbed_settings.py is still respected, but environmental variables have higher prio.

Note that the latest mbed CLI supports global config setting for these variables.

Also updated license of settings.py and default_settings.py and added comments