### PR TITLE
K22 K27 updates

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -521,7 +521,7 @@
         "default_toolchain": "ARM",
         "detect_code": ["0261"],
         "progen_target": {"target": "frdm-kl27z"},
-        "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "standard"
     },
     "K64F": {

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/cmsis_nvic.c
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/cmsis_nvic.c
@@ -32,11 +32,11 @@
 
 extern void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler);
 
-void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
+void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     InstallIRQHandler(IRQn, vector);
 }
 
-uint32_t NVIC_GetVector(IRQn_Type IRQn) {
+uint32_t __NVIC_GetVector(IRQn_Type IRQn) {
     uint32_t *vectors = (uint32_t*)SCB->VTOR;
     return vectors[IRQn + 16];
 }

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/cmsis_nvic.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/cmsis_nvic.h
@@ -41,8 +41,8 @@
 extern "C" {
 #endif
 
-void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
-uint32_t NVIC_GetVector(IRQn_Type IRQn);
+void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t __NVIC_GetVector(IRQn_Type IRQn);
 
 #ifdef __cplusplus
 }

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/cmsis_nvic.c
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/cmsis_nvic.c
@@ -32,11 +32,11 @@
 
 extern void InstallIRQHandler(IRQn_Type irq, uint32_t irqHandler);
 
-void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
+void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector) {
     InstallIRQHandler(IRQn, vector);
 }
 
-uint32_t NVIC_GetVector(IRQn_Type IRQn) {
+uint32_t __NVIC_GetVector(IRQn_Type IRQn) {
     uint32_t *vectors = (uint32_t*)SCB->VTOR;
     return vectors[IRQn + 16];
 }

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/cmsis_nvic.h
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/cmsis_nvic.h
@@ -41,8 +41,8 @@
 extern "C" {
 #endif
 
-void NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
-uint32_t NVIC_GetVector(IRQn_Type IRQn);
+void __NVIC_SetVector(IRQn_Type IRQn, uint32_t vector);
+uint32_t __NVIC_GetVector(IRQn_Type IRQn);
 
 #ifdef __cplusplus
 }

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/pwmout_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_KL27Z/pwmout_api.c
@@ -34,6 +34,9 @@ void pwmout_init(pwmout_t* obj, PinName pin) {
     obj->pwm_name = pwm;
 
     uint32_t pwm_base_clock;
+
+    /* Set the TPM clock source to be IRC 48M */
+    CLOCK_SetTpmClock(1U);
     pwm_base_clock = CLOCK_GetFreq(kCLOCK_McgIrc48MClk);
     float clkval = (float)pwm_base_clock / 1000000.0f;
     uint32_t clkdiv = 0;


### PR DESCRIPTION
1. Update Interrupt function names
2. Fix an issue in the KL27 PWMOUT driver.