### PR TITLE
More verrbose errors for JSON parsing

### DIFF
--- a/tools/utils.py
+++ b/tools/utils.py
@@ -196,8 +196,12 @@ def dict_to_ascii(input):
 # Read a JSON file and return its Python representation, transforming all the strings from Unicode
 # to ASCII. The order of keys in the JSON file is preserved.
 def json_file_to_dict(fname):
-    with open(fname, "rt") as f:
-        return dict_to_ascii(json.load(f, object_pairs_hook=OrderedDict))
+    try:
+        with open(fname, "rt") as f:
+            return dict_to_ascii(json.load(f, object_pairs_hook=OrderedDict))
+    except (ValueError, IOError):
+        sys.stderr.write("Error parsing '%s':\n" % fname)
+        raise
 
 # Wowza, double closure
 def argparse_type(casedness, prefer_hyphen=False) :


### PR DESCRIPTION
This commit adds information about the location of problematic JSON
files when reporting a JSON parsing error.

Before this commit:

```
[ERROR] Expecting property name: line 7 column 9 (char 188)
```

After this commit:

```
Error parsing 'core/mbed_lib.json':
[ERROR] Expecting property name: line 7 column 9 (char 188)
```