### PR TITLE
Fix #2027 Add timeinfo.tm_isdst = -1 to pass MBED_16 test with IAR.

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/rtc_api.c
@@ -163,6 +163,8 @@ time_t rtc_read(void)
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
+    // Daylight Saving Time information is not available
+    timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp
     time_t t = mktime(&timeinfo);

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
@@ -182,6 +182,8 @@ time_t rtc_read(void)
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
+    // Daylight Saving Time information is not available
+    timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp
     time_t t = mktime(&timeinfo);

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
@@ -182,6 +182,7 @@ time_t rtc_read(void)
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
+    // Daylight Saving Time information is not available
     timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
@@ -182,6 +182,7 @@ time_t rtc_read(void)
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
+    timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp
     time_t t = mktime(&timeinfo);

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/rtc_api.c
@@ -182,6 +182,7 @@ time_t rtc_read(void)
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
+    // Daylight Saving Time information is not available
     timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/rtc_api.c
@@ -182,6 +182,7 @@ time_t rtc_read(void)
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
+    timeinfo.tm_isdst  = -1;
 
     // Convert to timestamp
     time_t t = mktime(&timeinfo);


### PR DESCRIPTION
```
Test summary:
+--------+---------------------+-----------+---------+------------------+--------------------+---------------+-------+
| Result | Target              | Toolchain | Test ID | Test Description | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+---------------------+-----------+---------+------------------+--------------------+---------------+-------+
| OK     | NUCLEO_F410RB[F63D] | uARM      | MBED_16 | RTC              |        5.43        |       20      |  1/1  |
| OK     | NUCLEO_F410RB[F63D] | IAR       | MBED_16 | RTC              |        5.41        |       20      |  0/1  |
| OK     | NUCLEO_F410RB[F63D] | ARM       | MBED_16 | RTC              |       22.07        |       20      |  1/1  |
| OK     | NUCLEO_F410RB[F63D] | GCC_ARM   | MBED_16 | RTC              |        5.51        |       20      |  1/1  |
+--------+---------------------+-----------+---------+------------------+--------------------+---------------+-------+
Result: 4 OK
```