### PR TITLE
Fix issue #2124: IAR no rtos

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -545,7 +545,6 @@ extern "C" int __wrap_main(void) {
 // code will call a function to setup argc and argv (__iar_argc_argv) if it is defined.
 // Since mbed doesn't use argc/argv, we use this function to call our mbed_main.
 extern "C" void __iar_argc_argv() {
-    mbed_sdk_init();
     mbed_main();
 }
 #endif


### PR DESCRIPTION
Remove the 2nd call of mbed_sdk_init in __iar_argc_argv