### PR TITLE
[Tools] mbed Online Build System support and improvements

### DIFF
--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -19,7 +19,6 @@ from project_generator_definitions.definitions import ProGenDef
 
 from tools.export.exporters import Exporter, ExporterTargetsProperty
 from tools.targets import TARGET_MAP, TARGET_NAMES
-from tools.settings import ARM_INC
 
 # If you wish to add a new target, add it to project_generator_definitions, and then
 # define progen_target name in the target class (`` self.progen_target = 'my_target_name' ``)
@@ -79,8 +78,6 @@ class Uvision4(Exporter):
         project_data['tool_specific']['uvision']['misc']['c_flags'] = list(set(self.progen_flags['common_flags'] + self.progen_flags['c_flags'] + self.progen_flags['cxx_flags']))
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--c99")
-        # ARM_INC is by default as system inclusion, not required for exported project
-        project_data['tool_specific']['uvision']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         # cpp is not required as it's implicit for cpp files
         project_data['tool_specific']['uvision']['misc']['c_flags'].remove("--cpp")
         # we want no-vla for only cxx, but it's also applied for C in IDE, thus we remove it

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -19,7 +19,6 @@ from project_generator_definitions.definitions import ProGenDef
 
 from tools.export.exporters import Exporter, ExporterTargetsProperty
 from tools.targets import TARGET_MAP, TARGET_NAMES
-from tools.settings import ARM_INC
 
 # If you wish to add a new target, add it to project_generator_definitions, and then
 # define progen_target name in the target class (`` self.progen_target = 'my_target_name' ``)
@@ -77,8 +76,6 @@ class Uvision5(Exporter):
         project_data['tool_specific']['uvision5']['misc']['asm_flags'] = list(set(self.progen_flags['asm_flags']))
         # cxx flags included, as uvision have them all in one tab
         project_data['tool_specific']['uvision5']['misc']['c_flags'] = list(set(self.progen_flags['common_flags'] + self.progen_flags['c_flags'] + self.progen_flags['cxx_flags']))
-        # ARM_INC is by default as system inclusion, not required for exported project
-        project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("-I \""+ARM_INC+"\"")
         # not compatible with c99 flag set in the template
         project_data['tool_specific']['uvision5']['misc']['c_flags'].remove("--c99")
         # cpp is not required as it's implicit for cpp files

--- a/tools/settings.py
+++ b/tools/settings.py
@@ -81,17 +81,6 @@ for _n in _ENV_PATHS:
 
 
 ##############################################################################
-# ARM Compiler Paths
-##############################################################################
-
-ARM_BIN = join(ARM_PATH, "bin")
-ARM_INC = join(ARM_PATH, "include")
-ARM_LIB = join(ARM_PATH, "lib")
-ARM_CPPLIB = join(ARM_LIB, "cpplib")
-MY_ARM_CLIB = join(ARM_LIB, "lib", "microlib")
-
-
-##############################################################################
 # Test System Settings
 ##############################################################################
 SERVER_PORT = 59432

--- a/tools/synch.py
+++ b/tools/synch.py
@@ -122,7 +122,7 @@ def ignore_path(name, reg_exps):
 class MbedRepository:
     @staticmethod
     def run_and_print(command, cwd):
-        stdout, _, _ = run_cmd(command, wd=cwd, redirect=True)
+        stdout, _, _ = run_cmd(command, work_dir=cwd, redirect=True)
         print(stdout)
 
     def __init__(self, name, team = None):
@@ -147,7 +147,7 @@ class MbedRepository:
     def publish(self):
         # The maintainer has to evaluate the changes first and explicitly accept them
         self.run_and_print(['hg', 'addremove'], cwd=self.path)
-        stdout, _, _ = run_cmd(['hg', 'status'], wd=self.path)
+        stdout, _, _ = run_cmd(['hg', 'status'], work_dir=self.path)
         if stdout == '':
             print "No changes"
             return False

--- a/tools/targets.py
+++ b/tools/targets.py
@@ -61,6 +61,9 @@ class Target:
     # need to be computed differently than regular attributes
     __cumulative_attributes = ['extra_labels', 'macros', 'device_has', 'features']
 
+    # List of targets that were added dynamically using "add_py_targets" (see below)
+    __py_targets = set()
+
     # Location of the 'targets.json' file
     __targets_json_location = os.path.join(os.path.dirname(os.path.abspath(__file__)), '..', 'hal', 'targets.json')
 

--- a/tools/test_api.py
+++ b/tools/test_api.py
@@ -58,7 +58,7 @@ from tools.build_api import create_result
 from tools.build_api import add_result_to_report
 from tools.build_api import scan_for_source_paths
 from tools.libraries import LIBRARIES, LIBRARY_MAP
-from tools.toolchains import TOOLCHAIN_BIN_PATH
+from tools.toolchains import TOOLCHAIN_PATHS
 from tools.toolchains import TOOLCHAINS
 from tools.test_exporters import ReportExporter, ResultExporterType
 from tools.utils import argparse_filestring_type
@@ -1343,8 +1343,8 @@ def print_test_configuration_from_json(json_data, join_delim=", "):
                 if conflict:
                     cell_val += '*'
                 # Check for conflicts: toolchain vs toolchain path
-                if toolchain in TOOLCHAIN_BIN_PATH:
-                    toolchain_path = TOOLCHAIN_BIN_PATH[toolchain]
+                if toolchain in TOOLCHAIN_PATHS:
+                    toolchain_path = TOOLCHAIN_PATHS[toolchain]
                     if not os.path.isdir(toolchain_path):
                         conflict_path = True
                         if toolchain not in toolchain_path_conflicts:
@@ -1368,8 +1368,8 @@ def print_test_configuration_from_json(json_data, join_delim=", "):
 
         for toolchain in toolchain_path_conflicts:
         # Let's check toolchain configuration
-            if toolchain in TOOLCHAIN_BIN_PATH:
-                toolchain_path = TOOLCHAIN_BIN_PATH[toolchain]
+            if toolchain in TOOLCHAIN_PATHS:
+                toolchain_path = TOOLCHAIN_PATHS[toolchain]
                 if not os.path.isdir(toolchain_path):
                     result += "\t# Toolchain %s path not found: %s\n"% (toolchain, toolchain_path)
     return result

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -108,6 +108,7 @@ class ARM(mbedToolchain):
                     'toolchain_name': self.name
                 }
             elif msg is not None:
+                # Determine the warning/error column by calculating the ^ position
                 match = ARM.INDEX_PATTERN.match(line)
                 if match is not None:
                     msg['col'] = len(match.group('col'))

--- a/tools/toolchains/arm.py
+++ b/tools/toolchains/arm.py
@@ -17,8 +17,7 @@ limitations under the License.
 import re
 from os.path import join, dirname, splitext, basename, exists
 
-from tools.toolchains import mbedToolchain
-from tools.settings import ARM_BIN, ARM_INC, ARM_LIB, MY_ARM_CLIB, ARM_CPPLIB, GOANNA_PATH
+from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 from tools.utils import mkdir
 import copy
@@ -29,13 +28,14 @@ class ARM(mbedToolchain):
 
     STD_LIB_NAME = "%s.ar"
     DIAGNOSTIC_PATTERN  = re.compile('"(?P<file>[^"]+)", line (?P<line>\d+)( \(column (?P<column>\d+)\)|): (?P<severity>Warning|Error): (?P<message>.+)')
+    INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
     DEP_PATTERN = re.compile('\S+:\s(?P<file>.+)\n')
 
 
     DEFAULT_FLAGS = {
         'common': ["-c", "--gnu",
             "-Otime", "--split_sections", "--apcs=interwork",
-            "--brief_diagnostics", "--restrict", "--multibyte_chars", "-I \""+ARM_INC+"\""],
+            "--brief_diagnostics", "--restrict", "--multibyte_chars"],
         'asm': [],
         'c': ["--md", "--no_depend_system_headers", "--c99", "-D__ASSERT_MSG"],
         'cxx': ["--cpp", "--no_rtti", "--no_vla"],
@@ -56,6 +56,9 @@ class ARM(mbedToolchain):
         else:
             cpu = target.core
 
+        ARM_BIN = join(TOOLCHAIN_PATHS['ARM'], "bin")
+        ARM_INC = join(TOOLCHAIN_PATHS['ARM'], "include")
+        
         main_cc = join(ARM_BIN, "armcc")
 
         self.flags['common'] += ["--cpu=%s" % cpu]
@@ -68,13 +71,9 @@ class ARM(mbedToolchain):
         else:
             self.flags['c'].append("-O3")
 
-        self.asm = [main_cc] + self.flags['common'] + self.flags['asm']
-        if not "analyze" in self.options:
-            self.cc = [main_cc] + self.flags['common'] + self.flags['c']
-            self.cppc = [main_cc] + self.flags['common'] + self.flags['c'] + self.flags['cxx']
-        else:
-            self.cc  = [join(GOANNA_PATH, "goannacc"), "--with-cc=" + main_cc.replace('\\', '/'), "--dialect=armcc", '--output-format="%s"' % self.GOANNA_FORMAT] + self.flags['common'] + self.flags['c'] 
-            self.cppc= [join(GOANNA_PATH, "goannac++"), "--with-cxx=" + main_cc.replace('\\', '/'), "--dialect=armcc", '--output-format="%s"' % self.GOANNA_FORMAT] + self.flags['common'] + self.flags['c'] + self.flags['cxx']
+        self.asm = [main_cc] + self.flags['common'] + self.flags['asm'] + ["-I \""+ARM_INC+"\""]
+        self.cc = [main_cc] + self.flags['common'] + self.flags['c'] + ["-I \""+ARM_INC+"\""]
+        self.cppc = [main_cc] + self.flags['common'] + self.flags['c'] + self.flags['cxx'] + ["-I \""+ARM_INC+"\""]
 
         self.ld = [join(ARM_BIN, "armlink")]
         self.sys_libs = []
@@ -87,40 +86,54 @@ class ARM(mbedToolchain):
         for line in open(dep_path).readlines():
             match = ARM.DEP_PATTERN.match(line)
             if match is not None:
-                dependencies.append(match.group('file'))
+                #we need to append chroot, because when the .d files are generated the compiler is chrooted
+                dependencies.append((self.CHROOT if self.CHROOT else '') + match.group('file'))
         return dependencies
-
+        
     def parse_output(self, output):
+        msg = None
         for line in output.splitlines():
             match = ARM.DIAGNOSTIC_PATTERN.match(line)
             if match is not None:
-                self.cc_info(
-                    match.group('severity').lower(),
-                    match.group('file'),
-                    match.group('line'),
-                    match.group('message'),
-                    target_name=self.target.name,
-                    toolchain_name=self.name
-                )
-            match = self.goanna_parse_line(line)
-            if match is not None:
-                self.cc_info(
-                    match.group('severity').lower(),
-                    match.group('file'),
-                    match.group('line'),
-                    match.group('message')
-                )
+                if msg is not None:
+                    self.cc_info(msg)
+                msg = {
+                    'severity': match.group('severity').lower(),
+                    'file': match.group('file'),
+                    'line': match.group('line'),
+                    'col': match.group('column') if match.group('column') else 0,
+                    'message': match.group('message'),
+                    'text': '',
+                    'target_name': self.target.name,
+                    'toolchain_name': self.name
+                }
+            elif msg is not None:
+                match = ARM.INDEX_PATTERN.match(line)
+                if match is not None:
+                    msg['col'] = len(match.group('col'))
+                    self.cc_info(msg)
+                    msg = None
+                else:
+                    msg['text'] += line+"\n"
+        
+        if msg is not None:
+            self.cc_info(msg)
 
     def get_dep_option(self, object):
         base, _ = splitext(object)
         dep_path = base + '.d'
         return ["--depend", dep_path]
 
-    def get_config_option(self, config_header) :
+    def get_config_option(self, config_header):
         return ['--preinclude=' + config_header]
 
     def get_compile_options(self, defines, includes):        
-        opts = ['-D%s' % d for d in defines] + ['--via', self.get_inc_file(includes)]
+        opts = ['-D%s' % d for d in defines]
+        if self.RESPONSE_FILES:
+            opts += ['--via', self.get_inc_file(includes)]
+        else:
+            opts += ["-I%s" % i for i in includes]
+
         config_header = self.get_config_header()
         if config_header is not None:
             opts = opts + self.get_config_option(config_header)
@@ -183,32 +196,25 @@ class ARM(mbedToolchain):
         # Call cmdline hook
         cmd = self.hook.get_cmdline_linker(cmd)
 
-        # Split link command to linker executable + response file
-        link_files = join(dirname(output), ".link_files.txt")
-        with open(link_files, "wb") as f:
+        if self.RESPONSE_FILES:
+            # Split link command to linker executable + response file
             cmd_linker = cmd[0]
-            cmd_list = []
-            for c in cmd[1:]:
-                if c:
-                    cmd_list.append(('"%s"' % c) if not c.startswith('-') else c)                    
-            string = " ".join(cmd_list).replace("\\", "/")
-            f.write(string)
+            link_files = self.get_link_file(cmd[1:])
+            cmd = [cmd_linker, '--via', link_files]
 
         # Exec command
-        self.default_cmd([cmd_linker, '--via', link_files])
+        self.cc_verbose("Link: %s" % ' '.join(cmd))
+        self.default_cmd(cmd)
 
     @hook_tool
     def archive(self, objects, lib_path):
-        archive_files = join(dirname(lib_path), ".archive_files.txt")
-        with open(archive_files, "wb") as f:
-            o_list = []
-            for o in objects:
-                o_list.append('"%s"' % o)                    
-            string = " ".join(o_list).replace("\\", "/")
-            f.write(string)
+        if self.RESPONSE_FILES:
+            param = ['--via', self.get_arch_file(objects)]
+        else:
+            param = objects
 
         # Exec command
-        self.default_cmd([self.ar, '-r', lib_path, '--via', archive_files])
+        self.default_cmd([self.ar, '-r', lib_path] + param)
 
     @hook_tool
     def binary(self, resources, elf, bin):
@@ -219,6 +225,7 @@ class ARM(mbedToolchain):
         cmd = self.hook.get_cmdline_binary(cmd)
 
         # Exec command
+        self.cc_verbose("FromELF: %s" % ' '.join(cmd))
         self.default_cmd(cmd)
 
 
@@ -227,7 +234,7 @@ class ARM_STD(ARM):
         ARM.__init__(self, target, options, notify, macros, silent, extra_verbose=extra_verbose)
 
         # Run-time values
-        self.ld.extend(["--libpath \"%s\"" % ARM_LIB])
+        self.ld.extend(["--libpath", join(TOOLCHAIN_PATHS['ARM'], "lib")])
 
 
 class ARM_MICRO(ARM):
@@ -260,13 +267,13 @@ class ARM_MICRO(ARM):
             self.ld   += ["--noscanlib"]
 
             # System Libraries
-            self.sys_libs.extend([join(MY_ARM_CLIB, lib+".l") for lib in ["mc_p", "mf_p", "m_ps"]])
+            self.sys_libs.extend([join(TOOLCHAIN_PATHS['ARM'], "lib", "microlib", lib+".l") for lib in ["mc_p", "mf_p", "m_ps"]])
 
             if target.core == "Cortex-M3":
-                self.sys_libs.extend([join(ARM_CPPLIB, lib+".l") for lib in ["cpp_ws", "cpprt_w"]])
+                self.sys_libs.extend([join(TOOLCHAIN_PATHS['ARM'], "lib", "cpplib", lib+".l") for lib in ["cpp_ws", "cpprt_w"]])
 
             elif target.core in ["Cortex-M0", "Cortex-M0+"]:
-                self.sys_libs.extend([join(ARM_CPPLIB, lib+".l") for lib in ["cpp_ps", "cpprt_p"]])
+                self.sys_libs.extend([join(TOOLCHAIN_PATHS['ARM'], "lib", "cpplib", lib+".l") for lib in ["cpp_ps", "cpprt_p"]])
         else:
             # Run-time values
-            self.ld.extend(["--libpath \"%s\"" % ARM_LIB])
+            self.ld.extend(["--libpath", join(TOOLCHAIN_PATHS['ARM'], "lib")])

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -153,6 +153,7 @@ class GCC(mbedToolchain):
                     'toolchain_name': self.name
                 }
             elif msg is not None:
+                # Determine the warning/error column by calculating the ^ position
                 match = GCC.INDEX_PATTERN.match(line)
                 if match is not None:
                     msg['col'] = len(match.group('col'))

--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -17,9 +17,7 @@ limitations under the License.
 import re
 from os.path import join, basename, splitext, dirname, exists
 
-from tools.toolchains import mbedToolchain
-from tools.settings import GCC_ARM_PATH, GCC_CR_PATH
-from tools.settings import GOANNA_PATH
+from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 
 class GCC(mbedToolchain):
@@ -28,6 +26,7 @@ class GCC(mbedToolchain):
 
     STD_LIB_NAME = "lib%s.a"
     DIAGNOSTIC_PATTERN = re.compile('((?P<file>[^:]+):(?P<line>\d+):)(\d+:)? (?P<severity>warning|error): (?P<message>.+)')
+    INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
 
     DEFAULT_FLAGS = {
         'common': ["-c", "-Wall", "-Wextra",
@@ -99,12 +98,8 @@ class GCC(mbedToolchain):
         main_cc = join(tool_path, "arm-none-eabi-gcc")
         main_cppc = join(tool_path, "arm-none-eabi-g++")
         self.asm = [main_cc] + self.flags['asm'] + self.flags["common"]
-        if not "analyze" in self.options:
-            self.cc  = [main_cc]
-            self.cppc =[main_cppc]
-        else:
-            self.cc  = [join(GOANNA_PATH, "goannacc"), "--with-cc=" + main_cc.replace('\\', '/'), "--dialect=gnu", '--output-format="%s"' % self.GOANNA_FORMAT]
-            self.cppc= [join(GOANNA_PATH, "goannac++"), "--with-cxx=" + main_cppc.replace('\\', '/'),  "--dialect=gnu", '--output-format="%s"' % self.GOANNA_FORMAT]
+        self.cc  = [main_cc]
+        self.cppc =[main_cppc]
         self.cc += self.flags['c'] + self.flags['common']
         self.cppc += self.flags['cxx'] + self.flags['common']
 
@@ -131,9 +126,9 @@ class GCC(mbedToolchain):
                 # back later to a space char)
                 file = file.replace('\\ ', '\a')
                 if file.find(" ") == -1:
-                    dependencies.append(file.replace('\a', ' '))
+                    dependencies.append((self.CHROOT if self.CHROOT else '') + file.replace('\a', ' '))
                 else:
-                    dependencies = dependencies + [f.replace('\a', ' ') for f in file.split(" ")]
+                    dependencies = dependencies + [(self.CHROOT if self.CHROOT else '') + f.replace('\a', ' ') for f in file.split(" ")]
         return dependencies
 
     def is_not_supported_error(self, output):
@@ -141,32 +136,30 @@ class GCC(mbedToolchain):
 
     def parse_output(self, output):
         # The warning/error notification is multiline
-        WHERE, WHAT = 0, 1
-        state, file, message = WHERE, None, None
+        msg = None
         for line in output.splitlines():
-            match = self.goanna_parse_line(line)
-            if match is not None:
-                self.cc_info(
-                    match.group('severity').lower(),
-                    match.group('file'),
-                    match.group('line'),
-                    match.group('message'),
-                    target_name=self.target.name,
-                    toolchain_name=self.name
-                )
-                continue
-
-
             match = GCC.DIAGNOSTIC_PATTERN.match(line)
             if match is not None:
-                self.cc_info(
-                    match.group('severity').lower(),
-                    match.group('file'),
-                    match.group('line'),
-                    match.group('message'),
-                    target_name=self.target.name,
-                    toolchain_name=self.name
-                )
+                if msg is not None:
+                    self.cc_info(msg)
+                msg = {
+                    'severity': match.group('severity').lower(),
+                    'file': match.group('file'),
+                    'line': match.group('line'),
+                    'col': 0,
+                    'message': match.group('message'),
+                    'text': '',
+                    'target_name': self.target.name,
+                    'toolchain_name': self.name
+                }
+            elif msg is not None:
+                match = GCC.INDEX_PATTERN.match(line)
+                if match is not None:
+                    msg['col'] = len(match.group('col'))
+                    self.cc_info(msg)
+                    msg = None
+                else:
+                    msg['text'] += line+"\n"
 
     def get_dep_option(self, object):
         base, _ = splitext(object)
@@ -177,7 +170,12 @@ class GCC(mbedToolchain):
         return ['-include', config_header]
 
     def get_compile_options(self, defines, includes):
-        opts = ['-D%s' % d for d in defines] + ['@%s' % self.get_inc_file(includes)]
+        opts = ['-D%s' % d for d in defines]
+        if self.RESPONSE_FILES:
+            opts += ['@%s' % self.get_inc_file(includes)]
+        else:
+            opts += ["-I%s" % i for i in includes]
+
         config_header = self.get_config_header()
         if config_header is not None:
             opts = opts + self.get_config_option(config_header)
@@ -235,32 +233,25 @@ class GCC(mbedToolchain):
         # Call cmdline hook
         cmd = self.hook.get_cmdline_linker(cmd)
 
-        # Split link command to linker executable + response file
-        link_files = join(dirname(output), ".link_files.txt")
-        with open(link_files, "wb") as f:
+        if self.RESPONSE_FILES:
+            # Split link command to linker executable + response file
             cmd_linker = cmd[0]
-            cmd_list = []
-            for c in cmd[1:]:
-                if c:
-                    cmd_list.append(('"%s"' % c) if not c.startswith('-') else c)
-            string = " ".join(cmd_list).replace("\\", "/")
-            f.write(string)
+            link_files = self.get_link_file(cmd[1:])
+            cmd = [cmd_linker, "@%s" % link_files]
 
         # Exec command
-        self.default_cmd([cmd_linker, "@%s" % link_files])
+        self.cc_verbose("Link: %s" % ' '.join(cmd))
+        self.default_cmd(cmd)
 
     @hook_tool
     def archive(self, objects, lib_path):
-        archive_files = join(dirname(lib_path), ".archive_files.txt")
-        with open(archive_files, "wb") as f:
-            o_list = []
-            for o in objects:
-                o_list.append('"%s"' % o)
-            string = " ".join(o_list).replace("\\", "/")
-            f.write(string)
+        if self.RESPONSE_FILES:
+            param = ["@%s" % self.get_arch_file(objects)]
+        else:
+            param = objects
 
         # Exec command
-        self.default_cmd([self.ar, 'rcs', lib_path, "@%s" % archive_files])
+        self.default_cmd([self.ar, 'rcs', lib_path] + param)
 
     @hook_tool
     def binary(self, resources, elf, bin):
@@ -271,12 +262,13 @@ class GCC(mbedToolchain):
         cmd = self.hook.get_cmdline_binary(cmd)
 
         # Exec command
+        self.cc_verbose("FromELF: %s" % ' '.join(cmd))
         self.default_cmd(cmd)
 
 
 class GCC_ARM(GCC):
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
-        GCC.__init__(self, target, options, notify, macros, silent, GCC_ARM_PATH, extra_verbose=extra_verbose)
+        GCC.__init__(self, target, options, notify, macros, silent, TOOLCHAIN_PATHS['GCC_ARM'], extra_verbose=extra_verbose)
 
         # Use latest gcc nanolib
         if "big-build" in self.options:
@@ -309,7 +301,7 @@ class GCC_ARM(GCC):
 
 class GCC_CR(GCC):
     def __init__(self, target, options=None, notify=None, macros=None, silent=False, extra_verbose=False):
-        GCC.__init__(self, target, options, notify, macros, silent, GCC_CR_PATH, extra_verbose=extra_verbose)
+        GCC.__init__(self, target, options, notify, macros, silent, TOOLCHAIN_PATHS['GCC_CR'], extra_verbose=extra_verbose)
 
         additional_compiler_flags = [
             "-D__NEWLIB__", "-D__CODE_RED", "-D__USE_CMSIS", "-DCPP_USE_HEAP",

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -18,9 +18,7 @@ import re
 from os import remove
 from os.path import join, exists, dirname, splitext, exists
 
-from tools.toolchains import mbedToolchain
-from tools.settings import IAR_PATH
-from tools.settings import GOANNA_PATH
+from tools.toolchains import mbedToolchain, TOOLCHAIN_PATHS
 from tools.hooks import hook_tool
 
 class IAR(mbedToolchain):
@@ -29,6 +27,7 @@ class IAR(mbedToolchain):
     STD_LIB_NAME = "%s.a"
 
     DIAGNOSTIC_PATTERN = re.compile('"(?P<file>[^"]+)",(?P<line>[\d]+)\s+(?P<severity>Warning|Error)(?P<message>.+)')
+    INDEX_PATTERN  = re.compile('(?P<col>\s*)\^')
 
     DEFAULT_FLAGS = {
         'common': [
@@ -66,12 +65,12 @@ class IAR(mbedToolchain):
         if target.core == "Cortex-M4F":
           c_flags_cmd = [
               "--cpu", "Cortex-M4F",
-              "--thumb", "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h")
+              "--thumb", "--dlib_config", join(TOOLCHAIN_PATHS['IAR'], "inc", "c", "DLib_Config_Full.h")
           ]
         else:
           c_flags_cmd = [
               "--cpu", cpuchoice,
-              "--thumb", "--dlib_config", join(IAR_PATH, "inc", "c", "DLib_Config_Full.h")
+              "--thumb", "--dlib_config", join(TOOLCHAIN_PATHS['IAR'], "inc", "c", "DLib_Config_Full.h")
           ]
         # custom c++ cmd flags
         cxx_flags_cmd = [
@@ -90,16 +89,12 @@ class IAR(mbedToolchain):
         else:
             c_flags_cmd.append("-Oh")
 
-        IAR_BIN = join(IAR_PATH, "bin")
+        IAR_BIN = join(TOOLCHAIN_PATHS['IAR'], "bin")
         main_cc = join(IAR_BIN, "iccarm")
 
         self.asm  = [join(IAR_BIN, "iasmarm")] + asm_flags_cmd + self.flags["asm"]
-        if not "analyze" in self.options:
-            self.cc   = [main_cc]
-            self.cppc = [main_cc]
-        else:
-            self.cc   = [join(GOANNA_PATH, "goannacc"), '--with-cc="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT]
-            self.cppc = [join(GOANNA_PATH, "goannac++"), '--with-cxx="%s"' % main_cc.replace('\\', '/'), "--dialect=iar-arm", '--output-format="%s"' % self.GOANNA_FORMAT]
+        self.cc   = [main_cc]
+        self.cppc = [main_cc]
         self.cc += self.flags["common"] + c_flags_cmd + self.flags["c"]
         self.cppc += self.flags["common"] + c_flags_cmd + cxx_flags_cmd + self.flags["cxx"]
         self.ld   = join(IAR_BIN, "ilinkarm")
@@ -107,29 +102,34 @@ class IAR(mbedToolchain):
         self.elf2bin = join(IAR_BIN, "ielftool")
 
     def parse_dependencies(self, dep_path):
-        return [path.strip() for path in open(dep_path).readlines()
+        return [(self.CHROOT if self.CHROOT else '')+path.strip() for path in open(dep_path).readlines()
                 if (path and not path.isspace())]
 
     def parse_output(self, output):
+        msg = None
         for line in output.splitlines():
             match = IAR.DIAGNOSTIC_PATTERN.match(line)
             if match is not None:
-                self.cc_info(
-                    match.group('severity').lower(),
-                    match.group('file'),
-                    match.group('line'),
-                    match.group('message'),
-                    target_name=self.target.name,
-                    toolchain_name=self.name
-                )
-            match = self.goanna_parse_line(line)
-            if match is not None:
-                self.cc_info(
-                    match.group('severity').lower(),
-                    match.group('file'),
-                    match.group('line'),
-                    match.group('message')
-                )
+                if msg is not None:
+                    self.cc_info(msg)
+                msg = {
+                    'severity': match.group('severity').lower(),
+                    'file': match.group('file'),
+                    'line': match.group('line'),
+                    'col': 0,
+                    'message': match.group('message'),
+                    'text': '',
+                    'target_name': self.target.name,
+                    'toolchain_name': self.name
+                }
+            elif msg is not None:
+                match = IAR.INDEX_PATTERN.match(line)
+                if match is not None:
+                    msg['col'] = len(match.group('col'))
+                    self.cc_info(msg)
+                    msg = None
+                else:
+                    msg['text'] += line+"\n"
 
     def get_dep_option(self, object):
         base, _ = splitext(object)
@@ -144,7 +144,12 @@ class IAR(mbedToolchain):
         return ['--preinclude=' + config_header]
 
     def get_compile_options(self, defines, includes, for_asm=False):
-        opts = ['-D%s' % d for d in defines] + ['-f', self.get_inc_file(includes)]
+        opts = ['-D%s' % d for d in defines]
+        if self.RESPONSE_FILES:
+            opts += ['-f', self.get_inc_file(includes)]
+        else:
+            opts += ["-I%s" % i for i in includes]
+
         config_header = self.get_config_header()
         if for_asm:
             # The assembler doesn't support '--preinclude', so we need to add
@@ -201,34 +206,27 @@ class IAR(mbedToolchain):
         # Call cmdline hook
         cmd = self.hook.get_cmdline_linker(cmd)
 
-        # Split link command to linker executable + response file
-        link_files = join(dirname(output), ".link_files.txt")
-        with open(link_files, "wb") as f:
+        if self.RESPONSE_FILES:
+            # Split link command to linker executable + response file
             cmd_linker = cmd[0]
-            cmd_list = []
-            for c in cmd[1:]:
-                if c:
-                    cmd_list.append(('"%s"' % c) if not c.startswith('-') else c)                    
-            string = " ".join(cmd_list).replace("\\", "/")
-            f.write(string)
+            link_files = self.get_link_file(cmd[1:])
+            cmd = [cmd_linker, '-f', link_files]
 
         # Exec command
-        self.default_cmd([cmd_linker, '-f', link_files])
+        self.cc_verbose("Link: %s" % ' '.join(cmd))
+        self.default_cmd(cmd)
 
     @hook_tool
     def archive(self, objects, lib_path):
-        archive_files = join(dirname(lib_path), ".archive_files.txt")
-        with open(archive_files, "wb") as f:
-            o_list = []
-            for o in objects:
-                o_list.append('"%s"' % o)                    
-            string = " ".join(o_list).replace("\\", "/")
-            f.write(string)
+        if self.RESPONSE_FILES:
+            param = ['-f', self.get_arch_file(objects)]
+        else:
+            param = objects
 
         if exists(lib_path):
             remove(lib_path)
 
-        self.default_cmd([self.ar, lib_path, '-f', archive_files])
+        self.default_cmd([self.ar, lib_path] + param)
 
     @hook_tool
     def binary(self, resources, elf, bin):
@@ -239,4 +237,5 @@ class IAR(mbedToolchain):
         cmd = self.hook.get_cmdline_binary(cmd)
 
         # Exec command
+        self.cc_verbose("FromELF: %s" % ' '.join(cmd))
         self.default_cmd(cmd)

--- a/tools/toolchains/iar.py
+++ b/tools/toolchains/iar.py
@@ -123,6 +123,7 @@ class IAR(mbedToolchain):
                     'toolchain_name': self.name
                 }
             elif msg is not None:
+                # Determine the warning/error column by calculating the ^ position
                 match = IAR.INDEX_PATTERN.match(line)
                 if match is not None:
                     msg['col'] = len(match.group('col'))


### PR DESCRIPTION
* added/improved chroot support globally
* added RESPONSE_FILES flag to support optional response files (on linux the cmd param length is 2 megabytes). Default True
* added unified handling for archive and link response file (similar to includes)
* added COMPILE_C_AS_CPP flag to support compiling of c files as cpp. Default False
* added mbedToolchain.init() for post __init__ hooks
* added support to identify compiler warning/error column (supports ARMCC, GCC and IAR). Errors/warnings now report file@line,col
* added global TOOLCHAIN_PATHS which allows overriding/changing of the toolchain paths. Also simplified ARM-related paths
* added target.json to mbed library release (by @0xc0170)
* added caching to mbedToolchain.need_update() to reduce IO hits
* improved run_cmd() performance by removing unnecessary check about the command being executed (should be checked once in the relevant toolchain instead)
* migrated compile_worker() to utils.py for lightweight thread initialization
* removed remnants of Goanna support (should be reimplemented as hooks to compile/link/archive instead)
* fixes for Python 2.7 compatibility (by @0xc0170)
* fixes for Exporters (by @0xc0170)