### PR TITLE
Fix issue2183

### DIFF
--- a/tools/export/exporters.py
+++ b/tools/export/exporters.py
@@ -23,6 +23,14 @@ class OldLibrariesException(Exception): pass
 
 class FailedBuildException(Exception) : pass
 
+# Exporter descriptor for TARGETS
+# TARGETS as class attribute for backward compatibility (allows: if in Exporter.TARGETS)
+class ExporterTargetsProperty(object):
+    def __init__(self, func):
+        self.func = func
+    def __get__(self, inst, cls):
+        return self.func(cls)
+
 class Exporter(object):
     TEMPLATE_DIR = dirname(__file__)
     DOT_IN_RELATIVE_PATH = False

--- a/tools/export/iar.py
+++ b/tools/export/iar.py
@@ -18,7 +18,7 @@ import re
 import os
 from project_generator_definitions.definitions import ProGenDef
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, ExporterTargetsProperty
 from tools.targets import TARGET_MAP, TARGET_NAMES
 
 # If you wish to add a new target, add it to project_generator_definitions, and then
@@ -35,19 +35,19 @@ class IAREmbeddedWorkbench(Exporter):
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 
-    @property
-    def TARGETS(self):
-        if not hasattr(self, "_targets_supported"):
-            self._targets_supported = []
+    @ExporterTargetsProperty
+    def TARGETS(cls):
+        if not hasattr(cls, "_targets_supported"):
+            cls._targets_supported = []
             for target in TARGET_NAMES:
                 try:
                     if (ProGenDef('iar').is_supported(str(TARGET_MAP[target])) or
                         ProGenDef('iar').is_supported(TARGET_MAP[target].progen['target'])):
-                        self._targets_supported.append(target)
+                        cls._targets_supported.append(target)
                 except AttributeError:
                     # target is not supported yet
                     continue
-        return self._targets_supported
+        return cls._targets_supported
 
     def generate(self, progen_build=False):
         """ Generates the project files """

--- a/tools/export/uvision4.py
+++ b/tools/export/uvision4.py
@@ -17,7 +17,7 @@ limitations under the License.
 from os.path import basename, join, dirname
 from project_generator_definitions.definitions import ProGenDef
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, ExporterTargetsProperty
 from tools.targets import TARGET_MAP, TARGET_NAMES
 from tools.settings import ARM_INC
 
@@ -36,19 +36,19 @@ class Uvision4(Exporter):
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 
-    @property
-    def TARGETS(self):
-        if not hasattr(self, "_targets_supported"):
-            self._targets_supported = []
+    @ExporterTargetsProperty
+    def TARGETS(cls):
+        if not hasattr(cls, "_targets_supported"):
+            cls._targets_supported = []
             for target in TARGET_NAMES:
                 try:
                     if (ProGenDef('uvision').is_supported(str(TARGET_MAP[target])) or
                         ProGenDef('uvision').is_supported(TARGET_MAP[target].progen['target'])):
-                        self._targets_supported.append(target)
+                        cls._targets_supported.append(target)
                 except AttributeError:
                     # target is not supported yet
                     continue
-        return self._targets_supported
+        return cls._targets_supported
 
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -17,7 +17,7 @@ limitations under the License.
 from os.path import basename, join, dirname
 from project_generator_definitions.definitions import ProGenDef
 
-from tools.export.exporters import Exporter
+from tools.export.exporters import Exporter, ExporterTargetsProperty
 from tools.targets import TARGET_MAP, TARGET_NAMES
 from tools.settings import ARM_INC
 
@@ -40,19 +40,19 @@ class Uvision5(Exporter):
     def __init__(self):
         self._targets = []
 
-    @property
-    def TARGETS(self):
-        if not hasattr(self, "_targets_supported"):
-            self._targets_supported = []
+    @ExporterTargetsProperty
+    def TARGETS(cls):
+        if not hasattr(cls, "_targets_supported"):
+            cls._targets_supported = []
             for target in TARGET_NAMES:
                 try:
                     if (ProGenDef('uvision5').is_supported(str(TARGET_MAP[target])) or
                         ProGenDef('uvision5').is_supported(TARGET_MAP[target].progen['target'])):
-                        self._targets_supported.append(target)
+                        cls._targets_supported.append(target)
                 except AttributeError:
                     # target is not supported yet
                     continue
-        return self._targets_supported
+        return cls._targets_supported
 
     def get_toolchain(self):
         return TARGET_MAP[self.target].default_toolchain

--- a/tools/export/uvision5.py
+++ b/tools/export/uvision5.py
@@ -36,10 +36,6 @@ class Uvision5(Exporter):
 
     MBED_CONFIG_HEADER_SUPPORTED = True
 
-    # backward compatibility with our scripts
-    def __init__(self):
-        self._targets = []
-
     @ExporterTargetsProperty
     def TARGETS(cls):
         if not hasattr(cls, "_targets_supported"):


### PR DESCRIPTION

@bogdanm @theotherjimmy Please review. This is a fix for backward compatibility as our tools use for instance ``if is in Exporter.TARGETS`` . I found one more solution to this via metaclass, but was less clear to me. Any suggestions welcome.

Tested with the same command as reported, plus some others (uvision4,5 and iar as all of them introduced TARGETS as property):
``tools\project.py -c -m NUCLEO_L432KC -p 0 -i uvision5``

cc @svastm 