### PR TITLE
iar - remove --vla flag for exporters

### DIFF
--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -72,6 +72,8 @@ class IAREmbeddedWorkbench(Exporter):
         project_data['tool_specific']['iar'].setdefault("misc", {})
         project_data['tool_specific']['iar'].update(tool_specific['iar'])
         project_data['tool_specific']['iar']['misc'].update(self.progen_flags)
+        # VLA is enabled via template IccAllowVLA
+        project_data['tool_specific']['iar']['misc']['c_flags'].remove("--vla")
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
         self.progen_gen_file('iar_arm', project_data)
 


### PR DESCRIPTION
The template file already enables VLA as it's for C only. This --vla flag
causes conflicts with --cpp flag that is enabled implicitly if C++ is enabled.

IAR template before this patch:
```
          <state></state>
          <state>--guard_calls</state>
          <state>--preinclude=mbed_config.h</state>
          <state>--vla</state>
          <state>--preinclude=mbed_config.h</state>
          <name>IExtraOptions</name>
```

This causes problems because C++ is enabled, thus --vla causes errors when compiling.

IAR template after this patch:
```
          <state></state>
          <state>--guard_calls</state>
          <state>--preinclude=mbed_config.h</state>
          <state>--preinclude=mbed_config.h</state>
          <name>IExtraOptions</name>
```

@theotherjimmy Seems that preinclude is 2x there

@sg- @bogdanm 