### PR TITLE
Fixed typo in incr/decr function

### DIFF
--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -234,9 +234,9 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
 
 bool core_util_atomic_cas_ptr(void **ptr, void **expectedCurrentValue, void *desiredValue) {
     return core_util_atomic_cas_u32(
-            (uintptr_t *)ptr,
-            (uintptr_t *)expectedCurrentValue,
-            (uintptr_t)desiredValue);
+            (uint32_t *)ptr,
+            (uint32_t *)expectedCurrentValue,
+            (uint32_t)desiredValue);
 }
 
 uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
@@ -270,7 +270,7 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
 }
 
 void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return core_util_atomic_incr_u32((uintptr_t)valuePtr, (uintptr_t)delta);
+    return (void *)core_util_atomic_incr_u32((uint32_t *)valuePtr, (uint32_t)delta);
 }
 
 
@@ -305,7 +305,7 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
 }
 
 void *core_util_atomic_decr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return core_util_atomic_decr_u32((uintptr_t)valuePtr, (uintptr_t)delta);
+    return (void *)core_util_atomic_decr_u32((uint32_t *)valuePtr, (uint32_t)delta);
 }
 
 

--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -232,12 +232,6 @@ bool core_util_atomic_cas_u32(uint32_t *ptr, uint32_t *expectedCurrentValue, uin
     return success;
 }
 
-bool core_util_atomic_cas_ptr(void **ptr, void **expectedCurrentValue, void *desiredValue) {
-    return core_util_atomic_cas_u32(
-            (uint32_t *)ptr,
-            (uint32_t *)expectedCurrentValue,
-            (uint32_t)desiredValue);
-}
 
 uint8_t core_util_atomic_incr_u8(uint8_t *valuePtr, uint8_t delta)
 {
@@ -267,10 +261,6 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
     *valuePtr = newValue;
     core_util_critical_section_exit();
     return newValue;
-}
-
-void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return (void *)core_util_atomic_incr_u32((uint32_t *)valuePtr, (uint32_t)delta);
 }
 
 
@@ -304,10 +294,21 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
     return newValue;
 }
 
+#endif
+
+
+bool core_util_atomic_cas_ptr(void **ptr, void **expectedCurrentValue, void *desiredValue) {
+    return core_util_atomic_cas_u32(
+            (uint32_t *)ptr,
+            (uint32_t *)expectedCurrentValue,
+            (uint32_t)desiredValue);
+}
+
+void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta) {
+    return (void *)core_util_atomic_incr_u32((uint32_t *)valuePtr, (uint32_t)delta);
+}
+
 void *core_util_atomic_decr_ptr(void **valuePtr, ptrdiff_t delta) {
     return (void *)core_util_atomic_decr_u32((uint32_t *)valuePtr, (uint32_t)delta);
 }
-
-
-#endif
 

--- a/hal/common/critical.c
+++ b/hal/common/critical.c
@@ -270,7 +270,7 @@ uint32_t core_util_atomic_incr_u32(uint32_t *valuePtr, uint32_t delta)
 }
 
 void *core_util_atomic_incr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return core_util_atomic_incr((uintptr_t)valuePtr, (uintptr_t)delta);
+    return core_util_atomic_incr_u32((uintptr_t)valuePtr, (uintptr_t)delta);
 }
 
 
@@ -305,8 +305,9 @@ uint32_t core_util_atomic_decr_u32(uint32_t *valuePtr, uint32_t delta)
 }
 
 void *core_util_atomic_decr_ptr(void **valuePtr, ptrdiff_t delta) {
-    return core_util_atomic_decr((uintptr_t)valuePtr, (uintptr_t)delta);
+    return core_util_atomic_decr_u32((uintptr_t)valuePtr, (uintptr_t)delta);
 }
+
 
 #endif
 


### PR DESCRIPTION
Sorry about the breakage, a last minute change went unnoticed since it only created a warning on GCC.

for #2126