### PR TITLE
In targets.json, add the "IPV4" setting for RZ_A1H(Rebase #2018)

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1510,7 +1510,8 @@
                 "template": ["iar_rz_a1h.ewp.tmpl"]
             }
         },
-        "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"]
+        "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
+        "features": ["IPV4"]
     },
     "VK_RZ_A1H": {
         "inherits": ["Target"],


### PR DESCRIPTION
Hi

We added "IPV4" of Compile Macro in "targets.json" file.
We failed in the reletion test of IPV4 because "IPV4" was not entered into our Build Target setting.

This PR is that was rebased https://github.com/mbedmicro/mbed/pull/2018.
Ref : https://github.com/mbedmicro/mbed/pull/2018#issuecomment-229234343

Regards,
Yamanaka