### PR TITLE
[STM32L0] Fix baudrate initialisation

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/serial_api.c
@@ -53,15 +53,13 @@ static void init_uart(serial_t *obj)
 {
     UartHandle.Instance = (USART_TypeDef *)(obj->uart);
 
-    if (obj->uart == LPUART_1) {
-        UartHandle.Init.BaudRate = obj->baudrate >> 1;
-    } else {
-        UartHandle.Init.BaudRate = obj->baudrate;
-    }
+    UartHandle.Init.BaudRate = obj->baudrate;
     UartHandle.Init.WordLength = obj->databits;
     UartHandle.Init.StopBits   = obj->stopbits;
     UartHandle.Init.Parity     = obj->parity;
     UartHandle.Init.HwFlowCtl  = UART_HWCONTROL_NONE;
+    UartHandle.Init.OverSampling   = UART_OVERSAMPLING_16;
+    UartHandle.Init.OneBitSampling = UART_ONE_BIT_SAMPLE_ENABLE;
 
     if (obj->pin_rx == NC) {
         UartHandle.Init.Mode = UART_MODE_TX;


### PR DESCRIPTION
Issue #2074

Assuming that OverSampling is initialized, the baudrate is now correctly
computed inside CMSIS (STM32 HAL) layer. This was not the case before but
most probably was fixed during latest L0 cube firmware upgrade:

commit ce436d51075b7ea08a2f0b05fd398d81d59bd54e
Author: svastm <simon.vanson@st.com>
Date:   Thu Apr 14 14:39:53 2016 +0200
    Update STM32CUBE_L0 from v1.2 to v1.5