### PR TITLE
Add support for static mutexes

### DIFF
--- a/hal/api/AnalogIn.h
+++ b/hal/api/AnalogIn.h
@@ -118,7 +118,7 @@ protected:
     }
 
     analogin_t _adc;
-    static PlatformMutex _mutex;
+    static PlatformMutexStatic _mutex;
 };
 
 } // namespace mbed

--- a/hal/api/FileBase.h
+++ b/hal/api/FileBase.h
@@ -65,7 +65,7 @@ public:
     /* disallow copy constructor and assignment operators */
 private:
     static FileBase *_head;
-    static PlatformMutex _mutex;
+    static PlatformMutexStatic _mutex;
 
     FileBase   *_next;
     const char * const _name;

--- a/hal/api/I2C.h
+++ b/hal/api/I2C.h
@@ -181,7 +181,7 @@ protected:
     i2c_t _i2c;
     static I2C  *_owner;
     int         _hz;
-    static PlatformMutex _mutex;
+    static PlatformMutexStatic _mutex;
 };
 
 } // namespace mbed

--- a/hal/common/AnalogIn.cpp
+++ b/hal/common/AnalogIn.cpp
@@ -22,7 +22,7 @@
 
 namespace mbed {
 
-PlatformMutex AnalogIn::_mutex;
+PlatformMutexStatic AnalogIn::_mutex;
 
 };
 

--- a/hal/common/FileBase.cpp
+++ b/hal/common/FileBase.cpp
@@ -18,7 +18,7 @@
 namespace mbed {
 
 FileBase *FileBase::_head = NULL;
-PlatformMutex FileBase::_mutex;
+PlatformMutexStatic FileBase::_mutex;
 
 FileBase::FileBase(const char *name, PathType t) : _next(NULL),
                                                    _name(name),

--- a/hal/common/I2C.cpp
+++ b/hal/common/I2C.cpp
@@ -20,7 +20,7 @@
 namespace mbed {
 
 I2C *I2C::_owner = NULL;
-PlatformMutex I2C::_mutex;
+PlatformMutexStatic I2C::_mutex;
 
 I2C::I2C(PinName sda, PinName scl) :
 #if DEVICE_I2C_ASYNCH

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -72,7 +72,7 @@ extern const char __stderr_name[] = "/stderr";
  * (or rather index+3, as filehandles 0-2 are stdin/out/err).
  */
 static FileHandle *filehandles[OPEN_MAX];
-static PlatformMutex filehandle_mutex;
+static PlatformMutexStatic filehandle_mutex;
 
 FileHandle::~FileHandle() {
     filehandle_mutex.lock();


### PR DESCRIPTION
Add PlatformMutexStatic which is lazily initialized in static context
which allows it to be garbage collected.  The lazy initialization also
allows it to be used earlier than normal mutexes.