### PR TITLE
[STM32XX] Fix RTC minimum date

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/rtc_api.c
@@ -56,7 +56,7 @@ static void rtc_configure_time_and_date()
     mDate.WeekDay = 1;
     mDate.Month = 1;
     mDate.Date = 1;
-    mDate.Year = 1970;
+    mDate.Year = 2;
     if (HAL_RTC_SetDate(&RtcHandle, &mDate, RTC_FORMAT_BIN) != HAL_OK) {
         error("Date set failed\n");
     }
@@ -64,7 +64,7 @@ static void rtc_configure_time_and_date()
     mTime.Hours = 0;
     mTime.Minutes = 0;
     mTime.Seconds = 0;
-    mTime.TimeFormat = RTC_HOURFORMAT12_AM;
+    mTime.TimeFormat = RTC_HOURFORMAT_24;
     mTime.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     mTime.StoreOperation = RTC_STOREOPERATION_RESET;
     if (HAL_RTC_SetTime(&RtcHandle, &mTime, RTC_FORMAT_BIN) != HAL_OK) {
@@ -243,12 +243,7 @@ time_t rtc_read(void) {
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-#if DEVICE_LOWPOWERTIMER
-    //We need to add 52 to get the 1970 year
-    timeinfo.tm_year = dateStruct.Year + 52;
-#else
-    timeinfo.tm_year = dateStruct.Year + 100;
-#endif
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -273,11 +268,11 @@ void rtc_write(time_t t) {
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 
@@ -295,7 +290,7 @@ void rtc_set_alarm(struct tm *ti, uint32_t subsecs)
     mAlarm.AlarmTime.Minutes = ti->tm_min;
     mAlarm.AlarmTime.Seconds = ti->tm_sec;
     mAlarm.AlarmTime.SubSeconds = subsecs;
-    mAlarm.AlarmTime.TimeFormat = RTC_HOURFORMAT12_AM;
+    mAlarm.AlarmTime.TimeFormat = RTC_HOURFORMAT_24;
     mAlarm.AlarmMask = RTC_ALARMMASK_DATEWEEKDAY;
     mAlarm.AlarmSubSecondMask = RTC_ALARMSUBSECONDMASK_NONE;
     mAlarm.AlarmDateWeekDaySel = RTC_ALARMDATEWEEKDAYSEL_DATE;

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/rtc_api.c
@@ -159,7 +159,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -184,7 +184,7 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/rtc_api.c
@@ -178,7 +178,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -203,11 +203,11 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/rtc_api.c
@@ -178,7 +178,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -203,11 +203,11 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/rtc_api.c
@@ -178,7 +178,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -206,11 +206,11 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/rtc_api.c
@@ -190,7 +190,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -217,11 +217,11 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/rtc_api.c
@@ -189,7 +189,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -216,11 +216,11 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/rtc_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/rtc_api.c
@@ -191,7 +191,7 @@ time_t rtc_read(void)
     timeinfo.tm_wday = dateStruct.WeekDay;
     timeinfo.tm_mon  = dateStruct.Month - 1;
     timeinfo.tm_mday = dateStruct.Date;
-    timeinfo.tm_year = dateStruct.Year + 100;
+    timeinfo.tm_year = dateStruct.Year + 68;
     timeinfo.tm_hour = timeStruct.Hours;
     timeinfo.tm_min  = timeStruct.Minutes;
     timeinfo.tm_sec  = timeStruct.Seconds;
@@ -218,11 +218,11 @@ void rtc_write(time_t t)
     dateStruct.WeekDay        = timeinfo->tm_wday;
     dateStruct.Month          = timeinfo->tm_mon + 1;
     dateStruct.Date           = timeinfo->tm_mday;
-    dateStruct.Year           = timeinfo->tm_year - 100;
+    dateStruct.Year           = timeinfo->tm_year - 68;
     timeStruct.Hours          = timeinfo->tm_hour;
     timeStruct.Minutes        = timeinfo->tm_min;
     timeStruct.Seconds        = timeinfo->tm_sec;
-    timeStruct.TimeFormat     = RTC_HOURFORMAT12_PM;
+    timeStruct.TimeFormat     = RTC_HOURFORMAT_24;
     timeStruct.DayLightSaving = RTC_DAYLIGHTSAVING_NONE;
     timeStruct.StoreOperation = RTC_STOREOPERATION_RESET;
 


### PR DESCRIPTION
# Problem

- The `MBED_16` fail on `STM32F0` targets.
- None of the ST targets are able to `set_time(0) => year 1970` correctly.

# Fix

### STM32F0, STM32F3, STM32F4, STM32F7, STM32L0, STM32L1, STM32L4
They use a BCD format to store the date in the RTC. The year is store on 2 * 4 bits. Because the first year is reserved to see if the RTC is init, the supposed range is `01-99`. The idea is to cover the standard range from `1970` to `2038` (limited by the 32 bits of `time_t`).

The fix move the RTC range to match the standard one. The idea is to keep the year `1970` and the leap years synchronized. By moving it `68` years forward from `1970`, it become `1969-2067` which include `1970-2038`. `68` is also a multiple of `4` so it let the leap year synchronized. Between `1904` and `2096` there is a leap year every 4 years.

### STM32F1
They don't use a BCD format but a 32bit register for the seconds and a software structure to store dates. It should not be a problem to not use shifts.

# Test

I used the following code to test the fix.
``` c
#include "mbed.h"
#include "test_env.h"

#if !DEVICE_RTC
  #error [NOT_SUPPORTED] RTC is not supported
#endif

int main() {
    MBED_HOSTTEST_TIMEOUT(20);
    MBED_HOSTTEST_SELECT(st_rtc_min);
    MBED_HOSTTEST_DESCRIPTION(st_rtc_min);
    MBED_HOSTTEST_START("ST_RTC_MIN");
    
    struct tm timeinfo;
    time_t seconds = 0;
    char buffer[32] = {0};
    bool result = true;
    
    // test the minimum date
    // Set time to 1 Jan 1970 00:00:00
    timeinfo.tm_mon  = 0;
    timeinfo.tm_mday = 1;
    timeinfo.tm_year = 70;
    timeinfo.tm_hour = 0;
    timeinfo.tm_min  = 0;
    timeinfo.tm_sec  = 0;
    timeinfo.tm_isdst  = -1;
    set_time(mktime(&timeinfo));
    
    // Print the time
    seconds = time(NULL);
    strftime(buffer, 32, "%Y-%m-%d %H:%M:%S %p", localtime(&seconds));
    printf("MBED: [%ld] [%s]\r\n", seconds, buffer);
    
    if (strcmp(buffer,"1970-01-01 00:00:00 AM") != 0) {
      result = false;
    }
    
    // test the leap years
    // Set time to 28 Feb 2032 23:59:59
    timeinfo.tm_mon  = 1;
    timeinfo.tm_mday = 28;
    timeinfo.tm_year = 132;
    timeinfo.tm_hour = 23;
    timeinfo.tm_min  = 59;
    timeinfo.tm_sec  = 59;
    timeinfo.tm_isdst  = -1;
    set_time(mktime(&timeinfo));
    wait(1.1);
    
    // Print the time
    seconds = time(NULL);
    strftime(buffer, 32, "%Y-%m-%d %H:%M:%S %p", localtime(&seconds));
    printf("MBED: [%ld] [%s]\r\n", seconds, buffer);
    
    if (strcmp(buffer, "2032-02-29 00:00:00 AM") != 0) {
      result = false;
    }
    
    // test the maximum date
    // IAR use to fail on this one because his year 2038 bug seems to 
    // happen the 6 Feb 2036
    // Set time to 19 Jan 2038 03:14:00
    timeinfo.tm_mon  = 0;
    timeinfo.tm_mday = 19;
    timeinfo.tm_year = 138;
    timeinfo.tm_hour = 3;
    timeinfo.tm_min  = 14;
    timeinfo.tm_sec  = 0;
    timeinfo.tm_isdst  = -1;
    set_time(mktime(&timeinfo));
    wait(1.1);
    
    // Print the time
    seconds = time(NULL);
    strftime(buffer, 32, "%Y-%m-%d %H:%M:%S %p", localtime(&seconds));
    printf("MBED: [%ld] [%s]\r\n", seconds, buffer);
    
    if (strcmp(buffer, "2038-01-19 03:14:01 AM") != 0) {
      result = false;
    }
    
    notify_completion(result);
}
```

# Result

Target | toolchain | min date | max date
--- | --- | --- | ---
F0,F3,F4,F7,LX | uARM, ARM, GCC | 1 Jan 1969 | 19 Jan 2038
F0,F3,F4,F7,LX | IAR | 1 Jan 1969 | 6 Feb 2036
F1 | uARM, ARM, GCC | 13 Dec 1901 | 19 Jan 2038
F1 | IAR | 13 Dec 1901 | 6 Feb 2036