### PR TITLE
[KSDK2_MCUS] Fix I2C slave address

### DIFF
--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/i2c_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/i2c_api.c
@@ -233,7 +233,7 @@ int i2c_slave_write(i2c_t *obj, const char *data, int length) {
 }
 
 void i2c_slave_address(i2c_t *obj, int idx, uint32_t address, uint32_t mask) {
-    i2c_addrs[obj->instance]->A1 = ((uint32_t)(address)) << 1U;
+    i2c_addrs[obj->instance]->A1 = address & 0xfe;
 }
 #endif
 


### PR DESCRIPTION
I2C slave address on TARGET_KSDK2_MCUS is set as `(user_input_address | 1) << 1`.However, the bit shift is needless.So, this commit removes it.

(My mbed account is `mrks`.I have accepted `contributor_agreement`.)