### PR TITLE
[STM32XX] Fix timer interrupt handler

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
@@ -51,8 +51,10 @@ void timer_update_irq_handler(void)
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 }
 
@@ -64,31 +66,35 @@ void timer_oc_irq_handler(void)
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cval; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -78,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -78,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
@@ -51,37 +51,43 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cval; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/hal_tick.c
@@ -52,37 +52,43 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cnt_val; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cnt_val; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
-#if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
-#endif
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+    #if 0 // For DEBUG only
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+    #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/hal_tick.c
@@ -44,23 +44,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if DEBUG_TICK > 0
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -78,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/hal_tick.c
@@ -80,9 +80,9 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
 	if ( SystemCoreClock == 16000000 ) { 
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 �s tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 us tick
 	} else {
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 �s tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 us tick
 	}
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -76,9 +80,9 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
 	if ( SystemCoreClock == 16000000 ) { 
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 µs tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
 	} else {
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 µs tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 ï¿½s tick
 	}
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/hal_tick.c
@@ -79,7 +79,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -75,7 +79,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -78,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/hal_tick.c
@@ -82,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -77,7 +82,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/hal_tick.c
@@ -44,23 +44,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if DEBUG_TICK > 0
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446ZE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446ZE/hal_tick.c
@@ -44,23 +44,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if DEBUG_TICK > 0
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/hal_tick.c
@@ -80,9 +80,9 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
 	if ( SystemCoreClock == 16000000 ) { 
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 �s tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 us tick
 	} else {
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 �s tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 us tick
 	}
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -76,9 +80,9 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
 	if ( SystemCoreClock == 16000000 ) { 
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 µs tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
 	} else {
-		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 µs tick
+		TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 2 / 1000000) - 1; // 1 ï¿½s tick
 	}
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/hal_tick.c
@@ -41,24 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }
@@ -75,7 +79,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 ï¿½s tick
 	  TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/hal_tick.c
@@ -79,7 +79,7 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period            = 0xFFFFFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)( SystemCoreClock / 1000000) - 1; // 1 us tick
 	  TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     TimMasterHandle.Init.RepetitionCounter = 0;

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/hal_tick.c
@@ -45,24 +45,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if DEBUG_TICK > 0
-            HAL_GPIO_TogglePin(GPIOG, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOG, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/hal_tick.c
@@ -45,24 +45,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if DEBUG_TICK > 0
-            HAL_GPIO_TogglePin(GPIOG, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOG, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F767ZI/hal_tick.c
@@ -45,24 +45,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if DEBUG_TICK > 0
-            HAL_GPIO_TogglePin(GPIOG, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOG, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/hal_tick.c
@@ -51,37 +51,43 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cval; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/hal_tick.c
@@ -51,8 +51,7 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET)
-        {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
             __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
             SlaveCounter++;
         }
@@ -60,8 +59,7 @@ void timer_irq_handler(void) {
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET)
-        {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
             __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
             if (oc_rem_part > 0) {
                 set_compare(oc_rem_part); // Finish the remaining time left
@@ -80,8 +78,7 @@ void timer_irq_handler(void) {
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET)
-        {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
             __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
             uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
             if ((val - PreviousVal) >= HAL_TICK_DELAY) {

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/hal_tick.c
@@ -51,37 +51,43 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cval; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/hal_tick.c
@@ -51,37 +51,43 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cval; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/hal_tick.c
@@ -51,37 +51,43 @@ void timer_irq_handler(void) {
 
     // Clear Update interrupt flag
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_UPDATE);
-        SlaveCounter++;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_UPDATE) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_UPDATE);
+            SlaveCounter++;
+        }
     }
 
     // Channel 1 for mbed timeout
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC1);
-        if (oc_rem_part > 0) {
-            set_compare(oc_rem_part); // Finish the remaining time left
-            oc_rem_part = 0;
-        } else {
-            if (oc_int_part > 0) {
-                set_compare(0xFFFF);
-                oc_rem_part = cval; // To finish the counter loop the next time
-                oc_int_part--;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            if (oc_rem_part > 0) {
+                set_compare(oc_rem_part); // Finish the remaining time left
+                oc_rem_part = 0;
             } else {
-                us_ticker_irq_handler();
+                if (oc_int_part > 0) {
+                    set_compare(0xFFFF);
+                    oc_rem_part = cval; // To finish the counter loop the next time
+                    oc_int_part--;
+                } else {
+                    us_ticker_irq_handler();
+                }
             }
         }
     }
 
     // Channel 2 for HAL tick
     if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
-        __HAL_TIM_CLEAR_FLAG(&TimMasterHandle, TIM_FLAG_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/hal_tick.c
@@ -41,23 +41,28 @@ void us_ticker_irq_handler(void);
 
 void timer_irq_handler(void) {
     // Channel 1 for mbed timeout
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC1) == SET) {
-        us_ticker_irq_handler();
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC1) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC1) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC1);
+            us_ticker_irq_handler();
+        }
     }
 
     // Channel 2 for HAL tick
-    if (__HAL_TIM_GET_ITSTATUS(&TimMasterHandle, TIM_IT_CC2) == SET) {
-        __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
-        uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
-        if ((val - PreviousVal) >= HAL_TICK_DELAY) {
-            // Increment HAL variable
-            HAL_IncTick();
-            // Prepare next interrupt
-            __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
-            PreviousVal = val;
+    if (__HAL_TIM_GET_FLAG(&TimMasterHandle, TIM_FLAG_CC2) == SET) {
+        if (__HAL_TIM_GET_IT_SOURCE(&TimMasterHandle, TIM_IT_CC2) == SET) {
+            __HAL_TIM_CLEAR_IT(&TimMasterHandle, TIM_IT_CC2);
+            uint32_t val = __HAL_TIM_GetCounter(&TimMasterHandle);
+            if ((val - PreviousVal) >= HAL_TICK_DELAY) {
+                // Increment HAL variable
+                HAL_IncTick();
+                // Prepare next interrupt
+                __HAL_TIM_SetCompare(&TimMasterHandle, TIM_CHANNEL_2, val + HAL_TICK_DELAY);
+                PreviousVal = val;
 #if 0 // For DEBUG only
-            HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
+                HAL_GPIO_TogglePin(GPIOB, GPIO_PIN_6);
 #endif
+            }
         }
     }
 }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/pwmout_api.c
@@ -266,7 +266,7 @@ void pwmout_period_us(pwmout_t* obj, int us) {
     SystemCoreClockUpdate();
 
     TimHandle.Init.Period        = us - 1;
-    TimHandle.Init.Prescaler     = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 µs tick
+    TimHandle.Init.Prescaler     = (uint16_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimHandle.Init.ClockDivision = 0;
     TimHandle.Init.CounterMode   = TIM_COUNTERMODE_UP;
     HAL_TIM_PWM_Init(&TimHandle);

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/us_ticker.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/us_ticker.c
@@ -180,7 +180,7 @@ void us_ticker_init(void) {
     // Configure time base
     TimMasterHandle.Instance = TIM_MST;
     TimMasterHandle.Init.Period        = 0xFFFF;
-    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 �s tick
+    TimMasterHandle.Init.Prescaler         = (uint32_t)(SystemCoreClock / 1000000) - 1; // 1 us tick
     TimMasterHandle.Init.ClockDivision     = 0;
     TimMasterHandle.Init.CounterMode       = TIM_COUNTERMODE_UP;
     HAL_TIM_Base_Init(&TimMasterHandle);

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/pwmout_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/pwmout_api.c
@@ -195,9 +195,9 @@ void pwmout_period_us(pwmout_t* obj, int us)
     TimHandle.Init.Period        = us - 1;
     // TIMxCLK = PCLKx when the APB prescaler = 1 else TIMxCLK = 2 * PCLKx
     if (APBxCLKDivider == RCC_HCLK_DIV1)
-      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq) / 1000000) - 1; // 1 µs tick
+      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq) / 1000000) - 1; // 1 us tick
     else
-      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq * 2) / 1000000) - 1; // 1 µs tick
+      TimHandle.Init.Prescaler   = (uint16_t)((PclkFreq * 2) / 1000000) - 1; // 1 us tick
     TimHandle.Init.ClockDivision = 0;
     TimHandle.Init.CounterMode   = TIM_COUNTERMODE_UP;
 


### PR DESCRIPTION
Some of the targets use only the flag and some other only the interrupt source to check which channel of the master timer has triggered an interrupt in an interrupt handler.

The flag can be set by hardware even if the interrupt is disable and two interrupt can be enable, for one triggered, in the same handler so we need a double check here.

The major issue is that some `interrupt_x` handler code can be execute even if the `interrupt_x` have been disable.

---

These commits make all of the st targets checking both int source and flag for the master timer.

---

Please merge this after these ones, I will rebase:
- [x] #2077 `NUCLEO_F429ZI`
- [x] #2039 `NUCLEO_F446ZE`