### PR TITLE
Suppress warnings about deprecated __ldrex/strex

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CA.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CA.h
@@ -60,6 +60,11 @@
  #undef  __USE_EXCLUSIVE_ACCESS
 #endif
 
+/* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
+#ifdef __USE_EXCLUSIVE_ACCESS
+#pragma diag_suppress 3731
+#endif
+
 #elif defined (__GNUC__)        /* GNU Compiler */
 
 #undef  __USE_EXCLUSIVE_ACCESS

--- a/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_A/rt_HAL_CM.h
@@ -46,6 +46,11 @@
  #undef  __USE_EXCLUSIVE_ACCESS
 #endif
 
+/* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
+#ifdef __USE_EXCLUSIVE_ACCESS
+#pragma diag_suppress 3731
+#endif
+
 #elif defined (__GNUC__)        /* GNU Compiler */
 
 #undef  __USE_EXCLUSIVE_ACCESS

--- a/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
+++ b/rtos/rtx/TARGET_CORTEX_M/rt_HAL_CM.h
@@ -47,6 +47,11 @@
  #undef  __USE_EXCLUSIVE_ACCESS
 #endif
 
+/* Supress __ldrex and __strex deprecated warnings - "#3731-D: intrinsic is deprecated" */
+#ifdef __USE_EXCLUSIVE_ACCESS
+#pragma diag_suppress 3731
+#endif
+
 #ifndef __CMSIS_GENERIC
 #define __DMB() do {\
                    __schedule_barrier();\


### PR DESCRIPTION
Suppress warnings about ARMCC warnings about the __ldrex and __strex
intrinsics to match CMSIS 5.