### PR TITLE
introduce a context structure to encompass global state in the K64F Storage driver

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -126,7 +126,6 @@
 /*! @brief Access to FTFx->FCCOB */
 extern volatile uint32_t *const kFCCOBx;
 
-static flash_config_t privateDeviceConfig;
 #endif /* #ifdef USING_KSDK2 */
 
 /*
@@ -753,13 +752,6 @@ static int32_t initialize(ARM_Storage_Callback_t callback)
 
         return 1; /* synchronous completion. */
     }
-
-#ifdef USING_KSDK2
-    status_t rc = FLASH_Init(&privateDeviceConfig);
-    if (rc != kStatus_FLASH_Success) {
-        return ARM_DRIVER_ERROR;
-    }
-#endif /* ifdef USING_KSDK2 */
 
     if (controllerCurrentlyBusy()) {
         /* The user cannot initiate any further FTFE commands until notified that the

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -611,7 +611,6 @@ static int32_t executeCommand(void)
 
 static void ftfe_ccie_irq_handler(void)
 {
-    NVIC_ClearPendingIRQ(FTFE_IRQn);
     disbleCommandCompletionInterrupt();
 
     /* check for errors */

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -174,16 +174,16 @@ struct mtd_k64f_data {
 static const ARM_STORAGE_BLOCK blockTable[] = {
     {
         /**< This is the start address of the flash block. */
-#ifdef CONFIG_HARDWARE_MTD_START_ADDR
-        .addr       = CONFIG_HARDWARE_MTD_START_ADDR,
+#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR
+        .addr       = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR,
 #else
         .addr       = BLOCK1_START_ADDR,
 #endif
 
         /**< This is the size of the flash block, in units of bytes.
          *   Together with addr, it describes a range [addr, addr+size). */
-#ifdef CONFIG_HARDWARE_MTD_SIZE
-        .size       = CONFIG_HARDWARE_MTD_SIZE,
+#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE
+        .size       = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE,
 #else
         .size       = BLOCK1_SIZE,
 #endif
@@ -205,7 +205,7 @@ static const ARM_DRIVER_VERSION version = {
 };
 
 
-#if (!defined(CONFIG_HARDWARE_MTD_ASYNC_OPS) || CONFIG_HARDWARE_MTD_ASYNC_OPS)
+#if (!defined(DEVICE_STORAGE_CONFIG_HARDWARE_MTD_ASYNC_OPS) || DEVICE_STORAGE_CONFIG_HARDWARE_MTD_ASYNC_OPS)
 #define ASYNC_OPS 1
 #else
 #define ASYNC_OPS 0
@@ -224,8 +224,8 @@ static const ARM_STORAGE_CAPABILITIES caps = {
     .asynchronous_ops = ASYNC_OPS,
 
     /* Enable chip-erase functionality if we own all of block-1. */
-    #if ((!defined (CONFIG_HARDWARE_MTD_START_ADDR) || (CONFIG_HARDWARE_MTD_START_ADDR == BLOCK1_START_ADDR)) && \
-         (!defined (CONFIG_HARDWARE_MTD_SIZE)       || (CONFIG_HARDWARE_MTD_SIZE == BLOCK1_SIZE)))
+    #if ((!defined (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR) || (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR == BLOCK1_START_ADDR)) && \
+         (!defined (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE)       || (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE == BLOCK1_SIZE)))
     .erase_all        = 1,    /**< Supports EraseChip operation. */
     #else
     .erase_all        = 0,    /**< Supports EraseChip operation. */
@@ -233,8 +233,8 @@ static const ARM_STORAGE_CAPABILITIES caps = {
 };
 
 static const ARM_STORAGE_INFO info = {
-#ifdef CONFIG_HARDWARE_MTD_SIZE
-    .total_storage        = CONFIG_HARDWARE_MTD_SIZE, /**< Total available storage, in units of octets. */
+#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE
+    .total_storage        = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE, /**< Total available storage, in units of octets. */
 #else
     .total_storage        = BLOCK1_SIZE, /**< Total available storage, in units of octets. By default, BLOCK0 is reserved to hold program code. */
 #endif


### PR DESCRIPTION
Together with other minor changes.
This will bring the state of the K64F driver to the point where we can submit a fix for the read-while-write issue in isolation.

@simonqhughes 

follows from https://github.com/mbedmicro/mbed/pull/2117