### PR TITLE
[STM32] Serial interrupt TC vs. TXE

### DIFF
--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/serial_api.c
@@ -771,7 +771,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             NVIC_EnableIRQ(irq_n);
 #endif
         } else { // TxIrq
-            __HAL_UART_ENABLE_IT(handle, UART_IT_TXE);
+            __HAL_UART_ENABLE_IT(handle, UART_IT_TC);
             NVIC_SetVector(irq_n, vector);
             NVIC_EnableIRQ(irq_n);
 #if DEVICE_SERIAL_ASYNCH_DMA
@@ -788,7 +788,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             // Check if TxIrq is disabled too
             if ((handle->Instance->CR1 & USART_CR1_TXEIE) == 0) all_disabled = 1;
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(handle, UART_IT_TXE);
+            __HAL_UART_DISABLE_IT(handle, UART_IT_TC);
             // Check if RxIrq is disabled too
             if ((handle->Instance->CR1 & USART_CR1_RXNEIE) == 0) all_disabled = 1;
         }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/serial_api.c
@@ -422,7 +422,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             // Check if TxIrq is disabled too
             if ((UartHandle.Instance->CR1 & USART_CR1_TXEIE) == 0) all_disabled = 1;
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TXE);
+            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TC);
             // Check if RxIrq is disabled too
             if ((UartHandle.Instance->CR1 & USART_CR1_RXNEIE) == 0) all_disabled = 1;
         }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/serial_api.c
@@ -341,7 +341,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             // Check if TxIrq is disabled too
             if ((UartHandle.Instance->CR1 & USART_CR1_TXEIE) == 0) all_disabled = 1;
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TXE);
+            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TC);
             // Check if RxIrq is disabled too
             if ((UartHandle.Instance->CR1 & USART_CR1_RXNEIE) == 0) all_disabled = 1;
         }

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/serial_api.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/serial_api.c
@@ -456,7 +456,7 @@ void serial_irq_set(serial_t *obj, SerialIrq irq, uint32_t enable)
             // Check if TxIrq is disabled too
             if ((UartHandle.Instance->CR1 & USART_CR1_TXEIE) == 0) all_disabled = 1;
         } else { // TxIrq
-            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TXE);
+            __HAL_UART_DISABLE_IT(&UartHandle, UART_IT_TC);
             // Check if RxIrq is disabled too
             if ((UartHandle.Instance->CR1 & USART_CR1_RXNEIE) == 0) all_disabled = 1;
         }


### PR DESCRIPTION
Reported in Issue #2119

There was some inconsistency in serial interrupt handling accross STM32
serial_api.c implementation. In case application wants to be notified of
Tx interrupt, it is mainly interested in transmission complete information,
which is the _TC interrupt.

The _TXE (Transmit Data REgister Empty) is used only within driver
in case SERIAL_ASYNCH is being supported to make the transmission
more efficient.