### PR TITLE
[Tools] Unify common routines in build_api.py

### DIFF
--- a/tools/toolchains/__init__.py
+++ b/tools/toolchains/__init__.py
@@ -248,6 +248,9 @@ class mbedToolchain:
         # Labels generated from toolchain and target rules/features (used for selective build)
         self.labels = None
 
+        # This will hold the initialized config object
+        self.config = None
+
         # This will hold the configuration data (as returned by Config.get_config_data())
         self.config_data = None
 


### PR DESCRIPTION
Introduce prepare_toolchain() which handles:
 * de-duplication of src_paths
 * config initialization
 * toolchain initialization
 * toolchain flags
 * returns toolchain object

Introduce scan_resources() which handles:
 * scanning of sources
 * scanning of include dirs
 * inclusion of addition include dirs
 * returns resources object with scanned resources

Apply prepare_toolchain() and scan_resources() in:
* get_config()
* build_project()
* build_library()