### PR TITLE
[Tools] Force program_cycle_s to be used as an attribue everywhere

### DIFF
--- a/tools/make.py
+++ b/tools/make.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
                 # Import pyserial: https://pypi.python.org/pypi/pyserial
                 from serial import Serial
 
-                sleep(TARGET_MAP[mcu].program_cycle_s())
+                sleep(TARGET_MAP[mcu].program_cycle_s)
 
                 serial = Serial(options.serial, timeout = 1)
                 if options.baud:

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -215,6 +215,7 @@ class Target:
         # Create also a list with only the names of the targets in the resolution order
         self.resolution_order_names = [t[0] for t in self.resolution_order]
 
+    @property
     def program_cycle_s(self):
         try:
             return self.__getattr__("program_cycle_s")

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -898,7 +898,7 @@ class SingleTestRunner(object):
                                                       reset=host_test_reset,
                                                       reset_tout=reset_tout,
                                                       copy_method=selected_copy_method,
-                                                      program_cycle_s=target_by_mcu.program_cycle_s())
+                                                      program_cycle_s=target_by_mcu.program_cycle_s)
                 single_test_result, single_test_output, single_testduration, single_timeout = host_test_result
 
             # Store test result
@@ -2083,4 +2083,3 @@ def test_spec_from_test_builds(test_builds):
     return {
         "builds": test_builds
     }
-    


### PR DESCRIPTION
Aligns program_cycle_s with the changes to the target configs