### PR TITLE
Add config option for stdio baud rate

### DIFF
--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -98,6 +98,9 @@ static void init_serial() {
 #if DEVICE_SERIAL
     if (stdio_uart_inited) return;
     serial_init(&stdio_uart, STDIO_UART_TX, STDIO_UART_RX);
+#if MBED_CONF_CORE_STDIO_BAUD_RATE
+    serial_baud(&stdio_uart, MBED_CONF_CORE_STDIO_BAUD_RATE);
+#endif
 #endif
 }
 

--- a/mbed_lib.json
+++ b/mbed_lib.json
@@ -4,6 +4,11 @@
         "stdio-convert-newlines": {
             "help": "Enable conversion to standard newlines on stdin/stdout",
             "value": false
+        },
+
+        "stdio-baud-rate": {
+            "help": "Baud rate for stdio",
+            "value": 9600
         }
     }
 }


### PR DESCRIPTION
Adds `core.stdio-baud-rate configuration` option. Defaults to 9600 for backwards compatibility. Mirrors the `core.stdio-convert-newlines` option.

This came up in an offline discussion again. The currently supported mechanism for changing baud rate is through the SerialBase::baud member function. This works great for implementing drivers, but has shown to be limiting for applications, where the owner of the serial connection is less well defined.

Previous discussions:
- https://github.com/mbedmicro/mbed/issues/1969
- https://github.com/mbedmicro/mbed/pull/1988
- https://github.com/ARMmbed/mbed-os/issues/449

cc @sg-, @bogdanm, @0xc0170 