### PR TITLE
[api] Mark FunctionPointer and friends as deprecated

### DIFF
--- a/hal/api/FunctionPointer.h
+++ b/hal/api/FunctionPointer.h
@@ -17,6 +17,7 @@
 #define MBED_FUNCTIONPOINTER_H
 
 #include "Callback.h"
+#include "toolchain.h"
 #include <string.h>
 #include <stdint.h>
 
@@ -28,10 +29,12 @@ namespace mbed {
 template <typename R, typename A1>
 class FunctionPointerArg1 : public Callback<R(A1)> {
 public:
+    MBED_DEPRECATED("FunctionPointerArg1<R, A> has been replaced by Callback<R(A)>")
     FunctionPointerArg1(R (*function)(A1) = 0)
         : Callback<R(A1)>(function) {}
 
     template<typename T>
+    MBED_DEPRECATED("FunctionPointerArg1<R, A> has been replaced by Callback<R(A)>")
     FunctionPointerArg1(T *object, R (T::*member)(A1))
         : Callback<R(A1)>(object, member) {}
 
@@ -43,10 +46,12 @@ public:
 template <typename R>
 class FunctionPointerArg1<R, void> : public Callback<R()> {
 public:
+    MBED_DEPRECATED("FunctionPointer has been replaced by Callback<void()>")
     FunctionPointerArg1(R (*function)() = 0)
         : Callback<R()>(function) {}
 
     template<typename T>
+    MBED_DEPRECATED("FunctionPointer has been replaced by Callback<void()>")
     FunctionPointerArg1(T *object, R (T::*member)())
         : Callback<R()>(object, member) {}
 


### PR DESCRIPTION
FunctionPointer/FunctionPointerArg0/FunctionPointerArg1 has been replaced by the more flexible Callback template class.

For the motivation behind adopting the Callback class: https://github.com/mbedmicro/mbed/pull/1783

Feel free to discuss if you all feel strongly about keeping the FunctionPointer class.
cc @0xc0170, @sg- 