### PR TITLE
[tools-build.py]Enforce supported toolchains

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -231,52 +231,54 @@ if __name__ == '__main__':
         for toolchain in toolchains:
             for target in targets:
                 tt_id = "%s::%s" % (toolchain, target)
-                try:
-                    mcu = TARGET_MAP[target]
-                    if options.source_dir:
-                        lib_build_res = build_library(options.source_dir, options.build_dir, mcu, toolchain,
-                                                    options=options.options,
-                                                    extra_verbose=options.extra_verbose_notify,
-                                                    notify=notify,
-                                                    verbose=options.verbose,
-                                                    silent=options.silent,
-                                                    jobs=options.jobs,
-                                                    clean=options.clean,
-                                                    archive=(not options.no_archive),
-                                                    macros=options.macros,
-                                                    name=options.artifact_name)
-                    else:
-                        lib_build_res = build_mbed_libs(mcu, toolchain,
-                                                    options=options.options,
-                                                    extra_verbose=options.extra_verbose_notify,
-                                                    notify=notify,
-                                                    verbose=options.verbose,
-                                                    silent=options.silent,
-                                                    jobs=options.jobs,
-                                                    clean=options.clean,
-                                                    macros=options.macros)
+                if toolchain not in TARGET_MAP[target].supported_toolchains:
+                    # Log this later
+                    print "%s skipped: toolchain not supported" % tt_id
+                    skipped.append(tt_id)
+                else:
+                    try:
+                        mcu = TARGET_MAP[target]
+                        if options.source_dir:
+                            lib_build_res = build_library(options.source_dir, options.build_dir, mcu, toolchain,
+                                                        options=options.options,
+                                                        extra_verbose=options.extra_verbose_notify,
+                                                        verbose=options.verbose,
+                                                        silent=options.silent,
+                                                        jobs=options.jobs,
+                                                        clean=options.clean,
+                                                        archive=(not options.no_archive),
+                                                        macros=options.macros,
+                                                        name=options.artifact_name)
+                        else:
+                            lib_build_res = build_mbed_libs(mcu, toolchain,
+                                                        options=options.options,
+                                                        extra_verbose=options.extra_verbose_notify,
+                                                        verbose=options.verbose,
+                                                        silent=options.silent,
+                                                        jobs=options.jobs,
+                                                        clean=options.clean,
+                                                        macros=options.macros)
 
-                    for lib_id in libraries:
-                        build_lib(lib_id, mcu, toolchain,
-                                  options=options.options,
-                                  extra_verbose=options.extra_verbose_notify,
-                                  notify=notify,
-                                  verbose=options.verbose,
-                                  silent=options.silent,
-                                  clean=options.clean,
-                                  macros=options.macros,
-                                  jobs=options.jobs)
-                    if lib_build_res:
-                        successes.append(tt_id)
-                    else:
-                        skipped.append(tt_id)
-                except Exception, e:
-                    if options.verbose:
-                        import traceback
-                        traceback.print_exc(file=sys.stdout)
-                        sys.exit(1)
-                    failures.append(tt_id)
-                    print e
+                        for lib_id in libraries:
+                            build_lib(lib_id, mcu, toolchain,
+                                    options=options.options,
+                                    extra_verbose=options.extra_verbose_notify,
+                                    verbose=options.verbose,
+                                    silent=options.silent,
+                                    clean=options.clean,
+                                    macros=options.macros,
+                                    jobs=options.jobs)
+                        if lib_build_res:
+                            successes.append(tt_id)
+                        else:
+                            skipped.append(tt_id)
+                    except Exception, e:
+                        if options.verbose:
+                            import traceback
+                            traceback.print_exc(file=sys.stdout)
+                            sys.exit(1)
+                        failures.append(tt_id)
+                        print e
 
     # Write summary of the builds
     print


### PR DESCRIPTION
by skipping unsupported combinations

before:
```
$ python tools/build.py -t IAR -m NRF51_DK --source . --build build
[SNIP]
Compile: us_ticker.c
  #error Compiler not supported.
   ^
"Z:\home\jimbri01\src\mbedmicro\mbed\hal\targets\hal\TARGET_NORDIC\TARGET_MCU_NRF51822\us_ticker.c",382  Fatal error[Pe035]: #error directive: Compiler not supported.
Fatal error detected, aborting.

  #error Compiler not supported.
   ^
"Z:\home\jimbri01\src\mbedmicro\mbed\hal\targets\hal\TARGET_NORDIC\TARGET_MCU_NRF51822\us_ticker.c",382  Fatal error[Pe035]: #error directive: Compiler not supported.
Fatal error detected, aborting.


Completed in: (8.96)s

Build failures:
  * IAR::NRF51_DK
```
after:
```
$ python tools/build.py -t IAR -m NRF51_DK --source . --build build
IAR::NRF51_DK skipped: toolchain not supported

Completed in: (0.00)s

Build skipped:
  * IAR::NRF51_DK
```