### PR TITLE
Fix paths for project.py

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -101,7 +101,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
             if supported:
                 # target checked, export
                 try:
-                    exporter = Exporter(target, tempdir, project_name, build_url_resolver, extra_symbols=extra_symbols)
+                    exporter = Exporter(target, tempdir, project_name, build_url_resolver, extra_symbols=extra_symbols, sources_relative=relative)
                     exporter.scan_and_copy_resources(project_path, tempdir, relative)
                     exporter.generate()
                     report['success'] = True

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -58,7 +58,7 @@ def online_build_url_resolver(url):
 
 
 def export(project_path, project_name, ide, target, destination='/tmp/',
-           tempdir=None, clean=True, extra_symbols=None, zip=True, relative=False, build_url_resolver=online_build_url_resolver):
+           tempdir=None, clean=True, extra_symbols=None, zip=True, sources_relative=False, build_url_resolver=online_build_url_resolver):
     # Convention: we are using capitals for toolchain and target names
     if target is not None:
         target = target.upper()
@@ -75,7 +75,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
         try:
             ide = "zip"
             exporter = zip.ZIP(target, tempdir, project_name, build_url_resolver, extra_symbols=extra_symbols)
-            exporter.scan_and_copy_resources(project_path, tempdir, relative)
+            exporter.scan_and_copy_resources(project_path, tempdir, sources_relative)
             exporter.generate()
             report['success'] = True
         except OldLibrariesException, e:
@@ -101,8 +101,8 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
             if supported:
                 # target checked, export
                 try:
-                    exporter = Exporter(target, tempdir, project_name, build_url_resolver, extra_symbols=extra_symbols, sources_relative=relative)
-                    exporter.scan_and_copy_resources(project_path, tempdir, relative)
+                    exporter = Exporter(target, tempdir, project_name, build_url_resolver, extra_symbols=extra_symbols, sources_relative=sources_relative)
+                    exporter.scan_and_copy_resources(project_path, tempdir, sources_relative)
                     exporter.generate()
                     report['success'] = True
                 except OldLibrariesException, e:

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -25,7 +25,7 @@ class Exporter(object):
     TEMPLATE_DIR = dirname(__file__)
     DOT_IN_RELATIVE_PATH = False
 
-    def __init__(self, target, inputDir, program_name, build_url_resolver, extra_symbols=None):
+    def __init__(self, target, inputDir, program_name, build_url_resolver, extra_symbols=None, sources_relative=True):
         self.inputDir = inputDir
         self.target = target
         self.program_name = program_name
@@ -35,6 +35,7 @@ class Exporter(object):
         self.jinja_environment = Environment(loader=jinja_loader)
         self.extra_symbols = extra_symbols
         self.config_macros = []
+        self.sources_relative = sources_relative
 
     def get_toolchain(self):
         return self.TOOLCHAIN
@@ -109,7 +110,7 @@ class Exporter(object):
         # TODO: Fix this, the inc_dirs are not valid (our scripts copy files), therefore progen
         # thinks it is not dict but a file, and adds them to workspace.
         project.project['common']['include_paths'] = self.resources.inc_dirs
-        project.generate(tool_name, copied=True)
+        project.generate(tool_name, copied=not self.sources_relative)
 
     def __scan_all(self, path):
         resources = []

--- a/tools/project.py
+++ b/tools/project.py
@@ -210,7 +210,7 @@ if __name__ == '__main__':
             setup_user_prj(project_dir[0], test.source_dir, test.dependencies)
 
         # Export to selected toolchain
-        tmp_path, report = export(project_dir, project_name, ide, mcu, project_dir[0], project_temp, clean=clean, zip=zip, extra_symbols=lib_symbols, relative=sources_relative)
+        tmp_path, report = export(project_dir, project_name, ide, mcu, project_dir[0], project_temp, clean=clean, zip=zip, extra_symbols=lib_symbols, sources_relative=sources_relative)
         if report['success']:
             if not zip:
                 zip_path = join(project_temp, "%s_%s" % (project_name, mcu))


### PR DESCRIPTION
tested with export using mbed (the change, introducing a flag to indicate if we use relative paths or not) and project.py (no regression there as copied flag for progen stays as it was). The fix is the first commit . 

The second commit is a cosmetic change , that actually can be breaking for callers of ``export`` as I renamed the default argument from ``relative`` to ``sources_relative``, as it is more clear what's the intention. I can revert it , just proposing an unification of this flag in the 2 files.

Tested with uvision and IAR (checked the paths are correct ). Using master of project generator (v0.9x should work as there are no changes required for this patch in the progen).

@bogdanm @theotherjimmy 

