### PR TITLE
Exporters - progen TARGETS lazy evaluated

### DIFF
--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -35,16 +35,19 @@ class IAREmbeddedWorkbench(Exporter):
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 
-    # backward compatibility with our scripts
-    TARGETS = []
-    for target in TARGET_NAMES:
-        try:
-            if (ProGenDef('iar').is_supported(str(TARGET_MAP[target])) or
-                ProGenDef('iar').is_supported(TARGET_MAP[target].progen['target'])):
-                TARGETS.append(target)
-        except AttributeError:
-            # target is not supported yet
-            continue
+    @property
+    def TARGETS(self):
+        if not hasattr(self, "_targets_supported"):
+            self._targets_supported = []
+            for target in TARGET_NAMES:
+                try:
+                    if (ProGenDef('iar').is_supported(str(TARGET_MAP[target])) or
+                        ProGenDef('iar').is_supported(TARGET_MAP[target].progen['target'])):
+                        self._targets_supported.append(target)
+                except AttributeError:
+                    # target is not supported yet
+                    continue
+        return self._targets_supported
 
     def generate(self):
         """ Generates the project files """

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -36,16 +36,19 @@ class Uvision4(Exporter):
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 
-    # backward compatibility with our scripts
-    TARGETS = []
-    for target in TARGET_NAMES:
-        try:
-            if (ProGenDef('uvision').is_supported(str(TARGET_MAP[target])) or
-                ProGenDef('uvision').is_supported(TARGET_MAP[target].progen['target'])):
-                TARGETS.append(target)
-        except AttributeError:
-            # target is not supported yet
-            continue
+    @property
+    def TARGETS(self):
+        if not hasattr(self, "_targets_supported"):
+            self._targets_supported = []
+            for target in TARGET_NAMES:
+                try:
+                    if (ProGenDef('uvision').is_supported(str(TARGET_MAP[target])) or
+                        ProGenDef('uvision').is_supported(TARGET_MAP[target].progen['target'])):
+                        self._targets_supported.append(target)
+                except AttributeError:
+                    # target is not supported yet
+                    continue
+        return self._targets_supported
 
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -37,15 +37,22 @@ class Uvision5(Exporter):
     MBED_CONFIG_HEADER_SUPPORTED = True
 
     # backward compatibility with our scripts
-    TARGETS = []
-    for target in TARGET_NAMES:
-        try:
-            if (ProGenDef('uvision5').is_supported(str(TARGET_MAP[target])) or
-                ProGenDef('uvision5').is_supported(TARGET_MAP[target].progen['target'])):
-                TARGETS.append(target)
-        except AttributeError:
-            # target is not supported yet
-            continue
+    def __init__(self):
+        self._targets = []
+
+    @property
+    def TARGETS(self):
+        if not hasattr(self, "_targets_supported"):
+            self._targets_supported = []
+            for target in TARGET_NAMES:
+                try:
+                    if (ProGenDef('uvision5').is_supported(str(TARGET_MAP[target])) or
+                        ProGenDef('uvision5').is_supported(TARGET_MAP[target].progen['target'])):
+                        self._targets_supported.append(target)
+                except AttributeError:
+                    # target is not supported yet
+                    continue
+        return self._targets_supported
 
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain


### PR DESCRIPTION
To speed up project.py, use @property for TARGETS.

When exporters are used, it would ask progen for support for all targets
(number of tools x number of targets).
```
Profiling:

Before the change:
       1    0.000    0.000    0.010    0.010 definitions.py:113(get_tool_definition)
      824    0.004    0.000    2.990    0.004 definitions.py:124(is_supported)
        1    0.000    0.000    0.000    0.000 definitions.py:145(get_debugger)
        1    0.002    0.002    0.044    0.044 definitions.py:15(<module>)
      384    0.002    0.000    2.986    0.008 definitions.py:26(_load_record)
        1    0.000    0.000    0.000    0.000 definitions.py:32(ProGenMcus)
      992    0.055    0.000    1.959    0.002 definitions.py:34(__init__)
     1376    0.002    0.000    0.003    0.000 definitions.py:40(get_mcus)
      384    0.001    0.000    1.070    0.003 definitions.py:43(get_mcu_record)
        1    0.000    0.000    0.000    0.000 definitions.py:50(ProGenTargets)
      992    0.000    0.000    0.000    0.000 definitions.py:52(__init__)
     1196    0.002    0.000    0.004    0.000 definitions.py:55(get_targets)
      204    0.001    0.000    1.922    0.009 definitions.py:58(get_mcu_record)
        1    0.000    0.000    0.000    0.000 definitions.py:67(get_debugger)
        1    0.000    0.000    0.000    0.000 definitions.py:74(ProGenDef)
      992    0.008    0.000    1.973    0.002 definitions.py:83(__init__)

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 4
Milliseconds      : 723
Ticks             : 47237302
TotalDays         : 5.46728032407407E-05
TotalHours        : 0.00131214727777778
TotalMinutes      : 0.0787288366666667
TotalSeconds      : 4.7237302
TotalMilliseconds : 4723.7302

After the change:

        1    0.000    0.000    0.010    0.010 definitions.py:113(get_tool_definition)
        2    0.000    0.000    0.025    0.012 definitions.py:124(is_supported)
        1    0.000    0.000    0.000    0.000 definitions.py:145(get_debugger)
        1    0.002    0.002    0.042    0.042 definitions.py:15(<module>)
        3    0.000    0.000    0.035    0.012 definitions.py:26(_load_record)
        1    0.000    0.000    0.000    0.000 definitions.py:32(ProGenMcus)
        2    0.000    0.000    0.005    0.002 definitions.py:34(__init__)
        5    0.000    0.000    0.000    0.000 definitions.py:40(get_mcus)
        3    0.000    0.000    0.000    0.000 definitions.py:43(get_mcu_record)
        1    0.000    0.000    0.000    0.000 definitions.py:50(ProGenTargets)
        2    0.000    0.000    0.000    0.000 definitions.py:52(__init__)
        5    0.000    0.000    0.000    0.000 definitions.py:55(get_targets)
        3    0.000    0.000    0.035    0.012 definitions.py:58(get_mcu_record)
        1    0.000    0.000    0.000    0.000 definitions.py:67(get_debugger)
        1    0.000    0.000    0.000    0.000 definitions.py:74(ProGenDef)
        2    0.000    0.000    0.005    0.003 definitions.py:83(__init__)

Days              : 0
Hours             : 0
Minutes           : 0
Seconds           : 1
Milliseconds      : 178
Ticks             : 11780618
TotalDays         : 1.3634974537037E-05
TotalHours        : 0.000327239388888889
TotalMinutes      : 0.0196343633333333
TotalSeconds      : 1.1780618
TotalMilliseconds : 1178.0618
```

Fixes #2171 

@theotherjimmy @screamerbg @sarahmarshy 