### PR TITLE
Use nano lib by default for nrf51 based targets.

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1092,7 +1092,8 @@
             "function": "MCU_NRF51Code.binary_hook",
             "toolchains": ["ARM_STD", "GCC_ARM"]
         },
-        "program_cycle_s": 6
+        "program_cycle_s": 6,
+        "default_build": "small"
     },
     "MCU_NRF51_16K_BASE": {
         "inherits": ["MCU_NRF51"],


### PR DESCRIPTION
By default, `default_build` is set to `standard` for all targets.
 
`NRF51` is very a very constrained platform, it makes a lot of sense to set `default_build` to `small` for all `NRF51` based targets. 
