### PR TITLE
Change how the config system is used

### DIFF
--- a/hal/api/mbed.h
+++ b/hal/api/mbed.h
@@ -18,6 +18,9 @@
 
 #define MBED_LIBRARY_VERSION 121
 
+// Include the configuration data as early as possible
+#include "mbed_config.h"
+
 #include "toolchain.h"
 #include "platform.h"
 

--- a/tools/config.py
+++ b/tools/config.py
@@ -435,7 +435,7 @@ class Config:
     #          (as returned by get_config_data())
     @staticmethod
     def config_to_header(config, fname = None):
-        params, macros = config[0], config[1]
+        params, macros = (config[0], config[1]) if config else ({}, {})
         Config._check_required_parameters(params)
         header_data =  "// Automatically generated configuration file.\n"
         header_data += "// DO NOT EDIT, content will be overwritten.\n\n"

--- a/tools/export/atmelstudio.py
+++ b/tools/export/atmelstudio.py
@@ -33,8 +33,6 @@ class AtmelStudio(Exporter):
 
     DOT_IN_RELATIVE_PATH = True
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     def generate(self):
 
         source_files = []

--- a/tools/export/codered.py
+++ b/tools/export/codered.py
@@ -22,8 +22,6 @@ class CodeRed(Exporter):
     NAME = 'CodeRed'
     TOOLCHAIN = 'GCC_CR'
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     TARGETS = [
         'LPC1768',
         'LPC4088',

--- a/tools/export/emblocks.py
+++ b/tools/export/emblocks.py
@@ -31,8 +31,6 @@ class IntermediateFile(Exporter):
     # we support all GCC targets (is handled on IDE side)
     TARGETS = gccTargets
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     FILE_TYPES = {
         'headers': 'h',
         'c_sources': 'c',

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -36,7 +36,6 @@ class Exporter(object):
         self.extra_symbols = extra_symbols
         self.config_macros = []
         self.sources_relative = sources_relative
-        self.config_header = None
 
     def get_toolchain(self):
         return self.TOOLCHAIN
@@ -49,9 +48,6 @@ class Exporter(object):
     def progen_flags(self):
         if not hasattr(self, "_progen_flag_cache") :
             self._progen_flag_cache = dict([(key + "_flags", value) for key,value in self.flags.iteritems()])
-            if self.config_header:
-                self._progen_flag_cache['c_flags'] += self.toolchain.get_config_option(self.config_header)
-                self._progen_flag_cache['cxx_flags'] += self.toolchain.get_config_option(self.config_header)
         return self._progen_flag_cache
 
     def __scan_and_copy(self, src_path, trg_path):
@@ -166,20 +162,14 @@ class Exporter(object):
             # use the prj_dir (source, not destination)
             resources = self.toolchain.scan_resources(prj_paths[0])
             for path in prj_paths[1:]:
-                resources.add(toolchain.scan_resources(path))
+                resources.add(self.toolchain.scan_resources(path))
 
         # Loads the resources into the config system which might expand/modify resources based on config data
         self.resources = config.load_resources(resources)
 
+        # Generate configuration header
+        config.get_config_data_header(join(trg_path, self.toolchain.MBED_CONFIG_FILE_NAME))
 
-        if hasattr(self, "MBED_CONFIG_HEADER_SUPPORTED") and self.MBED_CONFIG_HEADER_SUPPORTED :
-            # Add the configuration file to the target directory
-            self.config_header = self.toolchain.MBED_CONFIG_FILE_NAME
-            config.get_config_data_header(join(trg_path, self.config_header))
-            self.config_macros = []
-        else :
-            # And add the configuration macros to the toolchain
-            self.config_macros = config.get_config_data_macros()
         # Check the existence of a binary build of the mbed library for the desired target
         # This prevents exporting the mbed libraries from source
         # if not self.toolchain.mbed_libs:

--- a/tools/export/gccarm.py
+++ b/tools/export/gccarm.py
@@ -128,8 +128,6 @@ class GccArm(Exporter):
 
     DOT_IN_RELATIVE_PATH = True
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     def generate(self):
         # "make" wants Unix paths
         if self.sources_relative:

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -33,8 +33,6 @@ class IAREmbeddedWorkbench(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     # backward compatibility with our scripts
     TARGETS = []
     for target in TARGET_NAMES:

--- a/tools/export/simplicityv3.py
+++ b/tools/export/simplicityv3.py
@@ -101,8 +101,6 @@ class SimplicityV3(Exporter):
 
     DOT_IN_RELATIVE_PATH = False
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     orderedPaths = Folder("Root")
 
     def check_and_add_path(self, path):

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -34,8 +34,6 @@ class Uvision4(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     # backward compatibility with our scripts
     TARGETS = []
     for target in TARGET_NAMES:

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -34,8 +34,6 @@ class Uvision5(Exporter):
     # PROGEN_ACTIVE contains information for exporter scripts that this is using progen
     PROGEN_ACTIVE = True
 
-    MBED_CONFIG_HEADER_SUPPORTED = True
-
     # backward compatibility with our scripts
     TARGETS = []
     for target in TARGET_NAMES:

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -116,15 +116,8 @@ class ARM(mbedToolchain):
         dep_path = base + '.d'
         return ["--depend", dep_path]
 
-    def get_config_option(self, config_header) :
-        return ['--preinclude=' + config_header]
-
     def get_compile_options(self, defines, includes):        
-        opts = ['-D%s' % d for d in defines] + ['--via', self.get_inc_file(includes)]
-        config_header = self.get_config_header()
-        if config_header is not None:
-            opts = opts + self.get_config_option(config_header)
-        return opts
+        return ['-D%s' % d for d in defines] + ['--via', self.get_inc_file(includes)]
 
     @hook_tool
     def assemble(self, source, object, includes):

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -166,15 +166,8 @@ class GCC(mbedToolchain):
         dep_path = base + '.d'
         return ["-MD", "-MF", dep_path]
 
-    def get_config_option(self, config_header):
-        return ['-include', config_header]
-
     def get_compile_options(self, defines, includes):
-        opts = ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
-        config_header = self.get_config_header()
-        if config_header is not None:
-            opts = opts + self.get_config_option(config_header)
-        return opts
+        return ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
 
     @hook_tool
     def assemble(self, source, object, includes):

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -137,26 +137,13 @@ class IAR(mbedToolchain):
         base, _ = splitext(object)
         return ["-l", base + '.s.txt']
 
-    def get_config_option(self, config_header):
-        return ['--preinclude=' + config_header]
-
-    def get_compile_options(self, defines, includes, for_asm=False):
-        opts = ['-D%s' % d for d in defines] + ['-f', self.get_inc_file(includes)]
-        config_header = self.get_config_header()
-        if for_asm:
-            # The assembler doesn't support '--preinclude', so we need to add
-            # the macros directly
-            opts = opts + ['-D%s' % d for d in self.get_config_macros()]
-        else:
-            config_header = self.get_config_header()
-            if config_header is not None:
-                opts = opts + self.get_config_option(config_header)
-        return opts
+    def get_compile_options(self, defines, includes):
+        return ['-D%s' % d for d in defines] + ['-f', self.get_inc_file(includes)]
 
     @hook_tool
     def assemble(self, source, object, includes):
         # Build assemble command
-        cmd = self.asm + self.get_compile_options(self.get_symbols(), includes, for_asm=True) + ["-o", object, source]
+        cmd = self.asm + self.get_compile_options(self.get_symbols(), includes) + ["-o", object, source]
 
         # Call cmdline hook
         cmd = self.hook.get_cmdline_assembler(cmd)


### PR DESCRIPTION
This commit address the issue presented in
https://github.com/mbedmicro/mbed/issues/2073. Previously, mbed_config.h
was automatically included by the toolchain. With this change, all the
sources that need "mbed_config.h" need to include it manually. However,
"mbed.h" now includes "mbed_config.h", so configuration data is
automatically available to sources that include "mbed.h".

With this change, even if there's no configuration data in the project
being built, an empty "mbed_config.h" is generated by the build system.

This change looks big, but most of it is an almost complete reversal of
https://github.com/mbedmicro/mbed/pull/1975.

This is likely a breaking change, and needs to be properly
communicated.