### PR TITLE
uvision4/5 - remove no-vla for exporters

### DIFF
--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -80,6 +80,8 @@ class Uvision4(Exporter):
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         # cpp is not required as it's implicit for cpp files
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--cpp")
+        # we want no-vla for only cxx, but it's also applied for C in IDE, thus we remove it
+        project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--no_vla")
         project_data['tool_specific']['uvision']['misc']['ld_flags'] = self.progen_flags['ld_flags']
 
         i = 0

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -80,6 +80,8 @@ class Uvision5(Exporter):
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
         # cpp is not required as it's implicit for cpp files
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--cpp")
+        # we want no-vla for only cxx, but it's also applied for C in IDE, thus we remove it
+        project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--no_vla")
         project_data['tool_specific']['uvision5']['misc']['ld_flags'] = self.progen_flags['ld_flags']
 
         i = 0


### PR DESCRIPTION
IDE has C/C++ tab, thus this only cxx flag would be applied for
C files.

This fixes errors I have seen in the C files ,as no-vla is applied for C files as well in the IDE projects.

@bogdanm @kjbracey-arm 