### PR TITLE
[rtos] Add default constructor for Semaphore

### DIFF
--- a/rtos/rtos/Semaphore.h
+++ b/rtos/rtos/Semaphore.h
@@ -31,9 +31,9 @@ namespace rtos {
 class Semaphore {
 public:
     /** Create and Initialize a Semaphore object used for managing resources.
-      @param number of available resources; maximum index value is (count-1).
+      @param number of available resources; maximum index value is (count-1). (default: 0).
     */
-    Semaphore(int32_t count);
+    Semaphore(int32_t count=0);
 
     /** Wait until a Semaphore resource becomes available.
       @param   millisec  timeout value or 0 in case of no time-out. (default: osWaitForever).


### PR DESCRIPTION
Currently Semaphore can not be instantiated without an explicit count as a constructor argument. This limits where Semaphores can be declared and requires explicit initialization in several annoying places, such as in member variables and SingletonPtr targets.

This adds a default count of 0, which has shown to be the most common initial value used for semaphores.

cc @0xc0170, @c1728p9 