### PR TITLE
IDE build tests with progen

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ PySerial>=2.7
 PrettyTable>=0.7.2
 Jinja2>=2.7.3
 IntelHex>=1.3
-project-generator>=0.9.3,<0.10.0
+project-generator>=0.9.7,<0.10.0
 project_generator_definitions>=0.2.26,<0.3.0
 junit-xml
 pyYAML

--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -21,6 +21,8 @@ from tools.config import Config
 
 class OldLibrariesException(Exception): pass
 
+class FailedBuildException(Exception) : pass
+
 class Exporter(object):
     TEMPLATE_DIR = dirname(__file__)
     DOT_IN_RELATIVE_PATH = False
@@ -107,7 +109,7 @@ class Exporter(object):
         }
         return project_data
 
-    def progen_gen_file(self, tool_name, project_data):
+    def progen_gen_file(self, tool_name, project_data, progen_build=False):
         """ Generate project using ProGen Project API """
         settings = ProjectSettings()
         project = Project(self.program_name, [project_data], settings)
@@ -115,6 +117,11 @@ class Exporter(object):
         # thinks it is not dict but a file, and adds them to workspace.
         project.project['common']['include_paths'] = self.resources.inc_dirs
         project.generate(tool_name, copied=not self.sources_relative)
+        if progen_build:
+            print("Project exported, building...")
+            result = project.build(tool_name)
+            if result == -1:
+                raise FailedBuildException("Build Failed")
 
     def __scan_all(self, path):
         resources = []

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -46,7 +46,7 @@ class IAREmbeddedWorkbench(Exporter):
             # target is not supported yet
             continue
 
-    def generate(self):
+    def generate(self, progen_build=False):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -75,7 +75,10 @@ class IAREmbeddedWorkbench(Exporter):
         # VLA is enabled via template IccAllowVLA
         project_data['tool_specific']['iar']['misc']['c_flags'].remove("--vla")
         project_data['common']['build_dir'] = os.path.join(project_data['common']['build_dir'], 'iar_arm')
-        self.progen_gen_file('iar_arm', project_data)
+        if progen_build:
+            self.progen_gen_file('iar_arm', project_data, True)
+        else:
+            self.progen_gen_file('iar_arm', project_data)
 
 # Currently not used, we should reuse folder_name to create virtual folders
 class IarFolder():

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -50,7 +50,7 @@ class Uvision4(Exporter):
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain
 
-    def generate(self):
+    def generate(self, progen_build=False):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -96,4 +96,7 @@ class Uvision4(Exporter):
             i += 1
         project_data['common']['macros'].append('__ASSERT_MSG')
         project_data['common']['build_dir'] = join(project_data['common']['build_dir'], 'uvision4')
-        self.progen_gen_file('uvision', project_data)
+        if progen_build:
+            self.progen_gen_file('uvision', project_data, True)
+        else:
+            self.progen_gen_file('uvision', project_data)

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -50,7 +50,7 @@ class Uvision5(Exporter):
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain
 
-    def generate(self):
+    def generate(self, progen_build=False):
         """ Generates the project files """
         project_data = self.progen_get_project_data()
         tool_specific = {}
@@ -95,4 +95,7 @@ class Uvision5(Exporter):
                 project_data['common']['macros'].pop(i)
             i += 1
         project_data['common']['macros'].append('__ASSERT_MSG')
-        self.progen_gen_file('uvision5', project_data)
+        if progen_build:
+            self.progen_gen_file('uvision5', project_data, True)
+        else:
+            self.progen_gen_file('uvision5', project_data)

--- a/tools/project_api.py
+++ b/tools/project_api.py
@@ -1,0 +1,111 @@
+import sys
+from os.path import join, abspath, dirname, exists, basename
+ROOT = abspath(join(dirname(__file__), ".."))
+sys.path.insert(0, ROOT)
+
+from tools.paths import EXPORT_WORKSPACE, EXPORT_TMP
+from tools.paths import MBED_BASE, MBED_LIBRARIES
+from tools.export import export, setup_user_prj
+from tools.utils import mkdir
+from tools.tests import Test, TEST_MAP, TESTS
+from tools.libraries import LIBRARIES
+
+try:
+    import tools.private_settings as ps
+except:
+    ps = object()
+
+
+def get_program(n):
+    p = TEST_MAP[n].n
+    return p
+
+
+def get_test(p):
+    return Test(p)
+
+
+def get_test_from_name(n):
+    if not n in TEST_MAP.keys():
+        # Check if there is an alias for this in private_settings.py
+        if getattr(ps, "test_alias", None) is not None:
+            alias = ps.test_alias.get(n, "")
+            if not alias in TEST_MAP.keys():
+                return None
+            else:
+                n = alias
+        else:
+            return None
+    return get_program(n)
+
+
+def get_lib_symbols(macros, src, program):
+    # Some libraries have extra macros (called by exporter symbols) to we need to pass
+    # them to maintain compilation macros integrity between compiled library and
+    # header files we might use with it
+    lib_symbols = []
+    if macros:
+        lib_symbols += macros
+    if src:
+        return lib_symbols
+    test = get_test(program)
+    for lib in LIBRARIES:
+        if lib['build_dir'] in test.dependencies:
+            lib_macros = lib.get('macros', None)
+            if lib_macros is not None:
+                lib_symbols.extend(lib_macros)
+
+
+def setup_project(mcu, ide, program=None, source_dir=None, build=None):
+
+    # Some libraries have extra macros (called by exporter symbols) to we need to pass
+    # them to maintain compilation macros integrity between compiled library and
+    # header files we might use with it
+    if source_dir:
+        # --source is used to generate IDE files to toolchain directly in the source tree and doesn't generate zip file
+        project_dir = source_dir
+        project_name = TESTS[program] if program else "Unnamed_Project"
+        project_temp = join(source_dir[0], 'projectfiles', '%s_%s' % (ide, mcu))
+        mkdir(project_temp)
+    else:
+        test = get_test(program)
+        if not build:
+            # Substitute the library builds with the sources
+            # TODO: Substitute also the other library build paths
+            if MBED_LIBRARIES in test.dependencies:
+                test.dependencies.remove(MBED_LIBRARIES)
+                test.dependencies.append(MBED_BASE)
+
+        # Build the project with the same directory structure of the mbed online IDE
+        project_name = test.id
+        project_dir = [join(EXPORT_WORKSPACE, project_name)]
+        project_temp = EXPORT_TMP
+        setup_user_prj(project_dir[0], test.source_dir, test.dependencies)
+
+    return project_dir, project_name, project_temp
+
+
+def perform_export(dir, name, ide, mcu, temp, clean=False, zip=False, lib_symbols='',
+                   sources_relative=False, progen_build=False):
+
+    tmp_path, report = export(dir, name, ide, mcu, dir[0], temp, clean=clean,
+                              make_zip=zip, extra_symbols=lib_symbols, sources_relative=sources_relative,
+                              progen_build=progen_build)
+    return tmp_path, report
+
+
+def print_results(successes, failures, skips = []):
+    print
+    if len(successes) > 0:
+        print "Successful: "
+        for success in successes:
+            print "  * %s" % success
+    if len(failures) > 0:
+        print "Failed: "
+        for failure in failures:
+            print "  * %s" % failure
+    if len(skips) > 0:
+        print "Skipped: "
+        for skip in skips:
+            print "  * %s" % skip
+

--- a/tools/test/export/build_test.py
+++ b/tools/test/export/build_test.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python
+"""
+mbed SDK
+Copyright (c) 2011-2013 ARM Limited
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+"""
+
+
+import sys
+import argparse
+import os
+import shutil
+from os.path import join, abspath, dirname, exists, basename
+r=dirname(__file__)
+ROOT = abspath(join(r, "..","..",".."))
+sys.path.insert(0, ROOT)
+
+from tools.export import EXPORTERS
+from tools.targets import TARGET_NAMES, TARGET_MAP
+from tools.project_api import setup_project, perform_export, print_results, get_test_from_name, get_lib_symbols
+from project_generator_definitions.definitions import ProGenDef
+from tools.utils import args_error
+
+
+class ProgenBuildTest():
+    def __init__(self, desired_ides, targets):
+        #map of targets and the ides that can build programs for them
+        self.target_ides = {}
+        for target in targets:
+            self.target_ides[target] =[]
+            for ide in desired_ides:
+                if target in EXPORTERS[ide].TARGETS:
+                    #target is supported by ide
+                    self.target_ides[target].append(ide)
+            if len(self.target_ides[target]) == 0:
+                del self.target_ides[target]
+
+
+    @staticmethod
+    def get_pgen_targets(ides):
+        #targets supported by pgen and desired ides for tests
+        targs = []
+        for ide in ides:
+            for target in TARGET_NAMES:
+                if target not in targs and hasattr(TARGET_MAP[target],'progen') \
+                        and ProGenDef(ide).is_supported(TARGET_MAP[target].progen['target']):
+                    targs.append(target)
+        return targs
+
+    @staticmethod
+    def handle_project_files(project_dir, mcu, test, tool, clean=False):
+        log = ''
+        if tool == 'uvision' or tool == 'uvision5':
+            log = os.path.join(project_dir,"build","build_log.txt")
+        elif tool == 'iar':
+            log = os.path.join(project_dir, 'build_log.txt')
+        try:
+            with open(log, 'r') as f:
+                print f.read()
+        except:
+            return
+
+        prefix = "_".join([test, mcu, tool])
+        log_name = os.path.join(os.path.dirname(project_dir), prefix+"_log.txt")
+
+        #check if a log already exists for this platform+test+ide
+        if os.path.exists(log_name):
+            #delete it if so
+            os.remove(log_name)
+        os.rename(log, log_name)
+
+        if clean:
+            shutil.rmtree(project_dir, ignore_errors=True)
+            return
+
+    def generate_and_build(self, tests, clean=False):
+
+        #build results
+        successes = []
+        failures = []
+        skips = []
+        for mcu, ides in self.target_ides.items():
+            for test in tests:
+                #resolve name alias
+                test = get_test_from_name(test)
+                for ide in ides:
+                    lib_symbols = get_lib_symbols(None, None, test)
+                    project_dir, project_name, project_temp = setup_project(mcu, ide, test)
+
+                    dest_dir = os.path.dirname(project_temp)
+                    destination = os.path.join(dest_dir,"_".join([project_name, mcu, ide]))
+
+                    tmp_path, report = perform_export(project_dir, project_name, ide, mcu, destination,
+                                                      lib_symbols=lib_symbols, progen_build = True)
+
+                    if report['success']:
+                        successes.append("build for %s::%s\t%s" % (mcu, ide, project_name))
+                    elif report['skip']:
+                        skips.append("%s::%s\t%s" % (mcu, ide, project_name))
+                    else:
+                        failures.append("%s::%s\t%s for %s" % (mcu, ide, report['errormsg'], project_name))
+
+                    ProgenBuildTest.handle_project_files(destination, mcu, project_name, ide, clean)
+        return successes, failures, skips
+
+
+if __name__ == '__main__':
+    accepted_ides = ["iar", "uvision", "uvision5"]
+    accepted_targets = sorted(ProgenBuildTest.get_pgen_targets(accepted_ides))
+    default_tests = ["MBED_BLINKY"]
+
+    parser = argparse.ArgumentParser(description = "Test progen builders. Leave any flag off to run with all possible options.")
+    parser.add_argument("-i", "--IDEs",
+                      nargs = '+',
+                      dest="ides",
+                      help="tools you wish to perfrom build tests. (%s)" % ', '.join(accepted_ides),
+                      default = accepted_ides)
+
+    parser.add_argument("-n",
+                    nargs='+',
+                    dest="tests",
+                    help="names of desired test programs",
+                    default = default_tests)
+
+    parser.add_argument("-m", "--mcus",
+                      nargs='+',
+                      dest ="targets",
+                      help="generate project for the given MCUs (%s)" % '\n '.join(accepted_targets),
+                      default = accepted_targets)
+
+    parser.add_argument("-c", "--clean",
+                        dest="clean",
+                        action = "store_true",
+                        help="clean up the exported project files",
+                        default=False)
+
+    options = parser.parse_args()
+
+    tests = options.tests
+    ides = [ide.lower() for ide in options.ides]
+    targets = [target.upper() for target in options.targets]
+
+    if any(get_test_from_name(test) is None for test in tests):
+        args_error(parser, "[ERROR] test name not recognized")
+
+    if any(target not in accepted_targets for target in targets):
+        args_error(parser, "[ERROR] mcu must be one of the following:\n %s" % '\n '.join(accepted_targets))
+
+    if any(ide not in accepted_ides for ide in ides):
+        args_error(parser, "[ERROR] ide must be in %s" % ', '.join(accepted_ides))
+
+    build_test = ProgenBuildTest(ides, targets)
+    successes, failures, skips = build_test.generate_and_build(tests, options.clean)
+    print_results(successes, failures, skips)
+    sys.exit(len(failures))
+
+
+


### PR DESCRIPTION
I have separated some of the exporter logic in project.py to project_api.py. I did this because I wanted to use some of that functionality in the new build_test script. build_test allows testing of ide builds (currently supports iar, uvision, and uv5) using progen. 

build_test examples:

builds blinky for iar and k64f
```
python build_test.py -i iar -t MBED_BLINKY -m K64F
```
build blinky and Hello World test for all targets on all (supported) ides
```
python build_test.py -t MBED_BLINKY MBED_10
```

builds all tests (current default is just blinky but you can specify more with -t) for all progen targets on all ides 
```
python build_test.py 
```

Revision of [this](https://github.com/mbedmicro/mbed/pull/2080) PR.
