### PR TITLE
[Tools] Replace in memap CSV report fields

### DIFF
--- a/tools/memap.py
+++ b/tools/memap.py
@@ -436,16 +436,16 @@ class MemapParser(object):
                     csv_module_section += [i+k]
                     csv_sizes += [self.modules[i][k]]
 
-            csv_module_section += ['total_static_ram']
+            csv_module_section += ['static_ram']
             csv_sizes += [subtotal['.data']+subtotal['.bss']]
 
-            csv_module_section += ['allocated_heap']
+            csv_module_section += ['heap']
             if subtotal['.heap'] == 0:
                 csv_sizes += ['unknown']
             else:
                 csv_sizes += [subtotal['.heap']]
 
-            csv_module_section += ['allocated_stack']
+            csv_module_section += ['stack']
             if subtotal['.stack'] == 0:
                 csv_sizes += ['unknown']
             else:


### PR DESCRIPTION
## Changes
* This change is clean-up after #2047 (*Add memory usage summary for test building*)
* In code of memory usage summary columns were shortened and names changed a bit,
  see [here](https://github.com/mbedmicro/mbed/pull/2047/files?w=1#diff-f9cb941bde5647a5763e18fc220efc51R410)
  * Change was done to make columns not so wide for user.
  * This change did not propagate to JSON and CSV reports generated by memap script.
* There is a need to align memap CSV report fields (summary columns) with what
  is in code now. This discrepancy may create problems when generating reports
  in the future. All columns should have the same name.
* memap CSV summary fields names changes:
  * `total_static_ram` -> `static_ram`
  * `allocated_heap` -> `heap`
  * `allocated_stack` -> `stack`

See example of discrepancy:
* `total_static_ram` vs `static_ram`
* `allocated_heap` vs `heap`
* `allocated_stack` vs `stack`

## Current implementation outputs
What is in code and presented with prettytable:
```
+----------------------------------------+--------+-----------+------------+-------+-------+-----------+-------------+
| name                                   | target | toolchain | static_ram | stack |  heap | total_ram | total_flash |
+----------------------------------------+--------+-----------+------------+-------+-------+-----------+-------------+
| tests-mbed_drivers-c_strings           | K64F   | GCC_ARM   |      11468 | 32768 | 65540 |    109776 |       74182 |
| tests-mbed_drivers-callback            | K64F   | GCC_ARM   |      11980 | 32768 | 65540 |    110288 |       88406 |
| tests-mbedmicro-rtos-mbed-threads      | K64F   | GCC_ARM   |      11468 | 32768 | 65540 |    109776 |       75918 |
| tests-mbedmicro-rtos-mbed-timer        | K64F   | GCC_ARM   |      10788 | 32768 | 65540 |    109096 |       68534 |
+----------------------------------------+--------+-----------+------------+-------+-------+-----------+-------------+
```

vs CSV:

```
total_static_ram,allocated_heap,allocated_stack,total_ram,total_flash
10788,65540,32768,109096,67486
```

vs memstats_map.JSON:

```json
[
    {
        "module": "Fill",
        "size": {
            ".data": 4,
            ".bss": 2257,
            ".text": 173
        }
    },

    {
        "summary": {
            "total_flash": 67486,
            "allocated_stack": 32768,
            "total_static_ram": 10788,
            "total_ram": 109096,
            "allocated_heap": 65540
        }
    }
]
```