### PR TITLE
Enable passing individual files to --source options

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -440,12 +440,12 @@ class mbedToolchain:
         resources.base_path = base_path
 
         if isfile(path):
-            self.add_file(path, resources, base_path, exclude_paths=exclude_paths)
+            self._add_file(path, resources, base_path, exclude_paths=exclude_paths)
         else:
-            self.add_dir(path, resources, base_path, exclude_paths=exclude_paths)
+            self._add_dir(path, resources, base_path, exclude_paths=exclude_paths)
         return resources
 
-    def add_dir(self, path, resources, base_path, exclude_paths=None):
+    def _add_dir(self, path, resources, base_path, exclude_paths=None):
         """ os.walk(top[, topdown=True[, onerror=None[, followlinks=False]]])
         When topdown is True, the caller can modify the dirnames list in-place
         (perhaps using del or slice assignment), and walk() will only recurse into
@@ -506,9 +506,9 @@ class mbedToolchain:
 
             for file in files:
                 file_path = join(root, file)
-                self.add_file(file_path, resources, base_path)
+                self._add_file(file_path, resources, base_path)
 
-    def add_file(self, file_path, resources, base_path, exclude_paths=None):
+    def _add_file(self, file_path, resources, base_path, exclude_paths=None):
         resources.file_basepath[file_path] = base_path
 
         if self.is_ignored(file_path):

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -430,6 +430,12 @@ class mbedToolchain:
                 return True
         return False
 
+    # Create a Resources object from the path pointed to by *path* by either traversing a
+    # a directory structure, when *path* is a directory, or adding *path* to the resources,
+    # when *path* is a file.
+    # The parameter *base_path* is used to set the base_path attribute of the Resources
+    # object and the parameter *exclude_paths* is used by the directory traversal to
+    # exclude certain paths from the traversal.
     def scan_resources(self, path, exclude_paths=None, base_path=None):
         resources = Resources(path)
         if not base_path:
@@ -445,6 +451,9 @@ class mbedToolchain:
             self._add_dir(path, resources, base_path, exclude_paths=exclude_paths)
         return resources
 
+    # A helper function for scan_resources. _add_dir traverses *path* (assumed to be a
+    # directory) and heeds the ".mbedignore" files along the way. _add_dir calls _add_file
+    # on every file it considers adding to the resources object.
     def _add_dir(self, path, resources, base_path, exclude_paths=None):
         """ os.walk(top[, topdown=True[, onerror=None[, followlinks=False]]])
         When topdown is True, the caller can modify the dirnames list in-place
@@ -508,6 +517,8 @@ class mbedToolchain:
                 file_path = join(root, file)
                 self._add_file(file_path, resources, base_path)
 
+    # A helper function for both scan_resources and _add_dir. _add_file adds one file
+    # (*file_path*) to the resources object based on the file type.
     def _add_file(self, file_path, resources, base_path, exclude_paths=None):
         resources.file_basepath[file_path] = base_path
 


### PR DESCRIPTION
Should resolve #2011

This works:
```
$  python tools/make.py -t GCC_ARM -m K64F --source libraries/tests/mbed/blinky/main.cpp --source . --build .build
Building project main.cpp (K64F, GCC_ARM)
Compile: CAN.cpp
<snip>
Link: main.cpp
Elf2Bin: main.cpp
+-----------+-------+-------+------+
| Module    | .text | .data | .bss |
+-----------+-------+-------+------+
| Fill      |   121 |     4 | 2170 |
| Misc      | 47645 |  2252 | 3290 |
| Subtotals | 47766 |  2256 | 5460 |
+-----------+-------+-------+------+
Allocated Heap: 65540 bytes
Allocated Stack: 32768 bytes
Total Static RAM memory (data + bss): 7716 bytes
Total RAM memory (data + bss + heap + stack): 106024 bytes
Total Flash memory (text + data + misc): 51062 bytes
Image: .build/main.cpp.bin
```

and the led blinks.
also:
```
$  mbed compile -t GCC_ARM -m K64F --source core/libraries/tests/mbed/blinky/main.cpp --source . 
Building project main.cpp (K64F, GCC_ARM)
Compile: CAN.cpp
<snip>
Link: main.cpp
Elf2Bin: main.cpp
+-----------+-------+-------+------+
| Module    | .text | .data | .bss |
+-----------+-------+-------+------+
| Fill      |   166 |     0 | 2290 |
| Misc      | 62560 |  2288 | 6210 |
| Subtotals | 62726 |  2288 | 8500 |
+-----------+-------+-------+------+
Allocated Heap: 65540 bytes
Allocated Stack: 32768 bytes
Total Static RAM memory (data + bss): 10788 bytes
Total RAM memory (data + bss + heap + stack): 109096 bytes
Total Flash memory (text + data + misc): 66054 bytes
Image: ./.build/K64F/GCC_ARM/main.cpp.bin
```