### PR TITLE
RTOS - fix for main thread id might not be 0x02

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c
+++ b/rtos/rtx/TARGET_CORTEX_M/HAL_CM.c
@@ -35,7 +35,7 @@
 #include "rt_TypeDef.h"
 #include "RTX_Config.h"
 #include "rt_HAL_CM.h"
-
+#include "cmsis_os.h"
 
 /*----------------------------------------------------------------------------
  *      Global Variables
@@ -93,12 +93,12 @@ void rt_init_stack (P_TCB p_TCB, FUNCP task_body) {
 
 #ifdef __MBED_CMSIS_RTOS_CM
   /* Set a magic word for checking of stack overflow.
-   For the main thread (ID: 0x02) the stack is in a memory area shared with the
+   For the main thread (ID: MAIN_THREAD_ID) the stack is in a memory area shared with the
    heap, therefore the last word of the stack is a moving target.
    We want to do stack/heap collision detection instead.
    Similar applies to stack filling for the magic pattern.
   */
-  if (p_TCB->task_id != 0x02) {
+  if (p_TCB->task_id != MAIN_THREAD_ID) {
     p_TCB->stack[0] = MAGIC_WORD;
 
     /* Initialize stack with magic pattern. */

--- a/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
+++ b/rtos/rtx/TARGET_CORTEX_M/RTX_Conf_CM.c
@@ -39,11 +39,6 @@
  *      RTX User configuration part BEGIN
  *---------------------------------------------------------------------------*/
 
-#if defined(MBED_RTOS_SINGLE_THREAD)
-#define OS_TASKCNT  1
-#define OS_TIMERS   0
-#endif
-
 //-------- <<< Use Configuration Wizard in Context Menu >>> -----------------
 //
 // <h>Thread Configuration

--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -72,6 +72,24 @@
 #    define WORDS_STACK_SIZE   128
 #endif
 
+#ifdef __MBED_CMSIS_RTOS_CM
+
+/* Single thread - disable timers and set task count to one */
+#if defined(MBED_RTOS_SINGLE_THREAD)
+#define OS_TASKCNT  1
+#define OS_TIMERS   0
+#endif
+
+/* If os timers macro is set to 0, there's no timer thread created, therefore
+ * main thread has tid 0x01  
+ */
+#if (OS_TIMERS != 0)
+#define MAIN_THREAD_ID 0x02
+#else
+#define MAIN_THREAD_ID 0x01
+#endif
+#endif
+
 #define DEFAULT_STACK_SIZE         (WORDS_STACK_SIZE*4)
 
 #define osCMSIS           0x10002U     ///< CMSIS-RTOS API version (main [31:16] .sub [15:0])

--- a/rtos/rtx/TARGET_CORTEX_M/rt_System.c
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_System.c
@@ -315,7 +315,7 @@ void rt_systick (void) {
 __weak void rt_stk_check (void) {
 #ifdef __MBED_CMSIS_RTOS_CM
     /* Check for stack overflow. */
-    if (os_tsk.run->task_id == 0x02) {
+    if (os_tsk.run->task_id == MAIN_THREAD_ID) {
         // TODO: For the main thread the check should be done against the main heap pointer
     } else {
         if ((os_tsk.run->tsk_stack < (U32)os_tsk.run->stack) ||


### PR DESCRIPTION
Fixes #2059. As reported, if timer thread is not created, the main thread
id is 0x01. We introduce MAIN_THREAD_ID macro to define the id. We shall consider,
if we keep this in a variable.

I placed MAIN_THREAD_ID in cmsis_os.h as that header is safe to include within RTX, not like
RTX_Config.h or RTX_CM_Lib.h). I reported an issue to cmsis team about this inclusion mess within RTX.

tested with K64F with default config:

```
+--------+------------+-----------+---------+-------------------------+--------------------+---------------+-------+
| Result | Target     | Toolchain | Test ID | Test Description        | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+------------+-----------+---------+-------------------------+--------------------+---------------+-------+
| OK     | K64F[f3f7] | ARM       | RTOS_1  | Basic thread            |       11.36        |       15      |  1/1  |
| OK     | K64F[f3f7] | ARM       | RTOS_3  | Semaphore resource lock |        8.45        |       20      |  1/1  |
| OK     | K64F[f3f7] | ARM       | RTOS_5  | Queue messaging         |        2.4         |       20      |  1/1  |
| OK     | K64F[f3f7] | ARM       | RTOS_7  | Timer                   |       11.33        |       15      |  1/1  |
| OK     | K64F[f3f7] | ARM       | RTOS_8  | ISR (Queue)             |        6.41        |       20      |  1/1  |
+--------+------------+-----------+---------+-------------------------+--------------------+---------------+-------+

+--------+------------+-----------+---------+-------------------------+--------------------+---------------+-------+
| Result | Target     | Toolchain | Test ID | Test Description        | Elapsed Time (sec) | Timeout (sec) | Loops |
+--------+------------+-----------+---------+-------------------------+--------------------+---------------+-------+
| OK     | K64F[f3f7] | GCC_ARM   | RTOS_1  | Basic thread            |       11.37        |       15      |  1/1  |
| OK     | K64F[f3f7] | GCC_ARM   | RTOS_3  | Semaphore resource lock |        8.5         |       20      |  1/1  |
| OK     | K64F[f3f7] | GCC_ARM   | RTOS_5  | Queue messaging         |        2.38        |       20      |  1/1  |
| OK     | K64F[f3f7] | GCC_ARM   | RTOS_7  | Timer                   |       11.36        |       15      |  1/1  |
| OK     | K64F[f3f7] | GCC_ARM   | RTOS_8  | ISR (Queue)             |        6.45        |       20      |  1/1  |
+--------+------------+-----------+---------+-------------------------+--------------------+---------------+-------+
```

Our tests are multithreaded thus NOT SUPPORTED once I switch to small default build. I run just main thread with blinky to blink LED, working.

@gdhamp  Please verify this patch.