### PR TITLE
Remove support for the RTC

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -470,7 +470,7 @@
         "inherits": ["Target"],
         "progen": {"target": "frdm-kl25z"},
         "detect_code": ["0200"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "release": true
     },
     "KL26Z": {

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KLXX/rtc_api.c
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+#if DEVICE_RTC
+
 #include "rtc_api.h"
 #include "PeripheralPins.h"
 #include "clk_freqs.h"
@@ -112,3 +115,5 @@ void rtc_write(time_t t) {
     // re-enable counter
     RTC->SR |= RTC_SR_TCE_MASK;
 }
+
+#endif


### PR DESCRIPTION
Only early versions of the interface firmware provided a clock for the RTC that was used. This has long been depreciated since it also routed the same pin to an ADC on the arduino connector which caused wiring conflicts