### PR TITLE
Relative paths in test spec file

### DIFF
--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -2008,6 +2008,15 @@ def print_tests(tests, format="list", sort=True):
         print "Unknown format '%s'" % format
         sys.exit(1)
 
+def norm_relative_path(path, start):
+    """This function will create a normalized, relative path. It mimics the
+    python os.path.relpath function, but also normalizes a Windows-syle path
+    that use backslashes to a Unix style path that uses forward slashes."""
+    path = os.path.normpath(path)
+    path = os.path.relpath(path, start)
+    path = path.replace("\\", "/")
+    return path
+
 def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         options=None, clean=False, notify=None, verbose=False, jobs=1,
         macros=None, silent=False, report=None, properties=None,
@@ -2018,10 +2027,14 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
     Returns a tuple of the build result (True or False) followed by the test
     build data structure"""
     
+    execution_directory = "."
+
+    base_path = norm_relative_path(build_path, execution_directory)
+    
     test_build = {
         "platform": target.name,
         "toolchain": toolchain_name,
-        "base_path": build_path,
+        "base_path": base_path,
         "baud_rate": 9600,
         "binary_type": "bootable",
         "tests": {}
@@ -2060,7 +2073,7 @@ def build_tests(tests, base_source_paths, build_path, target, toolchain_name,
         
         # Normalize the path
         if bin_file:
-            bin_file = os.path.normpath(bin_file)
+            bin_file = norm_relative_path(bin_file, execution_directory)
             
             test_build['tests'][test_name] = {
                 "binaries": [


### PR DESCRIPTION
Test spec paths are now relative to tool execution directory as shown by the greentea docs here: https://github.com/ARMmbed/greentea#example-of-test-specification-file

This commit also normalizes the paths produced by the the test spec to Unix style paths to increase portability of the file.

## Before
```
{
  "builds": {
    "K64F-GCC_ARM": {
      "binary_type": "bootable", 
      "tests": {
        "mbed-os-tests-mbedmicro-rtos-mbed-mutex": {
          "binaries": [
            {
              "path": "C:\\m\\test\\.build\\tests\\K64F\\GCC_ARM\\mbed-os\\TESTS\\mbedmicro-rtos-mbed\\mutex\\mbed-os-tests-mbedmicro-rtos-mbed-mutex.bin"
            }
          ]
        }
      }, 
      "toolchain": "GCC_ARM", 
      "base_path": "C:\\m\\test\\.build/tests\\K64F\\GCC_ARM", 
      "baud_rate": 9600, 
      "platform": "K64F"
    }
  }
}
```

## After
```
{
  "builds": {
    "K64F-GCC_ARM": {
      "binary_type": "bootable", 
      "tests": {
        "mbed-os-tests-mbedmicro-rtos-mbed-mutex": {
          "binaries": [
            {
              "path": ".build/tests/K64F/GCC_ARM/mbed-os/TESTS/mbedmicro-rtos-mbed/mutex/mbed-os-tests-mbedmicro-rtos-mbed-mutex.bin"
            }
          ]
        }
      }, 
      "toolchain": "GCC_ARM", 
      "base_path": ".build/tests/K64F/GCC_ARM", 
      "baud_rate": 9600, 
      "platform": "K64F"
    }
  }
}
```