### PR TITLE
armcc - remove libpath from ld flags

### DIFF
--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -224,9 +224,6 @@ class ARM_STD(ARM):
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
         ARM.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
 
-        # Extend flags
-        self.flags['ld'].extend(["--libpath \"%s\"" % ARM_LIB])
-        
         # Run-time values
         self.ld.extend(["--libpath \"%s\"" % ARM_LIB])
 
@@ -269,7 +266,5 @@ class ARM_MICRO(ARM):
             elif target.core in ["Cortex-M0", "Cortex-M0+"]:
                 self.sys_libs.extend([join(ARM_CPPLIB, lib+".l") for lib in ["cpp_ps", "cpprt_p"]])
         else:
-            # Run-time values
-            self.flags['ld'].extend(["--libpath \"%s\"" % ARM_LIB])
             # Run-time values
             self.ld.extend(["--libpath \"%s\"" % ARM_LIB])


### PR DESCRIPTION
libpath is not required for exporters, as they provide default paths.
This caused problems when paths are not correct for mbed tools, a project
fails to build as path is not found.

@mlnx @adbridge @bogdanm @sg- 