### PR TITLE
[tools-build,make,test] Disallow parent of repo as --build args

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -38,6 +38,7 @@ from tools.build_api import print_build_results
 from tools.settings import CPPCHECK_CMD, CPPCHECK_MSG_FORMAT
 from utils import argparse_filestring_type
 from tools.settings import CPPCHECK_CMD, CPPCHECK_MSG_FORMAT, CLI_COLOR_MAP
+from utils import argparse_filestring_type, argparse_dir_not_parent
 
 if __name__ == '__main__':
     start = time()
@@ -48,7 +49,7 @@ if __name__ == '__main__':
     parser.add_argument("--source", dest="source_dir", type=argparse_filestring_type,
                         default=None, help="The source (input) directory", action="append")
 
-    parser.add_argument("--build", dest="build_dir",
+    parser.add_argument("--build", dest="build_dir", type=argparse_dir_not_parent(ROOT),
                       default=None, help="The build (output) directory")
 
     parser.add_argument("--no-archive", dest="no_archive", action="store_true",

--- a/tools/make.py
+++ b/tools/make.py
@@ -45,6 +45,7 @@ from tools.build_api import build_project
 from tools.build_api import mcu_toolchain_matrix
 from utils import argparse_filestring_type
 from utils import argparse_many
+from utils import argparse_dir_not_parent
 from argparse import ArgumentTypeError
 from tools.toolchains import mbedToolchain
 from tools.settings import CLI_COLOR_MAP
@@ -112,7 +113,7 @@ if __name__ == '__main__':
                        default=None, help="The source (input) directory", action="append")
     parser.add_argument("--duration", type=int, dest="duration",
                       default=None, help="Duration of the test")
-    parser.add_argument("--build", dest="build_dir",
+    parser.add_argument("--build", dest="build_dir", type=argparse_dir_not_parent(ROOT),
                       default=None, help="The build (output) directory")
     parser.add_argument("-N", "--artifact-name", dest="artifact_name",
                       default=None, help="The built project's name")

--- a/tools/project.py
+++ b/tools/project.py
@@ -12,8 +12,9 @@ from tools.export import export, EXPORTERS, mcu_ide_matrix
 from tools.tests import TESTS, TEST_MAP
 from tools.tests import test_known, test_name_known
 from tools.targets import TARGET_NAMES
+from tools.libraries import LIBRARIES
 from utils import argparse_filestring_type, argparse_many
-from utils import argparse_force_lowercase_type, argparse_force_uppercase_type
+from utils import argparse_force_lowercase_type, argparse_force_uppercase_type, argparse_dir_not_parent
 from project_api import setup_project, perform_export, print_results, get_lib_symbols
 
 
@@ -59,6 +60,7 @@ if __name__ == '__main__':
                       dest="build",
                       action="store_true",
                       default=False,
+                        type=argparse_dir_not_parent(ROOT),
                       help="use the mbed library build, instead of the sources")
 
     group.add_argument("-L", "--list-tests",

--- a/tools/test.py
+++ b/tools/test.py
@@ -34,6 +34,7 @@ from tools.targets import TARGET_MAP
 from tools.utils import mkdir, ToolException, NotSupportedException
 from tools.test_exporters import ReportExporter, ResultExporterType
 from utils import argparse_filestring_type, argparse_lowercase_type, argparse_many
+from utils import argparse_dir_not_parent
 from tools.toolchains import mbedToolchain
 from tools.settings import CLI_COLOR_MAP
 
@@ -57,7 +58,7 @@ if __name__ == '__main__':
                           type=argparse_filestring_type,
                             default=None, help="The source (input) directory (for sources other than tests). Defaults to current directory.", action="append")
 
-        parser.add_argument("--build", dest="build_dir",
+        parser.add_argument("--build", dest="build_dir", type=argparse_dir_not_parent(ROOT),
                           default=None, help="The build (output) directory")
 
         parser.add_argument("-l", "--list", action="store_true", dest="list",

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -21,7 +21,7 @@ import argparse
 import math
 from os import listdir, remove, makedirs
 from shutil import copyfile
-from os.path import isdir, join, exists, split, relpath, splitext
+from os.path import isdir, join, exists, split, relpath, splitext, abspath, commonprefix
 from subprocess import Popen, PIPE, STDOUT, call
 import json
 from collections import OrderedDict
@@ -307,3 +307,14 @@ def columnate(strings, seperator=", ", chars=80):
             append = append.ljust(total_width)
         output += append
     return output
+
+# fail if argument provided is a parent of the specified directory
+def argparse_dir_not_parent(other):
+    def parse_type(not_parent):
+        abs_other = abspath(other)
+        abs_not_parent = abspath(not_parent)
+        if abs_not_parent == commonprefix([abs_not_parent, abs_other]):
+            raise argparse.ArgumentTypeError("{0} may not be a parent directory of {1}".format(not_parent, other))
+        else:
+            return not_parent
+    return parse_type


### PR DESCRIPTION
Resolves #2081 by making any parent of the repo (or the repo dir itself)
passed to --build fail at argument parsing time.