### PR TITLE
Modify the timing at which mbed_main() is called in IAR compiler.

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
+++ b/rtos/rtx/TARGET_CORTEX_A/RTX_CM_lib.h
@@ -523,12 +523,15 @@ extern __weak void __iar_init_core( void );
 extern __weak void __iar_init_vfp( void );
 extern void __iar_dynamic_initialization(void);
 extern void mbed_sdk_init(void);
+extern void mbed_main(void);
+extern int main(void);
 static uint8_t low_level_init_needed;
 
 void pre_main(void) {
     if (low_level_init_needed) {
         __iar_dynamic_initialization();
     }
+    mbed_main();
     main();
 }
 


### PR DESCRIPTION
Hi

Renesas modified the timing at which mbed_main() is called in IAR compiler.
Because we failed about test "mbed call before main" in IAR compiler.
Ref:https://github.com/mbedmicro/mbed/pull/2018#issuecomment-229236123

Regards,

Tomo Yamanaka