### PR TITLE
RTOS: Only set the SVC priority if uVisor is not present

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
@@ -255,7 +255,11 @@ __inline static void rt_svc_init (void) {
   if (prigroup >= sh) {
     sh = prigroup + 1U;
   }
+
+/* Only change the SVCall priority if uVisor is not present. */
+#if !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED))
   NVIC_SYS_PRI2 = ((0xFEFFFFFFU << sh) & 0xFF000000U) | (NVIC_SYS_PRI2 & 0x00FFFFFFU);
+#endif /* !(defined(FEATURE_UVISOR) && defined(TARGET_UVISOR_SUPPORTED)) */
 #endif
 }
 


### PR DESCRIPTION
uVisor requires the SVCall to have priority 0, while RTX allows it to be
the second lowest priority level in the system (after PendSV).

This commit makes sure that the SVCall priority is not changed if uVisor
is present. The PendSV priority is not affected.

@meriac @Patater 