### PR TITLE
Changing -O2 parameter to -Os

### DIFF
--- a/tools/toolchains/gcc.py
+++ b/tools/toolchains/gcc.py
@@ -87,7 +87,7 @@ class GCC(mbedToolchain):
             self.flags["common"].append("-g")
             self.flags["common"].append("-O0")
         else:
-            self.flags["common"].append("-O2")
+            self.flags["common"].append("-Os")
 
         main_cc = join(tool_path, "arm-none-eabi-gcc")
         main_cppc = join(tool_path, "arm-none-eabi-g++")


### PR DESCRIPTION
This commit includes
- Changing build option parameter from -O2 to -Os to reduce flash size of the
  final binary pacakge.
  The original parameter of -O2 is kept to circumvent the error
  http://gcc.gnu.org/bugzilla/show_bug.cgi?id=46762 .
 But this error has been long fixed and released in latest 4.9.x GCC compiler.

 This change is necessary to reduce the generated binary size of mbed Client component to
avoid problem of getting images over 512 kB which is causing application to crash because of
Configuration Store problem https://github.com/ARMmbed/configuration-store/issues/21