### PR TITLE
[Exporters] Conflicting zip name

### DIFF
--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -58,7 +58,7 @@ def online_build_url_resolver(url):
 
 
 def export(project_path, project_name, ide, target, destination='/tmp/',
-           tempdir=None, clean=True, extra_symbols=None, zip=True, sources_relative=False, build_url_resolver=online_build_url_resolver):
+           tempdir=None, clean=True, extra_symbols=None, make_zip=True, sources_relative=False, build_url_resolver=online_build_url_resolver):
     # Convention: we are using capitals for toolchain and target names
     if target is not None:
         target = target.upper()
@@ -136,7 +136,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
         # copy .hgignore file to exported direcotry as well.
         if exists(os.path.join(exporter.TEMPLATE_DIR,'.hgignore')):
             copy(os.path.join(exporter.TEMPLATE_DIR,'.hgignore'), tempdir)
-        if zip:
+        if make_zip:
             zip_path = zip_working_directory_and_clean_up(tempdir, destination, project_name, clean)
         else:
             zip_path = destination


### PR DESCRIPTION
The boolean zip passed as a parameter conflicts with the zip exporter class imported.