### PR TITLE
SPI: Properly aquire peripheral in constructor

### DIFF
--- a/hal/common/SPI.cpp
+++ b/hal/common/SPI.cpp
@@ -36,8 +36,7 @@ SPI::SPI(PinName mosi, PinName miso, PinName sclk, PinName ssel) :
     // No lock needed in the constructor
 
     spi_init(&_spi, mosi, miso, sclk, ssel);
-    spi_format(&_spi, _bits, _mode, 0);
-    spi_frequency(&_spi, _hz);
+    aquire();
 }
 
 void SPI::format(int bits, int mode) {


### PR DESCRIPTION
Prevent mismatch between _owner and peripheral configuration. In the previous
implementation, the following code would leave the peripheral in an inconsistent
state:

```
SPI spi1(...);      // _owner is NULL, peripheral config is 1
spi1.transfer(...); // _owner is 1, config is 1
SPI spi2(...);      // _owner is 1, config is 2
spi1.transfer(...)  // 1 thinks it still owns peripheral, doesn't reconfigure
```

@0xc0170 