### PR TITLE
Added flow control for K64F

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -579,7 +579,7 @@
         "inherits": ["Target"],
         "progen": {"target": "frdm-k64f"},
         "detect_code": ["0240"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "STORAGE"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "STORAGE"],
         "features": ["IPV4"],
         "release": true
     },
@@ -592,7 +592,7 @@
         "is_disk_virtual": true,
         "macros": ["CPU_MK64FN1M0VMD12", "FSL_RTOS_MBED", "TARGET_K64F"],
         "progen": {"target": "mts-gambit"},
-        "device_has": ["I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
+        "device_has": ["I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
     },
     "HEXIWEAR": {
         "inherits": ["Target"],
@@ -605,7 +605,7 @@
         "default_toolchain": "ARM",
         "detect_code": ["0214"],
         "progen": {"target": "hexiwear-k64f"},
-        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
+        "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "standard"
     },
     "NUCLEO_F030R8": {

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/TARGET_FRDM/PeripheralPins.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/TARGET_FRDM/PeripheralPins.c
@@ -112,6 +112,40 @@ const PinMap PinMap_UART_RX[] = {
     {NC  ,  NC    , 0}
 };
 
+const PinMap PinMap_UART_CTS[] = {
+    {PTB13, UART_3, 2},
+    {PTE2 , UART_1, 3},
+    {PTE6 , UART_3, 3},
+    {PTE26, UART_4, 3},
+    {PTA0 , UART_0, 2},
+    {PTA16, UART_0, 3},
+    {PTB3 , UART_0, 3},
+    {PTB9 , UART_3, 3},
+    {PTC2 , UART_1, 3},
+    {PTC13, UART_4, 3},
+    {PTC19, UART_3, 3},
+    {PTD1 , UART_2, 3},
+    {PTD5 , UART_0, 3},
+    {NC   , NC    , 0}
+};
+
+const PinMap PinMap_UART_RTS[] = {
+    {PTB12, UART_3, 2},
+    {PTE3 , UART_1, 3},
+    {PTE7 , UART_3, 3},
+    {PTE27, UART_4, 3},
+    {PTA17, UART_0, 3},
+    {PTB8 , UART_3, 3},
+    {PTC1 , UART_1, 3},
+    {PTC12, UART_4, 3},
+    {PTC18, UART_3, 3},
+    {PTD0 , UART_2, 3},
+    {PTD4 , UART_0, 3},
+    {PTA3 , UART_0, 2},
+    {PTB2 , UART_0, 3},
+    {NC   , NC    , 0}
+};
+
 /************SPI***************/
 const PinMap PinMap_SPI_SCLK[] = {
     {PTD1 , SPI_0, 2},

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/serial_api.c
@@ -288,24 +288,24 @@ void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, Pi
     switch(type) {
         case FlowControlRTS:
             pinmap_pinout(rxflow, PinMap_UART_RTS);
-            uart_addrs[obj->index]->MODEM &= ~UART_MODEM_TXRTSE_MASK;
+            uart_addrs[obj->index]->MODEM &= ~UART_MODEM_TXCTSE_MASK;
             uart_addrs[obj->index]->MODEM |= UART_MODEM_RXRTSE_MASK;
             break;
 
         case FlowControlCTS:
             pinmap_pinout(txflow, PinMap_UART_CTS);
             uart_addrs[obj->index]->MODEM &= ~UART_MODEM_RXRTSE_MASK;
-            uart_addrs[obj->index]->MODEM |= UART_MODEM_TXRTSE_MASK;
+            uart_addrs[obj->index]->MODEM |= UART_MODEM_TXCTSE_MASK;
             break;
 
         case FlowControlRTSCTS:
             pinmap_pinout(rxflow, PinMap_UART_RTS);
             pinmap_pinout(txflow, PinMap_UART_CTS);
-            uart_addrs[obj->index]->MODEM |= UART_MODEM_TXRTSE_MASK | UART_MODEM_RXRTSE_MASK;
+            uart_addrs[obj->index]->MODEM |= UART_MODEM_TXCTSE_MASK | UART_MODEM_RXRTSE_MASK;
             break;
 
         case FlowControlNone:
-            uart_addrs[obj->index]->MODEM &= ~(UART_MODEM_TXRTSE_MASK | UART_MODEM_RXRTSE_MASK);
+            uart_addrs[obj->index]->MODEM &= ~(UART_MODEM_TXCTSE_MASK | UART_MODEM_RXRTSE_MASK);
             break;
 
         default:

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/serial_api.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/serial_api.c
@@ -280,4 +280,37 @@ void serial_break_clear(serial_t *obj) {
     uart_addrs[obj->index]->C2 &= ~UART_C2_SBK_MASK;
 }
 
+/*
+ * Only hardware flow control is implemented in this API.
+ */
+void serial_set_flow_control(serial_t *obj, FlowControl type, PinName rxflow, PinName txflow)
+{
+    switch(type) {
+        case FlowControlRTS:
+            pinmap_pinout(rxflow, PinMap_UART_RTS);
+            uart_addrs[obj->index]->MODEM &= ~UART_MODEM_TXRTSE_MASK;
+            uart_addrs[obj->index]->MODEM |= UART_MODEM_RXRTSE_MASK;
+            break;
+
+        case FlowControlCTS:
+            pinmap_pinout(txflow, PinMap_UART_CTS);
+            uart_addrs[obj->index]->MODEM &= ~UART_MODEM_RXRTSE_MASK;
+            uart_addrs[obj->index]->MODEM |= UART_MODEM_TXRTSE_MASK;
+            break;
+
+        case FlowControlRTSCTS:
+            pinmap_pinout(rxflow, PinMap_UART_RTS);
+            pinmap_pinout(txflow, PinMap_UART_CTS);
+            uart_addrs[obj->index]->MODEM |= UART_MODEM_TXRTSE_MASK | UART_MODEM_RXRTSE_MASK;
+            break;
+
+        case FlowControlNone:
+            uart_addrs[obj->index]->MODEM &= ~(UART_MODEM_TXRTSE_MASK | UART_MODEM_RXRTSE_MASK);
+            break;
+
+        default:
+            break;
+    }
+}
+
 #endif

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/PeripheralPins.h
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/api/PeripheralPins.h
@@ -36,7 +36,8 @@ extern const PinMap PinMap_I2C_SCL[];
 /************UART***************/
 extern const PinMap PinMap_UART_TX[];
 extern const PinMap PinMap_UART_RX[];
-
+extern const PinMap PinMap_UART_CTS[];
+extern const PinMap PinMap_UART_RTS[];
 /************SPI***************/
 extern const PinMap PinMap_SPI_SCLK[];
 extern const PinMap PinMap_SPI_MOSI[];


### PR DESCRIPTION
This commit adds hardware flow control capabilities for the K64F family
of MCUs. This is a backport of these commits:

https://github.com/ARMmbed/mbed-hal-ksdk-mcu/commit/9bfcfd0572d1835a889779515a3b612262785a46
https://github.com/ARMmbed/mbed-hal-frdm-k64f/commit/77042cc9453c91957b04e9bd200a2dd928723e5a

with a few changes:

- since the current version of KSDK doesn't seem to have APIs for
  manipulating the flow control settings, we change the peripheral
  registers directly.
- updated pin maps for RTS/CTS in accordance to the K64F datasheet.