### PR TITLE
Share test discovery logic

### DIFF
--- a/tools/test.py
+++ b/tools/test.py
@@ -31,7 +31,7 @@ from tools.options import get_default_options_parser
 from tools.build_api import build_project, build_library
 from tools.build_api import print_build_memory_usage_results
 from tools.targets import TARGET_MAP
-from tools.utils import mkdir, ToolException, NotSupportedException
+from tools.utils import mkdir, ToolException, NotSupportedException, args_error
 from tools.test_exporters import ReportExporter, ResultExporterType
 from utils import argparse_filestring_type, argparse_lowercase_type, argparse_many
 from tools.toolchains import mbedToolchain
@@ -95,6 +95,16 @@ if __name__ == '__main__':
 
         options = parser.parse_args()
 
+        if not options.mcu:
+            args_error(parser, "[ERROR] You should specify an MCU")
+
+        mcu = options.mcu[0]
+
+        if not options.tool:
+            args_error(parser, "[ERROR] You should specify a TOOLCHAIN")
+
+        toolchain = options.tool[0]
+
         # Filter tests by path if specified
         if options.paths:
             all_paths = options.paths
@@ -106,8 +116,8 @@ if __name__ == '__main__':
 
         # Find all tests in the relevant paths
         for path in all_paths:
-            all_tests.update(find_tests(path, options.mcu, options.tool, options.options))
-            
+            all_tests.update(find_tests(path, mcu, toolchain, options.options))
+
         # Filter tests by name if specified
         if options.names:
             all_names = options.names
@@ -150,16 +160,13 @@ if __name__ == '__main__':
             if not base_source_paths:
                 base_source_paths = ['.']
             
-            
-            target = options.mcu[0]
-            
             build_report = {}
             build_properties = {}
 
             library_build_success = False
             try:
                 # Build sources
-                build_library(base_source_paths, options.build_dir, target, options.tool[0],
+                build_library(base_source_paths, options.build_dir, mcu, toolchain,
                                                 options=options.options,
                                                 jobs=options.jobs,
                                                 clean=options.clean,
@@ -186,7 +193,7 @@ if __name__ == '__main__':
                 print "Failed to build library"
             else:
                 # Build all the tests
-                test_build_success, test_build = build_tests(tests, [options.build_dir], options.build_dir, target, options.tool[0],
+                test_build_success, test_build = build_tests(tests, [options.build_dir], options.build_dir, mcu, toolchain,
                         options=options.options,
                         clean=options.clean,
                         report=build_report,

--- a/tools/test.py
+++ b/tools/test.py
@@ -106,8 +106,8 @@ if __name__ == '__main__':
 
         # Find all tests in the relevant paths
         for path in all_paths:
-            all_tests.update(find_tests(path))
-
+            all_tests.update(find_tests(path, options.mcu, options.tool, options.options))
+            
         # Filter tests by name if specified
         if options.names:
             all_names = options.names

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -1974,7 +1974,6 @@ def get_default_test_options_parser():
                         help='Prints script version and exits')
     return parser
 
-
 def test_path_to_name(path):
     """Change all slashes in a path into hyphens
     This creates a unique cross-platform test name based on the path

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -58,8 +58,7 @@ from tools.build_api import create_result
 from tools.build_api import add_result_to_report
 from tools.build_api import scan_for_source_paths
 from tools.libraries import LIBRARIES, LIBRARY_MAP
-from tools.toolchains import TOOLCHAIN_BIN_PATH
-from tools.toolchains import TOOLCHAINS
+from tools.toolchains import TOOLCHAINS, TOOLCHAIN_BIN_PATH, TOOLCHAIN_CLASSES
 from tools.test_exporters import ReportExporter, ResultExporterType
 from tools.utils import argparse_filestring_type
 from tools.utils import argparse_uppercase_type
@@ -1975,6 +1974,7 @@ def get_default_test_options_parser():
                         help='Prints script version and exits')
     return parser
 
+
 def test_path_to_name(path):
     """Change all slashes in a path into hyphens
     This creates a unique cross-platform test name based on the path
@@ -1987,33 +1987,19 @@ def test_path_to_name(path):
 
     return "-".join(name_parts).lower()
 
-def find_tests(base_dir):
+def find_tests(base_dir, target, toolchain, options):
     """Given any directory, walk through the subdirectories and find all tests"""
 
-    def find_test_in_directory(directory, tests_path):
-        """Given a 'TESTS' directory, return a dictionary of test names and test paths.
-        The formate of the dictionary is {"test-name": "./path/to/test"}"""
-        test = None
-        if tests_path in directory:
-            head, test_case_directory = os.path.split(directory)
-            if test_case_directory != tests_path and test_case_directory != "host_tests":
-                head, test_group_directory = os.path.split(head)
-                if test_group_directory != tests_path and test_case_directory != "host_tests":
-                    test = {
-                        "name": test_path_to_name(directory),
-                        "path": directory
-                    }
+    # If the 'target' argument is a string, convert it to a target instance
+    target = TARGET_MAP[target]
+    toolchain = TOOLCHAIN_CLASSES[toolchain](target)
+    resources = toolchain.scan_resources(base_dir)
 
-        return test
-
-    tests_path = 'TESTS'
     tests = {}
-    dirs = scan_for_source_paths(base_dir)
 
-    for directory in dirs:
-        test = find_test_in_directory(directory, tests_path)
-        if test:
-            tests[test['name']] = test['path']
+    for directory in resources.test_directories:
+        test_name = test_path_to_name(directory)
+        tests[test_name] = directory
 
     return tests
 

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -83,6 +83,22 @@ def find_cmd_abspath(cmd):
             return abspath
 
 
+def directory_in_path(directory, path):
+    """ Returns True if `directory` is found within `path`.
+        Ex. directory_in_path("dir", "/is/dir/in/here") returns True
+        Ex. directory_in_path("dir", "/is/my_dir/in/here") returns False
+    """
+    head, tail = split(path)
+    
+    while tail:
+        if tail == directory:
+            return True
+        else:
+            head, tail = split(head)
+    
+    return False
+
+
 def mkdir(path):
     if not exists(path):
         makedirs(path)
@@ -138,6 +154,23 @@ def split_path(path):
     base, file = split(path)
     name, ext = splitext(file)
     return base, name, ext
+
+
+def is_test_directory(path):
+    """Given a path, return true if it is a test case directory.
+    Directory must follow this pattern: TESTS/testgroup/testcase. This
+    would return True."""
+    tests_path = 'TESTS'
+    if directory_in_path(tests_path, path):
+        head, test_case_directory = split(path)
+        if test_case_directory != tests_path and test_case_directory != "host_tests":
+            head, test_group_directory = split(head)
+            if test_group_directory != tests_path and test_case_directory != "host_tests":
+                head, candidate_tests_path = split(head)
+                if candidate_tests_path == tests_path:
+                    return True
+    
+    return False
 
 
 def args_error(parser, message):


### PR DESCRIPTION
This PR addresses #2104 by using the same scanning logic used in the toolchains to discover test cases. Previously this logic was partially duplicated here: https://github.com/mbedmicro/mbed/blob/master/tools/build_api.py#L956

Now tests under a `TARGET_`, `TOOLCHAIN_`, or `FEATURES_` directory should be correctly ignored.

### Breaking changes
`test.py` did not previously require the `-m` and `-t` arguments (because it was not necessary for listing tests). Both of these are now required, since the tests that are discovered are now dependent on the target and toolchain. This will break the `mbed test --compile-list` command at the moment and would require an update to mbed-cli.

Please review @screamerbg, @0xc0170 