### PR TITLE
Enable warnings for non-conforming c99/c++98 code

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -37,8 +37,8 @@ class GCC(mbedToolchain):
             "-MMD", "-fno-delete-null-pointer-checks", "-fomit-frame-pointer"
             ],
         'asm': ["-x", "assembler-with-cpp"],
-        'c': ["-std=gnu99"],
-        'cxx': ["-std=gnu++98", "-fno-rtti", "-Wvla"],
+        'c': ["-std=c99", "-pedantic"],
+        'cxx': ["-std=c++98", "-pedantic", "-fno-rtti"],
         'ld': ["-Wl,--gc-sections", "-Wl,--wrap,main",
             "-Wl,--wrap,_malloc_r", "-Wl,--wrap,_free_r", "-Wl,--wrap,_realloc_r"],
     }


### PR DESCRIPTION
This will help moving towards more strictly conforming code, which will help reduce problems with portability across compilers.

This pr is currently gcc only. If anyone knows the appropriate flags for armc5 or iar, let me know.

related: https://github.com/ARMmbed/mbed-os/issues/241

