### PR TITLE
project - zip and src check if empty fix

### DIFF
--- a/tools/project.py
+++ b/tools/project.py
@@ -136,8 +136,8 @@ if __name__ == '__main__':
         p, src, ide = options.program, options.source_dir, options.ide
         project_dir, project_name, project_temp = setup_project(mcu, ide, p, src, options.build)
 
-        zip = src is []  # create zip when no src_dir provided
-        clean = src is []  # don't clean when source is provided, use acrual source tree for IDE files
+        zip = not bool(src)  # create zip when no src_dir provided
+        clean = not bool(src)  # don't clean when source is provided, use acrual source tree for IDE files
 
         # Export to selected toolchain
         lib_symbols = get_lib_symbols(options.macros, src, p)


### PR DESCRIPTION
Regression from #2179. Fixes #2184.

Before:

```
python tools\project.py -m KL25Z -p 0 -i gcc_arm

 * KL25Z::gcc_arm      C:\Code\git_repo\github\mbed\.build\export\.temp\MBED_A1
```

With this patch:

```
python tools\project.py -m KL25Z -p 0 -i gcc_arm

  * KL25Z::gcc_arm     mbed\.build\export\MBED_A1_gcc_arm_KL25Z.zip
```

@sarahmarshy @theotherjimmy @screamerbg 