### PR TITLE
[NUCLEO_F303K8] fix MBED_16.

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/device.h
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/device.h
@@ -31,13 +31,7 @@
  */
 #ifndef MBED_DEVICE_H
 #define MBED_DEVICE_H
-
-
-
-
-
-
-
+#define DEVICE_RTC_LSI 1
 
 
 


### PR DESCRIPTION
On NUCLEO_F303K8, RTC clk is on LSI (no LSE connected)