### PR TITLE
Changing name of test binaries to just test case folder name.

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2033,13 +2033,17 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         test_build_path = os.path.join(build_path, test_path)
         src_path = base_source_paths + [test_path]
         bin_file = None
+        test_case_folder_name = os.path.basename(test_path)
+        
+        
         try:
             bin_file = build_project(src_path, test_build_path, target, toolchain_name,
                                      options=options,
                                      jobs=jobs,
                                      clean=clean,
                                      macros=macros,
-                                     name=test_name,
+                                     name=test_case_folder_name,
+                                     project_id=test_name,
                                      report=report,
                                      properties=properties,
                                      verbose=verbose)


### PR DESCRIPTION
This mitigates the Windows paths issue by shortening the test binary name to just the test case folder name instead of the full unique test name used by the tools. This doesn't solve the Windows path limit of 260 characters, but it does reduce the characters used.

The changes should be transparent to the building and test process, the only change should be the binary name has changed.

**Todo**
- [x] Review by @adbridge 
- [x] Review by @PrzemekWirkus 

@PrzemekWirkus will renaming the test binaries affect the host test discovery in htrun?