### PR TITLE
[tools/build_api] Retrun truthy value on success from build_*

### DIFF
--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -396,6 +396,7 @@ def build_library(src_paths, build_path, target, toolchain_name,
             cur_result["result"] = "OK"
 
             add_result_to_report(report, cur_result)
+        return True
 
     except Exception, e:
         if report != None:
@@ -540,6 +541,7 @@ def build_lib(lib_id, target, toolchain_name, options=None, verbose=False, clean
             cur_result["result"] = "OK"
 
             add_result_to_report(report, cur_result)
+        return True
 
     except Exception, e:
         if report != None:


### PR DESCRIPTION
before:
```
$  python tools/build.py  -m NRF51_DK --source . -t GCC_ARM,ARM --build build --silent
[SNIP]
Completed in: (3.39)s

Build skipped:
  * GCC_ARM::NRF51_DK
  * ARM::NRF51_DK

```
after:
```
$  python tools/build.py  -m NRF51_DK --source . -t GCC_ARM,ARM --build build --silent
[SNIP]
Completed in: (3.43)s

Build successes:
  * GCC_ARM::NRF51_DK
  * ARM::NRF51_DK

```