### PR TITLE
Progen build tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,8 +3,8 @@ PySerial>=2.7
 PrettyTable>=0.7.2
 Jinja2>=2.7.3
 IntelHex>=1.3
-project-generator>=0.9.3,<0.10.0
 project_generator_definitions>=0.2.26,<0.3.0
+project-generator>=0.9.7,<0.10.0
 junit-xml
 pyYAML
 requests

--- a/tools/build_test.py
+++ b/tools/build_test.py
@@ -78,7 +78,7 @@ if __name__ == '__main__':
                       nargs='+',
                       dest ="targets",
                       help="generate project for the given MCUs (%s)" % '\n '.join(accepted_targets),
-                      default = TARGET_NAMES)
+                      default = accepted_targets)
 
     options = parser.parse_args()
 

--- a/tools/build_test.py
+++ b/tools/build_test.py
@@ -1,0 +1,95 @@
+import sys
+from os.path import join, abspath, dirname, exists, basename
+ROOT = abspath(join(dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+import argparse
+
+from export import EXPORTERS
+from targets import TARGET_NAMES, TARGET_MAP
+from project_api import setup_project, perform_export, print_results, get_test_from_name
+from project_generator_definitions.definitions import ProGenDef
+from utils import args_error
+
+class BuildTest():
+    def __init__(self, desired_ides, tests, targets):
+        self.target_ides = {}
+        for target in targets:
+            self.target_ides[target] =[]
+            for ide in desired_ides:
+                if target in EXPORTERS[ide].TARGETS:
+                    self.target_ides[target].append(ide)
+            if len(self.target_ides[target]) == 0:
+                del self.target_ides[target]
+
+        successes, failures = self._generate_and_build(tests)
+        print_results(successes, failures)
+
+    @staticmethod
+    def get_pgen_targets(ides):
+        targs = []
+        for ide in ides:
+            for target in TARGET_NAMES:
+                if target not in targs and hasattr(TARGET_MAP[target],'progen') \
+                        and ProGenDef(ide).is_supported(TARGET_MAP[target].progen['target']):
+                    targs.append(target)
+        return targs
+
+    def _generate_and_build(self, tests):
+        successes = []
+        failures = []
+        for mcu, ides in self.target_ides.items():
+            for test in tests:
+                test = get_test_from_name(test)
+                for ide in ides:
+                    project_dir, project_name, project_temp = setup_project(mcu, ide, test)
+                    tmp_path, report = perform_export(project_dir, project_name, ide, mcu, project_temp,
+                                                      progen_build = True)
+                    if report['success']:
+                        successes.append("build for %s::%s\t%s" % (mcu, ide, project_name))
+                    else:
+                        failures.append("%s::%s\t%s for %s" % (mcu, ide, report['errormsg'], project_name))
+        return successes, failures
+
+
+if __name__ == '__main__':
+    accepted_ides = ["iar", "uvision", "uvision5"]
+    accepted_targets = sorted(BuildTest.get_pgen_targets(accepted_ides))
+    default_tests = ["MBED_BLINKY"]
+    parser = argparse.ArgumentParser(description = "Test progen builders. Leave any flag off to run with all possible options.")
+    parser.add_argument("-i", "--IDEs",
+                      nargs = '+',
+                      dest="ides",
+                      help="tools you wish to perfrom build tests. (%s)" % ', '.join(accepted_ides),
+                      default = accepted_ides)
+
+    parser.add_argument("-t", "--tests",
+                    nargs='+',
+                    dest="tests",
+                    help="names of desired test programs",
+                    default = default_tests)
+
+    parser.add_argument("-m", "--mcus",
+                      nargs='+',
+                      dest ="targets",
+                      help="generate project for the given MCUs (%s)" % '\n '.join(accepted_targets),
+                      default = TARGET_NAMES)
+
+    options = parser.parse_args()
+
+    tests = options.tests
+    ides = options.ides
+    targets = options.targets
+
+    if any(get_test_from_name(test) is None for test in tests):
+        args_error(parser, "[ERROR] test name not recognized")
+
+    if any(target not in accepted_targets for target in targets):
+        args_error(parser, "[ERROR] mcu must be one of the following:\n %s" % '\n '.join(accepted_targets))
+
+    if any(ide not in accepted_ides for ide in ides):
+        args_error(parser, "[ERROR] ide must be in %s" % ', '.join(accepted_ides))
+
+    b = BuildTest(ides, tests, targets)
+
+

--- a/tools/build_test.py
+++ b/tools/build_test.py
@@ -13,11 +13,13 @@ from utils import args_error
 
 class BuildTest():
     def __init__(self, desired_ides, tests, targets):
+        #map of targets and the ides that can build programs for them
         self.target_ides = {}
         for target in targets:
             self.target_ides[target] =[]
             for ide in desired_ides:
                 if target in EXPORTERS[ide].TARGETS:
+                    #target is supported by ide
                     self.target_ides[target].append(ide)
             if len(self.target_ides[target]) == 0:
                 del self.target_ides[target]
@@ -27,6 +29,7 @@ class BuildTest():
 
     @staticmethod
     def get_pgen_targets(ides):
+        #targets supported by pgen and desired ides for tests
         targs = []
         for ide in ides:
             for target in TARGET_NAMES:
@@ -36,10 +39,12 @@ class BuildTest():
         return targs
 
     def _generate_and_build(self, tests):
+        #build results
         successes = []
         failures = []
         for mcu, ides in self.target_ides.items():
             for test in tests:
+                #resolve name alias
                 test = get_test_from_name(test)
                 for ide in ides:
                     project_dir, project_name, project_temp = setup_project(mcu, ide, test)
@@ -78,8 +83,8 @@ if __name__ == '__main__':
     options = parser.parse_args()
 
     tests = options.tests
-    ides = options.ides
-    targets = options.targets
+    ides = [ide.lower() for ide in options.ides]
+    targets = [target.upper() for target in options.targets]
 
     if any(get_test_from_name(test) is None for test in tests):
         args_error(parser, "[ERROR] test name not recognized")

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -70,7 +70,9 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
     use_progen = False
 
     supported = True
-    report = {'success': False, 'errormsg':''}
+    report = {'success': False, 'errormsg':'', 'skip': False}
+
+
     
     if ide is None or ide == "zip":
         # Simple ZIP exporter
@@ -85,6 +87,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
     else:
         if ide not in EXPORTERS:
             report['errormsg'] = ERROR_MESSAGE_UNSUPPORTED_TOOLCHAIN % (target, ide)
+            report['skip'] = True
         else:
             Exporter = EXPORTERS[ide]
             target = EXPORT_MAP.get(target, target)
@@ -93,11 +96,12 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
                     use_progen = True
             except AttributeError:
                 pass
+
+            if target not in Exporter.TARGETS or ide.upper() not in TARGET_MAP[target].supported_toolchains:
+                supported = False
+
             if use_progen:
                 if not ProGenDef(ide).is_supported(TARGET_MAP[target].progen['target']):
-                    supported = False
-            else:
-                if target not in Exporter.TARGETS:
                     supported = False
 
             if supported:
@@ -120,6 +124,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
 
             else:
                 report['errormsg'] = ERROR_MESSAGE_UNSUPPORTED_TOOLCHAIN % (target, ide)
+                report['skip'] = True
 
     zip_path = None
     if report['success']:

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -97,7 +97,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
             except AttributeError:
                 pass
 
-            if target not in Exporter.TARGETS or ide.upper() not in TARGET_MAP[target].supported_toolchains:
+            if target not in Exporter.TARGETS or Exporter.TOOLCHAIN not in TARGET_MAP[target].supported_toolchains:
                 supported = False
 
             if use_progen:

--- a/tools/export/__init__.py
+++ b/tools/export/__init__.py
@@ -59,7 +59,7 @@ def online_build_url_resolver(url):
 
 def export(project_path, project_name, ide, target, destination='/tmp/',
            tempdir=None, pgen_build = False, clean=True, extra_symbols=None, make_zip=True, sources_relative=False,
-           build_url_resolver=online_build_url_resolver, **kwargs):
+           build_url_resolver=online_build_url_resolver, progen_build=False):
     # Convention: we are using capitals for toolchain and target names
     if target is not None:
         target = target.upper()
@@ -68,9 +68,6 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
         tempdir = tempfile.mkdtemp()
 
     use_progen = False
-    build = False
-    if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
-        build = True
 
     supported = True
     report = {'success': False, 'errormsg':''}
@@ -108,7 +105,7 @@ def export(project_path, project_name, ide, target, destination='/tmp/',
                 try:
                     exporter = Exporter(target, tempdir, project_name, build_url_resolver, extra_symbols=extra_symbols, sources_relative=sources_relative)
                     exporter.scan_and_copy_resources(project_path, tempdir, sources_relative)
-                    if build:
+                    if progen_build:
                         #try to build with pgen ide builders
                         try:
                             exporter.generate(progen_build=True)

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -109,7 +109,7 @@ class Exporter(object):
         }
         return project_data
 
-    def progen_gen_file(self, tool_name, project_data, pgen_build = False):
+    def progen_gen_file(self, tool_name, project_data, pgen_build=False):
         """" Generate project using ProGen Project API """
         settings = ProjectSettings()
         project = Project(self.program_name, [project_data], settings)
@@ -118,6 +118,7 @@ class Exporter(object):
         project.project['common']['include_paths'] = self.resources.inc_dirs
         project.generate(tool_name, copied=not self.sources_relative)
         if pgen_build:
+            print("Project exported, building...")
             result = project.build(tool_name)
             if result == -1:
                 raise FailedBuildException("Build Failed")

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -109,7 +109,7 @@ class Exporter(object):
         }
         return project_data
 
-    def progen_gen_file(self, tool_name, project_data, pgen_build=False):
+    def progen_gen_file(self, tool_name, project_data, progen_build=False):
         """" Generate project using ProGen Project API """
         settings = ProjectSettings()
         project = Project(self.program_name, [project_data], settings)
@@ -117,7 +117,7 @@ class Exporter(object):
         # thinks it is not dict but a file, and adds them to workspace.
         project.project['common']['include_paths'] = self.resources.inc_dirs
         project.generate(tool_name, copied=not self.sources_relative)
-        if pgen_build:
+        if progen_build:
             print("Project exported, building...")
             result = project.build(tool_name)
             if result == -1:

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -21,6 +21,8 @@ from tools.config import Config
 
 class OldLibrariesException(Exception): pass
 
+class FailedBuildException(Exception) : pass
+
 class Exporter(object):
     TEMPLATE_DIR = dirname(__file__)
     DOT_IN_RELATIVE_PATH = False
@@ -107,14 +109,18 @@ class Exporter(object):
         }
         return project_data
 
-    def progen_gen_file(self, tool_name, project_data):
-        """ Generate project using ProGen Project API """
+    def progen_gen_file(self, tool_name, project_data, pgen_build = False):
+        """" Generate project using ProGen Project API """
         settings = ProjectSettings()
         project = Project(self.program_name, [project_data], settings)
         # TODO: Fix this, the inc_dirs are not valid (our scripts copy files), therefore progen
         # thinks it is not dict but a file, and adds them to workspace.
         project.project['common']['include_paths'] = self.resources.inc_dirs
         project.generate(tool_name, copied=not self.sources_relative)
+        if pgen_build:
+            result = project.build(tool_name)
+            if result == -1:
+                raise FailedBuildException("Build Failed")
 
     def __scan_all(self, path):
         resources = []

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -46,7 +46,7 @@ class IAREmbeddedWorkbench(Exporter):
             # target is not supported yet
             continue
 
-    def generate(self):
+    def generate(self, **kwargs):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -75,7 +75,10 @@ class IAREmbeddedWorkbench(Exporter):
         # VLA is enabled via template IccAllowVLA
         project_data['tool_specific']['iar']['misc']['c_flags'].remove("--vla")
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
-        self.progen_gen_file('iar_arm', project_data)
+        if 'progen_build' in kwargs:
+            self.progen_gen_file('iar_arm', project_data, True)
+        else:
+            self.progen_gen_file('iar_arm', project_data)
 
 # Currently not used, we should reuse folder_name to create virtual folders
 class IarFolder():

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -46,7 +46,7 @@ class IAREmbeddedWorkbench(Exporter):
             # target is not supported yet
             continue
 
-    def generate(self, **kwargs):
+    def generate(self, progen_build=False):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -75,7 +75,7 @@ class IAREmbeddedWorkbench(Exporter):
         # VLA is enabled via template IccAllowVLA
         project_data['tool_specific']['iar']['misc']['c_flags'].remove("--vla")
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
-        if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
+        if progen_build:
             self.progen_gen_file('iar_arm', project_data, True)
         else:
             self.progen_gen_file('iar_arm', project_data)

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -75,7 +75,7 @@ class IAREmbeddedWorkbench(Exporter):
         # VLA is enabled via template IccAllowVLA
         project_data['tool_specific']['iar']['misc']['c_flags'].remove("--vla")
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
-        if 'progen_build' in kwargs:
+        if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
             self.progen_gen_file('iar_arm', project_data, True)
         else:
             self.progen_gen_file('iar_arm', project_data)

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -50,7 +50,7 @@ class Uvision4(Exporter):
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain
 
-    def generate(self):
+    def generate(self, **kwargs):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -96,4 +96,7 @@ class Uvision4(Exporter):
             i += 1
         project_data['common']['macros'].append('__ASSERT_MSG')
         project_data['common']['build_dir'] = join(project_data['common']['build_dir'], 'uvision4')
-        self.progen_gen_file('uvision', project_data)
+        if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
+            self.progen_gen_file('uvision', project_data, True)
+        else:
+            self.progen_gen_file('uvision', project_data)

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -50,7 +50,7 @@ class Uvision4(Exporter):
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain
 
-    def generate(self, **kwargs):
+    def generate(self, progen_build=False):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -96,7 +96,7 @@ class Uvision4(Exporter):
             i += 1
         project_data['common']['macros'].append('__ASSERT_MSG')
         project_data['common']['build_dir'] = join(project_data['common']['build_dir'], 'uvision4')
-        if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
+        if progen_build:
             self.progen_gen_file('uvision', project_data, True)
         else:
             self.progen_gen_file('uvision', project_data)

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -50,7 +50,7 @@ class Uvision5(Exporter):
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain
 
-    def generate(self, **kwargs):
+    def generate(self, progen_build=False):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -94,8 +94,8 @@ class Uvision5(Exporter):
             if macro.startswith('MBED_USERNAME'):
                 project_data['common']['macros'].pop(i)
             i += 1
-        project_data['common']['macros'].append('__ASSERT_MSG')
-        if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
+
+        if progen_build:
             self.progen_gen_file('uvision5', project_data, True)
         else:
             self.progen_gen_file('uvision5', project_data)

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -50,7 +50,7 @@ class Uvision5(Exporter):
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain
 
-    def generate(self):
+    def generate(self, **kwargs):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -95,4 +95,7 @@ class Uvision5(Exporter):
                 project_data['common']['macros'].pop(i)
             i += 1
         project_data['common']['macros'].append('__ASSERT_MSG')
-        self.progen_gen_file('uvision5', project_data)
+        if 'progen_build' in kwargs and kwargs.get('progen_build') == True:
+            self.progen_gen_file('uvision5', project_data, True)
+        else:
+            self.progen_gen_file('uvision5', project_data)

--- a/tools/project.py
+++ b/tools/project.py
@@ -136,6 +136,7 @@ if __name__ == '__main__':
         args_error(parser, "[ERROR] You should specify an IDE")
     ide = options.ide
 
+    # Program Number or name
     p, n, src= options.program, options.program_name, options.source_dir
 
     if src is None:
@@ -155,6 +156,8 @@ if __name__ == '__main__':
     # Export results
     successes = []
     failures = []
+
+    # source is used to generate IDE files to toolchain directly in the source tree and doesn't generate zip file
     zip = src is None
     clean = src is None
 

--- a/tools/project.py
+++ b/tools/project.py
@@ -168,12 +168,9 @@ if __name__ == '__main__':
         lib_symbols = []
         if options.macros:
             lib_symbols += options.macros
-        project_dir, project_name, project_temp = setup_project(mcu,
-                      ide,
-                      p,
-                      src,
-                      options.macros,
-                      options.build)
+        project_dir, project_name, project_temp = setup_project(mcu, ide, p, src,
+                                                                options.macros,
+                                                                options.build)
 
         tmp_path, report = perform_export(project_dir, project_name, ide, mcu,
                                           project_temp, clean, zip, lib_symbols,

--- a/tools/project.py
+++ b/tools/project.py
@@ -5,19 +5,16 @@ sys.path.insert(0, ROOT)
 
 from shutil import move, rmtree
 from argparse import ArgumentParser
-from os import path
 
-from tools.paths import EXPORT_DIR, EXPORT_WORKSPACE, EXPORT_TMP
-from tools.paths import MBED_BASE, MBED_LIBRARIES
-from tools.export import export, setup_user_prj, EXPORTERS, mcu_ide_matrix
-from tools.utils import args_error, mkdir
-from tools.tests import TESTS, Test, TEST_MAP
+from tools.paths import EXPORT_DIR
+from tools.export import EXPORTERS, mcu_ide_matrix
+from tools.utils import args_error
+from tools.tests import TESTS, TEST_MAP
 from tools.tests import test_known, test_name_known
 from tools.targets import TARGET_NAMES
-from tools.libraries import LIBRARIES
-from utils import argparse_lowercase_type, argparse_uppercase_type, argparse_filestring_type, argparse_many
+from utils import argparse_filestring_type, argparse_many
 from utils import argparse_force_lowercase_type, argparse_force_uppercase_type
-
+from project_api import setup_project, perform_export, print_results, get_test_from_name
 
 
 if __name__ == '__main__':
@@ -128,77 +125,68 @@ if __name__ == '__main__':
         if exists(EXPORT_DIR):
             rmtree(EXPORT_DIR)
 
+
+    # Target
+    if options.mcu is None :
+        args_error(parser, "[ERROR] You should specify an MCU")
+    mcus = options.mcu
+
+    # IDE
+    if options.ide is None:
+        args_error(parser, "[ERROR] You should specify an IDE")
+    ide = options.ide
+
+    p, n, src= options.program, options.program_name, options.source_dir
+
+    if src is None:
+        if p is not None and n is not None:
+            args_error(parser, "[ERROR] specify either '-n' or '-p', not both")
+        if n:
+            p = get_test_from_name(n)
+            if p is None:
+                args_error(parser, "[ERROR] Program with name '%s' not found" % n)
+
+        if p is None or (p < 0) or (p > (len(TESTS) - 1)):
+            message = "[ERROR] You have to specify one of the following tests:\n"
+            message += '\n'.join(map(str, sorted(TEST_MAP.values())))
+            args_error(parser, message)
+
+
     # Export results
     successes = []
     failures = []
-    zip = True
-    clean = True
+    zip = src is None
+    clean = src is None
 
     # source_dir = use relative paths, otherwise sources are copied
     sources_relative = True if options.source_dir else False
+    for mcu in mcus.split(','):
 
-    for mcu in options.mcu:
-        # Program Number or name
-        p, src, ide = options.program, options.source_dir, options.ide
+        lib_symbols = []
+        if options.macros:
+            lib_symbols += options.macros
+        project_dir, project_name, project_temp = setup_project(mcu,
+                      ide,
+                      p,
+                      src,
+                      options.macros,
+                      options.build)
 
-        if src:
-            # --source is used to generate IDE files to toolchain directly in the source tree and doesn't generate zip file
-            project_dir = options.source_dir
-            project_name = TESTS[p] if p else "Unnamed_project"
-            project_temp = path.join(options.source_dir[0], 'projectfiles', '%s_%s' % (ide, mcu))
-            mkdir(project_temp)
-            lib_symbols = []
-            if options.macros:
-                lib_symbols += options.macros
-            zip = False   # don't create zip
-            clean = False # don't cleanup because we use the actual source tree to generate IDE files
-        else:
-            test = Test(p)
+        tmp_path, report = perform_export(project_dir, project_name, ide, mcu,
+                                          project_temp, clean, zip, lib_symbols,
+                                          sources_relative)
 
-            # Some libraries have extra macros (called by exporter symbols) to we need to pass
-            # them to maintain compilation macros integrity between compiled library and
-            # header files we might use with it
-            lib_symbols = []
-            if options.macros:
-                lib_symbols += options.macros
-            for lib in LIBRARIES:
-                if lib['build_dir'] in test.dependencies:
-                    lib_macros = lib.get('macros', None)
-                    if lib_macros is not None:
-                        lib_symbols.extend(lib_macros)
 
-            if not options.build:
-                # Substitute the library builds with the sources
-                # TODO: Substitute also the other library build paths
-                if MBED_LIBRARIES in test.dependencies:
-                    test.dependencies.remove(MBED_LIBRARIES)
-                    test.dependencies.append(MBED_BASE)
-
-            # Build the project with the same directory structure of the mbed online IDE
-            project_name = test.id
-            project_dir = [join(EXPORT_WORKSPACE, project_name)]
-            project_temp = EXPORT_TMP
-            setup_user_prj(project_dir[0], test.source_dir, test.dependencies)
-
-        # Export to selected toolchain
-        tmp_path, report = export(project_dir, project_name, ide, mcu, project_dir[0], project_temp, clean=clean, make_zip=zip, extra_symbols=lib_symbols, sources_relative=sources_relative)
         if report['success']:
             if not zip:
                 zip_path = join(project_temp, project_name)
             else:
                 zip_path = join(EXPORT_DIR, "%s_%s_%s.zip" % (project_name, ide, mcu))
                 move(tmp_path, zip_path)
+
             successes.append("%s::%s\t%s"% (mcu, ide, zip_path))
         else:
             failures.append("%s::%s\t%s"% (mcu, ide, report['errormsg']))
 
     # Prints export results
-    print
-    if len(successes) > 0:
-        print "Successful exports:"
-        for success in successes:
-            print "  * %s"% success
-    if len(failures) > 0:
-        print "Failed exports:"
-        for failure in failures:
-            print "  * %s"% failure
+    print_results(successes, failures)

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -15,6 +15,7 @@ try:
 except:
     ps = object()
 
+
 def get_program(n):
     p = TEST_MAP[n].n
     return p
@@ -22,6 +23,7 @@ def get_program(n):
 
 def get_test(p):
     return Test(p)
+
 
 def get_test_from_name(n):
     if not n in TEST_MAP.keys():
@@ -36,7 +38,12 @@ def get_test_from_name(n):
             return None
     return get_program(n)
 
+
 def setup_project(mcu, ide, program = None, source_dir= None, macros = None, build = None):
+
+    # Some libraries have extra macros (called by exporter symbols) to we need to pass
+    # them to maintain compilation macros integrity between compiled library and
+    # header files we might use with it
     lib_symbols = []
     if macros:
         lib_symbols += macros
@@ -59,7 +66,7 @@ def setup_project(mcu, ide, program = None, source_dir= None, macros = None, bui
             if MBED_LIBRARIES in test.dependencies:
                 test.dependencies.remove(MBED_LIBRARIES)
                 test.dependencies.append(MBED_BASE)
-
+        # Build the project with the same directory structure of the mbed online IDE
         project_name = test.id
         project_dir = [join(EXPORT_WORKSPACE, project_name)]
         project_temp = EXPORT_TMP

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -1,0 +1,90 @@
+import sys
+from os.path import join, abspath, dirname, exists, basename
+ROOT = abspath(join(dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from tools.paths import EXPORT_WORKSPACE, EXPORT_TMP
+from tools.paths import MBED_BASE, MBED_LIBRARIES
+from tools.export import export, setup_user_prj
+from tools.utils import mkdir
+from tools.tests import Test, TEST_MAP
+from tools.libraries import LIBRARIES
+
+try:
+    import tools.private_settings as ps
+except:
+    ps = object()
+
+def get_program(n):
+    p = TEST_MAP[n].n
+    return p
+
+
+def get_test(p):
+    return Test(p)
+
+def get_test_from_name(n):
+    if not n in TEST_MAP.keys():
+        # Check if there is an alias for this in private_settings.py
+        if getattr(ps, "test_alias", None) is not None:
+            alias = ps.test_alias.get(n, "")
+            if not alias in TEST_MAP.keys():
+                return None
+            else:
+                n = alias
+        else:
+            return None
+    return get_program(n)
+
+def setup_project(mcu, ide, program = None, source_dir= None, macros = None, build = None):
+    lib_symbols = []
+    if macros:
+        lib_symbols += macros
+    if source_dir is not None:
+        project_dir = source_dir
+        project_name = program if program else "Unnamed_Project"
+        project_temp = join(source_dir[0], 'projectfiles', '%s_%s' % (ide, mcu))
+        mkdir(project_temp)
+    else:
+        test = get_test(program)
+        for lib in LIBRARIES:
+            if lib['build_dir'] in test.dependencies:
+                lib_macros = lib.get('macros', None)
+                if lib_macros is not None:
+                    lib_symbols.extend(lib_macros)
+
+        if not build:
+            # Substitute the library builds with the sources
+            # TODO: Substitute also the other library build paths
+            if MBED_LIBRARIES in test.dependencies:
+                test.dependencies.remove(MBED_LIBRARIES)
+                test.dependencies.append(MBED_BASE)
+
+        project_name = test.id
+        project_dir = [join(EXPORT_WORKSPACE, project_name)]
+        project_temp = EXPORT_TMP
+        setup_user_prj(project_dir[0], test.source_dir, test.dependencies)
+
+    return project_dir, project_name, project_temp
+
+
+def perform_export(dir, name, ide, mcu, temp, clean = True, zip = True, lib_symbols = '',
+                   sources_relative = False, progen_build = False):
+
+    tmp_path, report = export(dir, name, ide, mcu, dir[0], temp, clean=clean,
+                              make_zip=zip, extra_symbols=lib_symbols, sources_relative=sources_relative,
+                              progen_build = progen_build)
+    return tmp_path, report
+
+
+def print_results(successes, failures):
+    print
+    if len(successes) > 0:
+        print "Successful: "
+        for success in successes:
+            print "  * %s" % success
+    if len(failures) > 0:
+        print "Failed: "
+        for failure in failures:
+            print "  * %s" % failure
+

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -84,7 +84,7 @@ def perform_export(dir, name, ide, mcu, temp, clean=False, zip=False, lib_symbol
     return tmp_path, report
 
 
-def print_results(successes, failures):
+def print_results(successes, failures, skips = []):
     print
     if len(successes) > 0:
         print "Successful: "
@@ -94,4 +94,8 @@ def print_results(successes, failures):
         print "Failed: "
         for failure in failures:
             print "  * %s" % failure
+    if len(skips) > 0:
+        print "Skipped: "
+        for skip in skips:
+            print "  * %s" % skip
 

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -39,7 +39,7 @@ def get_test_from_name(n):
     return get_program(n)
 
 
-def setup_project(mcu, ide, program = None, source_dir= None, macros = None, build = None):
+def setup_project(mcu, ide, program=None, source_dir=None, macros=None, build=None):
 
     # Some libraries have extra macros (called by exporter symbols) to we need to pass
     # them to maintain compilation macros integrity between compiled library and
@@ -75,12 +75,12 @@ def setup_project(mcu, ide, program = None, source_dir= None, macros = None, bui
     return project_dir, project_name, project_temp
 
 
-def perform_export(dir, name, ide, mcu, temp, clean = True, zip = True, lib_symbols = '',
-                   sources_relative = False, progen_build = False):
+def perform_export(dir, name, ide, mcu, temp, clean=False, zip=False, lib_symbols='',
+                   sources_relative=False, progen_build=False):
 
     tmp_path, report = export(dir, name, ide, mcu, dir[0], temp, clean=clean,
                               make_zip=zip, extra_symbols=lib_symbols, sources_relative=sources_relative,
-                              progen_build = progen_build)
+                              progen_build=progen_build)
     return tmp_path, report
 
 

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -70,7 +70,7 @@ class ProgenBuildTest():
             with open(log, 'r') as f:
                 print f.read()
         except:
-            print("No log file found")
+            return
 
         test_prefix = "_".join([test, target, tool])
         log_name = os.path.join(new_dir,test_prefix+"_log.txt")
@@ -96,6 +96,7 @@ class ProgenBuildTest():
         #build results
         successes = []
         failures = []
+        skips = []
         for mcu, ides in self.target_ides.items():
             for test in tests:
                 #resolve name alias
@@ -107,11 +108,13 @@ class ProgenBuildTest():
 
                     if report['success']:
                         successes.append("build for %s::%s\t%s" % (mcu, ide, project_name))
+                    elif report['skip']:
+                        skips.append("%s::%s\t%s" % (mcu, ide, project_name))
                     else:
                         failures.append("%s::%s\t%s for %s" % (mcu, ide, report['errormsg'], project_name))
 
                     ProgenBuildTest.handle_project_files(ide, project_temp, mcu, project_name, clean)
-        return successes, failures
+        return successes, failures, skips
 
 
 if __name__ == '__main__':
@@ -160,8 +163,8 @@ if __name__ == '__main__':
         args_error(parser, "[ERROR] ide must be in %s" % ', '.join(accepted_ides))
 
     b = ProgenBuildTest(ides, tests, targets)
-    successes, failures = b.generate_and_build(tests, options.clean)
-    print_results(successes, failures)
+    successes, failures, skips = b.generate_and_build(tests, options.clean)
+    print_results(successes, failures, skips)
     sys.exit(len(failures))
 
 

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -24,7 +24,6 @@ import shutil
 from os.path import join, abspath, dirname, exists, basename
 r=dirname(__file__)
 ROOT = abspath(join(r, "..","..",".."))
-print ROOT
 sys.path.insert(0, ROOT)
 
 from tools.export import EXPORTERS
@@ -35,7 +34,7 @@ from tools.utils import args_error
 
 
 class ProgenBuildTest():
-    def __init__(self, desired_ides, tests, targets, clean=False):
+    def __init__(self, desired_ides, tests, targets):
         #map of targets and the ides that can build programs for them
         self.target_ides = {}
         for target in targets:
@@ -47,10 +46,6 @@ class ProgenBuildTest():
             if len(self.target_ides[target]) == 0:
                 del self.target_ides[target]
 
-        self.clean = clean
-
-        successes, failures = self._generate_and_build(tests)
-        print_results(successes, failures)
 
     @staticmethod
     def get_pgen_targets(ides):
@@ -96,7 +91,7 @@ class ProgenBuildTest():
             shutil.rmtree(project_files_dir, ignore_errors=True)
         os.rename(project_dir, project_files_dir)
 
-    def _generate_and_build(self, tests):
+    def generate_and_build(self, tests, clean=False):
 
         #build results
         successes = []
@@ -115,7 +110,7 @@ class ProgenBuildTest():
                     else:
                         failures.append("%s::%s\t%s for %s" % (mcu, ide, report['errormsg'], project_name))
 
-                    ProgenBuildTest.handle_project_files(ide, project_temp, mcu, project_name, self.clean)
+                    ProgenBuildTest.handle_project_files(ide, project_temp, mcu, project_name, clean)
         return successes, failures
 
 
@@ -164,6 +159,10 @@ if __name__ == '__main__':
     if any(ide not in accepted_ides for ide in ides):
         args_error(parser, "[ERROR] ide must be in %s" % ', '.join(accepted_ides))
 
-    b = ProgenBuildTest(ides, tests, targets, options.clean)
+    b = ProgenBuildTest(ides, tests, targets)
+    successes, failures = b.generate_and_build(tests, options.clean)
+    print_results(successes, failures)
+    sys.exit(len(failures))
+
 
 


### PR DESCRIPTION
I have separated some of the exporter logic in project.py to project_api.py. I did this because I wanted to use some of that functionality in the new build_test script. build_test allows testing of ide builds (currently supports iar, uvision, and uv5) using progen. 

build_test examples:

builds blinky for iar and k64f
```
python build_test.py -i iar -t MBED_BLINKY -m K64F
```
build blinky and Hello World test for all targets on all (supported) ides
```
python build_test.py -t MBED_BLINKY MBED_10
```

builds all tests (current default is just blinky but you can specify more with -t) for all progen targets on all ides 
```
python build_test.py 
```

