### PR TITLE
Removed heap region from ARM sct file on K devices

### DIFF
--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K22F/TOOLCHAIN_ARM_STD/MK22FN512xxx12.sct
@@ -50,10 +50,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x4000
-#define __heap_size__        0x8000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else
@@ -78,18 +74,6 @@
 #define m_data_2_start                 0x20000000
 #define m_data_2_size                  0x00010000
 
-/* Sizes */
-#if (defined(__stack_size__))
-  #define Stack_Size                   __stack_size__
-#else
-  #define Stack_Size                   0x0400
-#endif
-
-#if (defined(__heap_size__))
-  #define Heap_Size                    __heap_size__
-#else
-  #define Heap_Size                    0x0400
-#endif
 
 LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
@@ -105,10 +89,8 @@ LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {
   RW_m_data m_data_start m_data_size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_m_data_2 m_data_2_start m_data_2_size-Stack_Size-Heap_Size { ; RW data
+  RW_IRAM1 m_data_2_start m_data_2_size { ; RW data
     .ANY (+RW +ZI)
-  }
-  RW_IRAM1 ((ImageLimit(RW_m_data_2) == m_data_2_start) ? ImageLimit(RW_m_data) : +0) EMPTY Heap_Size { ; Heap region growing up
   }
   VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
   }

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct
@@ -49,10 +49,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x8000
-#define __heap_size__        0x10000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000400
 #else
@@ -77,18 +73,6 @@
 #define m_data_2_start                 0x20000000
 #define m_data_2_size                  0x00030000
 
-/* Sizes */
-#if (defined(__stack_size__))
-  #define Stack_Size                   __stack_size__
-#else
-  #define Stack_Size                   0x0400
-#endif
-
-#if (defined(__heap_size__))
-  #define Heap_Size                    __heap_size__
-#else
-  #define Heap_Size                    0x0400
-#endif
 
 LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
@@ -104,10 +88,8 @@ LR_m_text m_interrupts_start m_text_size+m_interrupts_size+m_flash_config_size {
   RW_m_data m_data_start m_data_size { ; RW data
     .ANY (+RW +ZI)
   }
-  RW_m_data_2 m_data_2_start m_data_2_size-Stack_Size-Heap_Size { ; RW data
+  RW_IRAM1 m_data_2_start m_data_2_size { ; RW data
     .ANY (+RW +ZI)
-  }
-  RW_IRAM1 ((ImageLimit(RW_m_data_2) == m_data_2_start) ? ImageLimit(RW_m_data) : +0) EMPTY Heap_Size { ; Heap region growing up
   }
   VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
   }

--- a/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
+++ b/hal/targets/cmsis/TARGET_Freescale/TARGET_KL27Z/TOOLCHAIN_ARM_STD/MKL27Z64xxx4.sct
@@ -50,10 +50,6 @@
 */
 #define __ram_vector_table__            1
 
-/* Heap 1/4 of ram and stack 1/8 */
-#define __stack_size__       0x800
-#define __heap_size__        0x1000
-
 #if (defined(__ram_vector_table__))
   #define __ram_vector_table_size__    0x00000200
 #else
@@ -75,18 +71,6 @@
 #define m_data_start                   (m_interrupts_ram_start + m_interrupts_ram_size)
 #define m_data_size                    (0x00004000 - m_interrupts_ram_size)
 
-/* Sizes */
-#if (defined(__stack_size__))
-  #define Stack_Size                   __stack_size__
-#else
-  #define Stack_Size                   0x0400
-#endif
-
-#if (defined(__heap_size__))
-  #define Heap_Size                    __heap_size__
-#else
-  #define Heap_Size                    0x0400
-#endif
 
 LR_m_text m_interrupts_start 0x10000 {   ; load region size_region
   VECTOR_ROM m_interrupts_start m_interrupts_size { ; load address = execution address
@@ -101,10 +85,8 @@ LR_m_text m_interrupts_start 0x10000 {   ; load region size_region
   }
   VECTOR_RAM m_interrupts_ram_start EMPTY m_interrupts_ram_size {
   }
-  RW_m_data m_data_start m_data_size-Stack_Size-Heap_Size { ; RW data
+  RW_IRAM1 m_data_start m_data_size { ; RW data
     .ANY (+RW +ZI)
-  }
-  RW_IRAM1 +0 EMPTY Heap_Size {    ; Heap region growing up
   }
 }
 


### PR DESCRIPTION
- `__heap_size__` was used to allocate a fixed size region for the heap in `RW_IRAM1` ([here](https://github.com/mbedmicro/mbed/blob/master/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_ARM_STD/MK64FN1M0xxx12.sct#L110))
- `__user_setup_stackheap` in `sys.cpp` uses `Image$$RW_IRAM1$$ZI$$Limit` as the start of the heap, which leaves the fixed size region unused ([here](https://github.com/mbedmicro/mbed/blob/master/hal/targets/cmsis/TARGET_Freescale/TARGET_K64F/TOOLCHAIN_ARM_STD/sys.cpp#L17))

`Image$$RW_IRAM1$$ZI$$Limit` is now correctly the end of global variables. This matches the sct files for other Freescale devices.

resolves ARMmbed/mbed-os#384
cc @sg-, @c1728p9