### PR TITLE
fpu with single/double precision - bugfix and extension

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1,6 +1,7 @@
 {
     "Target": {
         "core": null,
+        "fpu": "none",
         "default_toolchain": "ARM",
         "supported_toolchains": null,
         "extra_labels": [],
@@ -28,7 +29,8 @@
     },
     "CM4F_UARM": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "public": false,
         "supported_toolchains": ["uARM"],
@@ -36,7 +38,8 @@
     },
     "CM4F_ARM": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "public": false,
         "supported_toolchains": ["ARM"]
     },
@@ -347,7 +350,8 @@
     },
     "LPC4088": {
         "inherits": ["LPCTarget"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "extra_labels": ["NXP", "LPC408X"],
         "is_disk_virtual": true,
         "supported_toolchains": ["ARM", "GCC_CR", "GCC_ARM", "IAR"],
@@ -363,7 +367,8 @@
     },
     "LPC4330_M4": {
         "inherits": ["LPCTarget"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "progen": {"target": "lpc4330"},
         "extra_labels": ["NXP", "LPC43XX", "LPC4330"],
         "supported_toolchains": ["ARM", "GCC_CR", "IAR", "GCC_ARM"],
@@ -378,7 +383,8 @@
     },
     "LPC4337": {
         "inherits": ["LPCTarget"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "progen": {"target": "lpc4337"},
         "extra_labels": ["NXP", "LPC43XX", "LPC4337"],
         "supported_toolchains": ["ARM"],
@@ -500,7 +506,8 @@
     },
     "K22F": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "KSDK2_MCUS", "FRDM", "KPSDK_MCUS", "KPSDK_CODE"],
         "is_disk_virtual": true,
@@ -526,7 +533,8 @@
     },
     "K64F": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "extra_labels": ["Freescale", "KSDK2_MCUS", "FRDM", "KPSDK_MCUS", "KPSDK_CODE", "MCU_K64F"],
         "is_disk_virtual": true,
@@ -539,7 +547,8 @@
     },
     "MTS_GAMBIT": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "GCC_ARM"],
         "extra_labels": ["Freescale", "KSDK2_MCUS", "K64F", "KPSDK_MCUS", "KPSDK_CODE", "MCU_K64F"],
         "is_disk_virtual": true,
@@ -549,7 +558,8 @@
     },
     "HEXIWEAR": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "extra_labels": ["Freescale", "KSDK2_MCUS", "K64F"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"],
@@ -646,7 +656,8 @@
     },
     "NUCLEO_F302R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F3", "STM32F302R8"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -658,7 +669,8 @@
     },
     "NUCLEO_F303K8": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F3", "STM32F303K8"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -670,7 +682,8 @@
     },
     "NUCLEO_F303RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F3", "STM32F303RE"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -682,7 +695,8 @@
     },
     "NUCLEO_F334R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F3", "STM32F334R8"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -694,7 +708,8 @@
     },
     "NUCLEO_F401RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F401RE"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
@@ -706,7 +721,8 @@
     },
     "NUCLEO_F410RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F410RB"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
@@ -718,7 +734,8 @@
     },
     "NUCLEO_F411RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
@@ -730,7 +747,8 @@
     },
     "ELMO_F411RE": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
@@ -752,15 +770,16 @@
     },
     "NUCLEO_F446RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
-        "default_toolchain": "uARM",
+        "core": "Cortex-M4",
+        "fpu": "single",
+        "default_toolchain": "ARM",
         "extra_labels": ["STM", "STM32F4", "STM32F446RE"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "inherits": ["Target"],
         "progen": {"target": "nucleo-f446re"},
         "detect_code": ["0777"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_build": "small"
+        "default_build": "standard"
     },
     "NUCLEO_F446ZE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -776,7 +795,8 @@
     },
     "B96B_F446VE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F446VE"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
@@ -787,7 +807,8 @@
     },
     "NUCLEO_F746ZG": {
         "inherits": ["Target"],
-        "core": "Cortex-M7F",
+        "core": "Cortex-M7",
+        "fpu": "single",
         "extra_labels": ["STM", "STM32F7", "STM32F746", "STM32F746ZG"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "default_toolchain": "ARM",
@@ -802,6 +823,18 @@
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["IPV4"]
     },
+    "NUCLEO_F767ZI": {
+        "inherits": ["Target"],
+        "core": "Cortex-M7",
+        "fpu": "double",
+        "extra_labels": ["STM", "STM32F7", "STM32F767", "STM32F767ZI"],
+        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
+        "default_toolchain": "ARM",
+        "progen": {"target": "nucleo-f767zi"},
+        "detect_code": ["0818"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "default_build": "standard"
+    },
     "NUCLEO_L011K4": {
         "inherits": ["Target"],
         "core": "Cortex-M0+",
@@ -812,17 +845,6 @@
         "detect_code": ["0780"],
         "progen": {"target":"nucleo-l011k4"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
-    },
-    "NUCLEO_F767ZI": {
-        "inherits": ["Target"],
-        "core": "Cortex-M7F_DP",
-        "extra_labels": ["STM", "STM32F7", "STM32F767", "STM32F767ZI"],
-        "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
-        "default_toolchain": "ARM",
-        "progen": {"target": "nucleo-f767zi"},
-        "detect_code": ["0818"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "default_build": "standard"
     },
     "NUCLEO_L031K6": {
         "inherits": ["Target"],
@@ -874,7 +896,8 @@
     },
     "NUCLEO_L432KC": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32L4", "STM32L432KC"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -885,7 +908,8 @@
     },
     "NUCLEO_L476RG": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32L4", "STM32L476RG"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -905,13 +929,15 @@
     },
     "STM32F407": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "extra_labels": ["STM", "STM32F4", "STM32F4XX"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"]
     },
     "ARCH_MAX": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
         "program_cycle_s": 2,
         "extra_labels": ["STM", "STM32F4", "STM32F407", "STM32F407VG"],
@@ -940,7 +966,8 @@
     },
     "DISCO_F303VC": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F3", "STM32F303", "STM32F303VC"],
         "supported_toolchains": ["GCC_ARM"],
@@ -949,7 +976,8 @@
     },
     "DISCO_F334C8": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F3", "STM32F334C8"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -960,7 +988,8 @@
     },
     "DISCO_F407VG": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "progen": {"target": "disco-f407vg"},
         "extra_labels": ["STM", "STM32F4", "STM32F407", "STM32F407VG"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM"],
@@ -968,7 +997,8 @@
     },
     "DISCO_F429ZI": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F429", "STM32F429ZI"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
@@ -978,7 +1008,8 @@
     },
     "DISCO_F469NI": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F469", "STM32F469NI"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -1000,7 +1031,8 @@
     },
     "DISCO_F746NG": {
         "inherits": ["Target"],
-        "core": "Cortex-M7F",
+        "core": "Cortex-M7",
+        "fpu": "single",
         "extra_labels": ["STM", "STM32F7", "STM32F746", "STM32F746NG"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "default_toolchain": "ARM",
@@ -1011,7 +1043,8 @@
     },
     "DISCO_L476VG": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32L4", "STM32L476VG"],
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
@@ -1022,7 +1055,8 @@
     },
     "MTS_MDOT_F405RG": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F405RG"],
         "is_disk_virtual": true,
@@ -1032,7 +1066,8 @@
     },
     "MTS_MDOT_F411RE": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
         "macros": ["HSE_VALUE=26000000", "OS_CLOCK=96000000", "USE_PLL_HSE_EXTC=0", "VECT_TAB_OFFSET=0x00010000"],
@@ -1045,7 +1080,8 @@
     },
     "MTS_DRAGONFLY_F411RE": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F411RE"],
         "macros": ["HSE_VALUE=26000000", "VECT_TAB_OFFSET=0x08010000"],
@@ -1069,7 +1105,8 @@
     },
     "DISCO_F401VC": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "GCC_ARM",
         "extra_labels": ["STM", "STM32F4", "STM32F401", "STM32F401VC"],
         "supported_toolchains": ["GCC_ARM"],
@@ -1078,7 +1115,8 @@
     },
     "UBLOX_C029": {
         "supported_form_factors": ["ARDUINO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "extra_labels": ["STM", "STM32F4", "STM32F439", "STM32F439ZI"],
@@ -1505,7 +1543,8 @@
     },
     "ARM_MPS2_M4": {
         "inherits": ["ARM_MPS2_Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "supported_toolchains": ["ARM"],
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M4"],
         "macros": ["CMSDK_CM4"],
@@ -1620,7 +1659,8 @@
     },
     "EFM32WG_STK3800": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "macros": ["EFM32WG990F256"],
         "extra_labels": ["Silicon_Labs", "EFM32"],
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
@@ -1658,7 +1698,8 @@
     },
     "EFM32PG_STK3401": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "macros": ["EFM32PG1B200F256GM48"],
         "extra_labels": ["Silicon_Labs", "EFM32"],
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM", "IAR"],

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -759,7 +759,8 @@
     },
     "NUCLEO_F429ZI": {
         "inherits": ["Target"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F429", "STM32F429ZI"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
@@ -783,7 +784,8 @@
     },
     "NUCLEO_F446ZE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
-        "core": "Cortex-M4F",
+        "core": "Cortex-M4",
+        "fpu": "single",
         "default_toolchain": "uARM",
         "extra_labels": ["STM", "STM32F4", "STM32F446ZE"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -815,7 +815,7 @@
     },
     "NUCLEO_F767ZI": {
         "inherits": ["Target"],
-        "core": "Cortex-M7F",
+        "core": "Cortex-M7F_DP",
         "extra_labels": ["STM", "STM32F7", "STM32F767", "STM32F767ZI"],
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "default_toolchain": "ARM",

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -22,10 +22,7 @@ CORE_LABELS = {
     "Cortex-M1" : ["M1", "CORTEX_M", "LIKE_CORTEX_M1"],
     "Cortex-M3" : ["M3", "CORTEX_M", "LIKE_CORTEX_M3"],
     "Cortex-M4" : ["M4", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M4"],
-    "Cortex-M4F" : ["M4", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M4"],
     "Cortex-M7" : ["M7", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M7"],
-    "Cortex-M7F" : ["M7", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M7"],
-    "Cortex-M7F_DP" : ["M7", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M7"],
     "Cortex-A9" : ["A9", "CORTEX_A", "LIKE_CORTEX_A9"]
 }
 

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -25,6 +25,7 @@ CORE_LABELS = {
     "Cortex-M4F" : ["M4", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M4"],
     "Cortex-M7" : ["M7", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M7"],
     "Cortex-M7F" : ["M7", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M7"],
+    "Cortex-M7F_DP" : ["M7", "CORTEX_M", "RTOS_M4_M7", "LIKE_CORTEX_M7"],
     "Cortex-A9" : ["A9", "CORTEX_A", "LIKE_CORTEX_A9"]
 }
 

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -216,11 +216,13 @@ class mbedToolchain:
         "Cortex-M1" : ["__CORTEX_M3", "ARM_MATH_CM1"],
         "Cortex-M3" : ["__CORTEX_M3", "ARM_MATH_CM3", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-M4" : ["__CORTEX_M4", "ARM_MATH_CM4", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M4F" : ["__CORTEX_M4", "ARM_MATH_CM4", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-M7" : ["__CORTEX_M7", "ARM_MATH_CM7", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M7F" : ["__CORTEX_M7", "ARM_MATH_CM7", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
-        "Cortex-M7F_DP" : ["__CORTEX_M7", "ARM_MATH_CM7", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-A9" : ["__CORTEX_A9", "ARM_MATH_CA9", "__FPU_PRESENT", "__CMSIS_RTOS", "__EVAL", "__MBED_CMSIS_RTOS_CA9"],
+    }
+    
+    CORTEX_FPU_SYMBOLS = {
+        "single" : ["__FPU_PRESENT=1"],
+        "double" : ["__FPU_PRESENT=1"],
     }
 
     GOANNA_FORMAT = "[Goanna] warning [%FILENAME%:%LINENO%] - [%CHECKNAME%(%SEVERITY%)] %MESSAGE%"
@@ -366,6 +368,8 @@ class mbedToolchain:
             # Cortex CPU symbols
             if self.target.core in mbedToolchain.CORTEX_SYMBOLS:
                 self.symbols.extend(mbedToolchain.CORTEX_SYMBOLS[self.target.core])
+            if self.target.fpu in mbedToolchain.CORTEX_FPU_SYMBOLS:
+                self.symbols.extend(mbedToolchain.CORTEX_FPU_SYMBOLS[self.target.fpu])
 
             # Symbols defined by the on-line build.system
             self.symbols.extend(['MBED_BUILD_TIMESTAMP=%s' % self.timestamp, 'TARGET_LIKE_MBED', '__MBED__=1'])

--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -219,6 +219,7 @@ class mbedToolchain:
         "Cortex-M4F" : ["__CORTEX_M4", "ARM_MATH_CM4", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-M7" : ["__CORTEX_M7", "ARM_MATH_CM7", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-M7F" : ["__CORTEX_M7", "ARM_MATH_CM7", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
+        "Cortex-M7F_DP" : ["__CORTEX_M7", "ARM_MATH_CM7", "__FPU_PRESENT=1", "__CMSIS_RTOS", "__MBED_CMSIS_RTOS_CM"],
         "Cortex-A9" : ["__CORTEX_A9", "ARM_MATH_CA9", "__FPU_PRESENT", "__CMSIS_RTOS", "__EVAL", "__MBED_CMSIS_RTOS_CA9"],
     }
 

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -47,11 +47,11 @@ class ARM(mbedToolchain):
 
         if target.core == "Cortex-M0+":
             cpu = "Cortex-M0"
-        elif target.core == "Cortex-M4F":
+        elif target.core == "Cortex-M4" and target.fpu == "single":
             cpu = "Cortex-M4.fp"
-        elif target.core == "Cortex-M7F":
+        elif target.core == "Cortex-M7" and target.fpu == "single":
             cpu = "Cortex-M7.fp.sp"
-        elif target.core == "Cortex-M7F_DP":
+        elif target.core == "Cortex-M7" and target.fpu == "double":
             cpu = "Cortex-M7.fp.dp"
         else:
             cpu = target.core

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -51,6 +51,8 @@ class ARM(mbedToolchain):
             cpu = "Cortex-M4.fp"
         elif target.core == "Cortex-M7F":
             cpu = "Cortex-M7.fp.sp"
+        elif target.core == "Cortex-M7F_DP":
+            cpu = "Cortex-M7.fp.dp"
         else:
             cpu = target.core
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -48,12 +48,6 @@ class GCC(mbedToolchain):
 
         if target.core == "Cortex-M0+":
             cpu = "cortex-m0plus"
-        elif target.core == "Cortex-M4F":
-            cpu = "cortex-m4"
-        elif target.core == "Cortex-M7F":
-            cpu = "cortex-m7"
-        elif target.core == "Cortex-M7F_DP":
-            cpu = "cortex-m7"
         else:
             cpu = target.core.lower()
 
@@ -61,15 +55,15 @@ class GCC(mbedToolchain):
         if target.core.startswith("Cortex"):
             self.cpu.append("-mthumb")
 
-        if target.core == "Cortex-M4F":
+        if target.core == "Cortex-M4" and target.fpu == "single":
             self.cpu.append("-mfpu=fpv4-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
 
-        elif target.core == "Cortex-M7F":
+        elif target.core == "Cortex-M7" and target.fpu == "single":
             self.cpu.append("-mfpu=fpv5-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
 
-        elif target.core == "Cortex-M7F_DP":
+        elif target.core == "Cortex-M7" and target.fpu == "double":
             self.cpu.append("-mfpu=fpv5-d16")
             self.cpu.append("-mfloat-abi=softfp")
 

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -52,6 +52,8 @@ class GCC(mbedToolchain):
             cpu = "cortex-m4"
         elif target.core == "Cortex-M7F":
             cpu = "cortex-m7"
+        elif target.core == "Cortex-M7F_DP":
+            cpu = "cortex-m7"
         else:
             cpu = target.core.lower()
 
@@ -62,7 +64,12 @@ class GCC(mbedToolchain):
         if target.core == "Cortex-M4F":
             self.cpu.append("-mfpu=fpv4-sp-d16")
             self.cpu.append("-mfloat-abi=softfp")
+
         elif target.core == "Cortex-M7F":
+            self.cpu.append("-mfpu=fpv5-sp-d16")
+            self.cpu.append("-mfloat-abi=softfp")
+
+        elif target.core == "Cortex-M7F_DP":
             self.cpu.append("-mfpu=fpv5-d16")
             self.cpu.append("-mfloat-abi=softfp")
 

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -47,28 +47,39 @@ class IAR(mbedToolchain):
 
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
         mbedToolchain.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
-        if target.core == "Cortex-M7F":
-            cpuchoice = "Cortex-M7"
-        else:
-            cpuchoice = target.core
+        cpuchoice = target.core
         # flags_cmd are used only by our scripts, the project files have them already defined,
         # using this flags results in the errors (duplication)
         # asm accepts --cpu Core or --fpu FPU, not like c/c++ --cpu=Core
-        asm_flags_cmd = [
-            "--cpu", cpuchoice
-        ]
+        if target.core == "Cortex-M4" and target.fpu == "single":
+          asm_flags_cmd = [
+              "--cpu", "Cortex-M4F"
+          ]
+        else:
+          asm_flags_cmd = [
+              "--cpu", cpuchoice
+          ]
         # custom c flags
-        c_flags_cmd = [
-            "--cpu", cpuchoice,
-            "--thumb", "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h")
-        ]
+        if target.core == "Cortex-M4" and target.fpu == "single":
+          c_flags_cmd = [
+              "--cpu", "Cortex-M4F",
+              "--thumb", "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h")
+          ]
+        else:
+          c_flags_cmd = [
+              "--cpu", cpuchoice,
+              "--thumb", "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h")
+          ]
         # custom c++ cmd flags
         cxx_flags_cmd = [
             "--c++", "--no_rtti", "--no_exceptions"
         ]
-        if target.core == "Cortex-M7F":
+        if target.core == "Cortex-M7" and target.fpu == "single":
             asm_flags_cmd += ["--fpu", "VFPv5_sp"]
             c_flags_cmd.append("--fpu=VFPv5_sp")
+        if target.core == "Cortex-M7" and target.fpu == "double":
+            asm_flags_cmd += ["--fpu", "VFPv5"]
+            c_flags_cmd.append("--fpu=VFPv5")
 
         if "debug-info" in self.options:
             c_flags_cmd.append("-r")


### PR DESCRIPTION
This is an continuative work of PR #1909 and is a suggestion to discuss the problem of two possible Cortex M7 variants: with single or with double precision fpu. 

- creating new core name Cortex_M7F_DP for targets with a double precision fpu
- adding new core name to arm.py to set compiler/linker flags to a double precision fpu when configured in target.json; current state: every Cortex_M7F is configured with single precision fpu
- up to now: gcc wrote flag for a double precision fpu -> target with STM32F746 crashes when using double variables - mcu has only single precision fpu
-changing gcc.py to use single precision for Cortex-M7F und double precision for Cortex_M7F_DP
tested with NUCLEO_F746, NUCLEO_F767 and build.py+make.py and exporting with project.py + compiling/flashing