### PR TITLE
[bugfix gcc_arm] build+make <-> export project+make: different results

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -108,7 +108,7 @@ class Exporter(object):
         return project_data
 
     def progen_gen_file(self, tool_name, project_data):
-        """" Generate project using ProGen Project API """
+        """ Generate project using ProGen Project API """
         settings = ProjectSettings()
         project = Project(self.program_name, [project_data], settings)
         # TODO: Fix this, the inc_dirs are not valid (our scripts copy files), therefore progen

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -285,13 +285,17 @@ class GCC_ARM(GCC):
 
         if use_nano:
             self.ld.append("--specs=nano.specs")
+            self.flags['ld'].append("--specs=nano.specs")
             self.cc += ["-DMBED_RTOS_SINGLE_THREAD"]
             self.cppc += ["-DMBED_RTOS_SINGLE_THREAD"]
+            self.macros.extend(["MBED_RTOS_SINGLE_THREAD"])
 
         if target.name in ["LPC1768", "LPC4088", "LPC4088_DM", "LPC4330", "UBLOX_C027", "LPC2368", "ARM_BEETLE_SOC"]:
             self.ld.extend(["-u _printf_float", "-u _scanf_float"])
+            self.flags['ld'].extend(["-u _printf_float", "-u _scanf_float"])
         elif target.name in ["RZ_A1H", "VK_RZ_A1H", "ARCH_MAX", "DISCO_F407VG", "DISCO_F429ZI", "DISCO_F469NI", "NUCLEO_F401RE", "NUCLEO_F410RB", "NUCLEO_F411RE", "NUCLEO_F429ZI", "NUCLEO_F446RE", "NUCLEO_F446ZE", "ELMO_F411RE", "MTS_MDOT_F411RE", "MTS_DRAGONFLY_F411RE", "DISCO_F746NG"]:
             self.ld.extend(["-u_printf_float", "-u_scanf_float"])
+            self.flags['ld'].extend(["-u_printf_float", "-u_scanf_float"])
 
         self.sys_libs.append("nosys")
 


### PR DESCRIPTION
Problem
----------
when in target.json ```"default_build": "small"``` is configured and GCC_ARM is used
- build.py+make.py
  - uses linker option --specs=nano.specs
  - macro MBED_RTOS_SINGLE_THREAD is defined
- exporting with project.py + make Makefile
  - doesn't use the linker option --specs=nano.specs
  - doesn't contain macro MBED_RTOS_SINGLE_THREAD

results with current master branch
----------------------------------

```
build.py -m NUCLEO_F303K8 -t GCC_ARM
make.py -m NUCLEO_F303K8 -t GCC_ARM -n MBED_BLINKY
```
Result:

| Module    | .text | .data | .bss |
|-----------|-------|-------|------|
| Fill      |    31 |     0 |    9 |
| Misc      | 12397 |   136 |  607 |
| Subtotals | 12428 |   136 |  616 |

```
project.py -m NUCLEO_F303K8 -i gcc_arm -n MBED_BLINKY -b
make
```
Result:
arm-none-eabi-size  MBED_BLINKY.elf
   text    data     bss     dec     hex filename
  30004    2212     676   32892    807c MBED_BLINKY.elf

```
project.py -m NUCLEO_F303K8 -i gcc_arm -n MBED_BLINKY
make
```
Result:
arm-none-eabi-size  MBED_BLINKY.elf
   text    data     bss     dec     hex filename
  29084    2220     756   32060    7d3c MBED_BLINKY.elf



results with with this PR
----------------------------------

```
build.py -m NUCLEO_F303K8 -t GCC_ARM
make.py -m NUCLEO_F303K8 -t GCC_ARM -n MBED_BLINKY
```
Result:

| Module    | .text | .data | .bss |
|-----------|-------|-------|------|
| Fill      |    31 |     0 |    9 |
| Misc      | 12397 |   136 |  607 |
| Subtotals | 12428 |   136 |  616 |

```
project.py -m NUCLEO_F303K8 -i gcc_arm -n MBED_BLINKY -b
make
```
Result:
arm-none-eabi-size  MBED_BLINKY.elf
   text    data     bss     dec     hex filename
  12396     136     616   13148    335c MBED_BLINKY.elf

```
project.py -m NUCLEO_F303K8 -i gcc_arm -n MBED_BLINKY
make
```
Result:
arm-none-eabi-size  MBED_BLINKY.elf
   text    data     bss     dec     hex filename
  11480     144     696   12320    3020 MBED_BLINKY.elf

