### PR TITLE
avoid Read-While-Write errors

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -218,13 +218,25 @@ extern volatile uint32_t *const kFCCOBx;
 #endif
 
 /**
- * @brief RAM resident memcpy.
+ * @brief RAM resident memcpy. This is needed to avoid read-while-write collision errors.
  *
  * If we require all functions involved in the erase and programming of flash to
  * be memory-resident (see the explanations around __RAMFUNC above), then we
  * need to provide our own version of memcpy().
  *
- * @Note 'n' should be a multiple of sizeof(uint32_t).
+ * @param _dest
+ *            The destination memory. Needs to be aligned to a uint32_t boundary.
+ * @param _src
+ *            The source memory. Needs to be aligned to a uint32_t boundary.
+ * @param n
+ *            The number of bytes to copy. Needs to be a multiple of sizeof(uint32_t).
+ *
+ * @Note For the sake of achieving a faster implementation than byte-wise copy,
+ *       we've chosen to iterate in units of uint32_t, so this destination
+ *       address  must be aligned to a 32-bit boundary, and 'n' should be a
+ *       multiple of sizeof(uint32_t). This is not a problem for this driver
+ *       because address and sizes will all be aligned at least to a
+ *       PROGRAM_PHRASE_SIZEOF_INLINE_DATA.
  */
 __RAMFUNC
 static void MEMCPY(void *_dest, const void *_src, size_t n)

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -126,7 +126,6 @@
 /*! @brief Access to FTFx->FCCOB */
 extern volatile uint32_t *const kFCCOBx;
 
-static flash_config_t privateDeviceConfig;
 #endif /* #ifdef USING_KSDK2 */
 
 /*
@@ -753,13 +752,6 @@ static int32_t initialize(ARM_Storage_Callback_t callback)
 
         return 1; /* synchronous completion. */
     }
-
-#ifdef USING_KSDK2
-    status_t rc = FLASH_Init(&privateDeviceConfig);
-    if (rc != kStatus_FLASH_Success) {
-        return ARM_DRIVER_ERROR;
-    }
-#endif /* ifdef USING_KSDK2 */
 
     if (controllerCurrentlyBusy()) {
         /* The user cannot initiate any further FTFE commands until notified that the

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -611,7 +611,6 @@ static int32_t executeCommand(void)
 
 static void ftfe_ccie_irq_handler(void)
 {
-    NVIC_ClearPendingIRQ(FTFE_IRQn);
     disbleCommandCompletionInterrupt();
 
     /* check for errors */


### PR DESCRIPTION
fixes configuration-store/#21: avoid Read-While-Write errors

Refer to https://github.com/ARMmbed/configuration-store/issues/21 for more
background information.

Read-while-write errors may occur when there is a read/fetch on a bank of
internal flash while an erase/program operation to the same bank is active.
A read/fetch against internal flash can arise arbitrarily from program activity.  

The possibility of read-while-write collision errors depends on the application's span
of internal-flash.

In the trivial (and also the default) case when this boundary is set to lie at
the junction between the two banks of internal flash (i.e. BLOCK1_START_ADDR),
there is *no* possibility of read-while-write. In the more common case, when
the system doesn't reserve all of BLOCK1 for the flash driver, there exists
the possibility of read-while-write.

To avoid this problem for the common case (above), we enforce the following:

  - Force synchronous mode of execution in the storage_driver.
  - Disable interrupts during erase/program operations. This prevents the
    execution of arbitrary user-code which might access flash.
  - Ensure all code and data structures used in the storage driver execute
    out of RAM. Refer to __RAMFUNC which allows for this.

We assume that the build-time parameter `CONFIG_HARDWARE_MTD_START_ADDR` is the boundary between application and this driver. User needs to define this parameter to a value that lies *after* the end of their application's use of internal flash. This is important.
`CONFIG_HARDWARE_MTD_SIZE` may also need to be updated if `CONFIG_HARDWARE_MTD_START_ADDR` is set.

please review: @kjbracey-arm [you need to review only the commit 7810829; other commits are generic]
cc: @simonqhughes @meriac 

notify: @marcuschangarm @LiyouZhou
