### PR TITLE
Remove ldrex and strex from RTOS with ARMCC

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
@@ -40,7 +40,9 @@
 
 #if defined (__CC_ARM)          /* ARM Compiler */
 
-#if ((__TARGET_ARCH_7_M || __TARGET_ARCH_7E_M) && !defined(NO_EXCLUSIVE_ACCESS))
+// ARMCC has deprecated use for ldrex and strex functions
+// from C so do not used them on any devices.
+#if (0)
  #define __USE_EXCLUSIVE_ACCESS
 #else
  #undef  __USE_EXCLUSIVE_ACCESS

--- a/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
@@ -41,7 +41,9 @@
 
 #if defined (__CC_ARM)          /* ARM Compiler */
 
-#if ((defined(__TARGET_ARCH_7_M) || defined(__TARGET_ARCH_7E_M)) && !defined(NO_EXCLUSIVE_ACCESS))
+// ARMCC has deprecated use for ldrex and strex functions
+// from C so do not used them on any devices.
+#if (0)
  #define __USE_EXCLUSIVE_ACCESS
 #else
  #undef  __USE_EXCLUSIVE_ACCESS


### PR DESCRIPTION
ARMCC has marked the __strex and __strex intrinsics as deprecated so
turn them off for this compiler.