### PR TITLE
Fixed config-related options for the IAR assembler

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -217,8 +217,8 @@ def build_project(src_path, build_path, target, toolchain_name,
         # Load resources into the config system which might expand/modify resources based on config data
         resources = config.load_resources(resources)
 
-        # Set the toolchain's config header with the config data
-        toolchain.set_config_header_content(config.get_config_data_header())
+        # Set the toolchain's configuration data
+        toolchain.set_config_data(config.get_config_data())
 
         # Compile Sources
         objects = toolchain.compile_sources(resources, build_path, resources.inc_dirs)
@@ -361,8 +361,8 @@ def build_library(src_paths, build_path, target, toolchain_name,
         # Load resources into the config system which might expand/modify resources based on config data
         resources = config.load_resources(resources)
 
-        # Set the toolchain's config header with the config data
-        toolchain.set_config_header_content(config.get_config_data_header())
+        # Set the toolchain's configuration data
+        toolchain.set_config_data(config.get_config_data())
 
         # Copy headers, objects and static libraries - all files needed for static lib
         toolchain.copy_files(resources.headers, build_path, resources=resources)


### PR DESCRIPTION
The IAR assembler doesn't accept '--preinclude', but it accepts -D.
This commit changes the way the config-related macros are propagated
to the IAR assembler to use '-D' instead of '--preinclude'. This is
the only change related to functionality, the others are small,
backward compatible changes to the config code to make passing arguments
to the toolchain instances easier.

Tested by compiled blinky with IAR, GCC_ARM and ARM for K64F.