### PR TITLE
Change stack size of main thread for RZ_A1H

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -72,7 +72,7 @@
 
 //   <o>Main Thread stack size [bytes] <64-4096:8><#/4>
 //   <i> Defines stack size for main thread.
-//   <i> Default: 200
+//   <i> Default: 4096
 #ifndef OS_MAINSTKSIZE
  #define OS_MAINSTKSIZE 4096
 #endif

--- a/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_Conf_CA.c
@@ -74,7 +74,7 @@
 //   <i> Defines stack size for main thread.
 //   <i> Default: 200
 #ifndef OS_MAINSTKSIZE
- #define OS_MAINSTKSIZE 2048
+ #define OS_MAINSTKSIZE 4096
 #endif
 
 #ifndef __MBED_CMSIS_RTOS_CA9


### PR DESCRIPTION
Hi

We changed the stack size of main thread for RZ_A1H.
We changed "OS_MAINSTKSIZE" from 2048 to 4096.
Because stack shortage was found in the automatic test by the CI System of mbed OS.

Regards,
Yamanaka