### PR TITLE
If a target is restricted to single threaded mode,

### DIFF
--- a/libraries/tests/rtos/cmsis/basic/main.cpp
+++ b/libraries/tests/rtos/cmsis/basic/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut led1(LED1);
 DigitalOut led2(LED2);
 

--- a/libraries/tests/rtos/cmsis/isr/main.cpp
+++ b/libraries/tests/rtos/cmsis/isr/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 Queue<uint32_t, 5> queue;
 
 DigitalOut myled(LED1);

--- a/libraries/tests/rtos/cmsis/mail/main.cpp
+++ b/libraries/tests/rtos/cmsis/mail/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 typedef struct {
   float    voltage; /* AD result of measured voltage */
   float    current; /* AD result of measured current */

--- a/libraries/tests/rtos/cmsis/mutex/main.cpp
+++ b/libraries/tests/rtos/cmsis/mutex/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 osMutexId stdio_mutex;
 osMutexDef(stdio_mutex);
 

--- a/libraries/tests/rtos/cmsis/queue/main.cpp
+++ b/libraries/tests/rtos/cmsis/queue/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 typedef struct {
     float    voltage;   /* AD result of measured voltage */
     float    current;   /* AD result of measured current */

--- a/libraries/tests/rtos/cmsis/semaphore/main.cpp
+++ b/libraries/tests/rtos/cmsis/semaphore/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 osSemaphoreId two_slots;
 osSemaphoreDef(two_slots);
 

--- a/libraries/tests/rtos/cmsis/signals/main.cpp
+++ b/libraries/tests/rtos/cmsis/signals/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut led(LED1);
 
 void led_thread(void const *argument) {

--- a/libraries/tests/rtos/cmsis/timer/main.cpp
+++ b/libraries/tests/rtos/cmsis/timer/main.cpp
@@ -1,6 +1,10 @@
 #include "mbed.h"
 #include "cmsis_os.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut LEDs[4] = {
     DigitalOut(LED1), DigitalOut(LED2), DigitalOut(LED3), DigitalOut(LED4)
 };

--- a/libraries/tests/rtos/mbed/basic/main.cpp
+++ b/libraries/tests/rtos/mbed/basic/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 /*
  * The stack size is defined in cmsis_os.h mainly dependent on the underlying toolchain and
  * the C standard library. For GCC, ARM_STD and IAR it is defined with a size of 2048 bytes

--- a/libraries/tests/rtos/mbed/file/main.cpp
+++ b/libraries/tests/rtos/mbed/file/main.cpp
@@ -3,6 +3,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut led2(LED2);
 
 #define SIZE 100

--- a/libraries/tests/rtos/mbed/isr/main.cpp
+++ b/libraries/tests/rtos/mbed/isr/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define QUEUE_SIZE              5
 #define THREAD_DELAY            250
 #define QUEUE_PUT_ISR_VALUE     128

--- a/libraries/tests/rtos/mbed/mail/main.cpp
+++ b/libraries/tests/rtos/mbed/mail/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 typedef struct {
     float    voltage;   /* AD result of measured voltage */
     float    current;   /* AD result of measured current */

--- a/libraries/tests/rtos/mbed/mutex/main.cpp
+++ b/libraries/tests/rtos/mbed/mutex/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define THREAD_DELAY     50
 #define SIGNALS_TO_EMIT  100
 

--- a/libraries/tests/rtos/mbed/queue/main.cpp
+++ b/libraries/tests/rtos/mbed/queue/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 typedef struct {
     float    voltage;   /* AD result of measured voltage */
     float    current;   /* AD result of measured current */

--- a/libraries/tests/rtos/mbed/semaphore/main.cpp
+++ b/libraries/tests/rtos/mbed/semaphore/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define THREAD_DELAY     75
 #define SEMAPHORE_SLOTS  2
 #define SEM_CHANGES      100

--- a/libraries/tests/rtos/mbed/signals/main.cpp
+++ b/libraries/tests/rtos/mbed/signals/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 #define SIGNALS_TO_EMIT     100
 #define SIGNAL_HANDLE_DELEY 25
 #define SIGNAL_SET_VALUE    0x01

--- a/libraries/tests/rtos/mbed/timer/main.cpp
+++ b/libraries/tests/rtos/mbed/timer/main.cpp
@@ -2,6 +2,10 @@
 #include "test_env.h"
 #include "rtos.h"
 
+#if defined(MBED_RTOS_SINGLE_THREAD)
+  #error [NOT_SUPPORTED] test not supported
+#endif
+
 DigitalOut LEDs[4] = {
     DigitalOut(LED1), DigitalOut(LED2), DigitalOut(LED3), DigitalOut(LED4)
 };


### PR DESCRIPTION
fail compilation of the test as not supported