### PR TITLE
[STM32] Sleep code refactor

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F030R8/hal_tick.c
@@ -143,6 +143,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F031K6/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F042K6/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F070RB/hal_tick.c
@@ -155,6 +155,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F072RB/hal_tick.c
@@ -109,6 +109,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F0/TARGET_NUCLEO_F091RC/hal_tick.c
@@ -109,6 +109,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_DISCO_F100RB/hal_tick.c
@@ -131,6 +131,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_NUCLEO_F103RB/hal_tick.c
@@ -132,6 +132,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F303VC/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_DISCO_F334C8/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F302R8/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303K8/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F303RE/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F3/TARGET_NUCLEO_F334R8/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_B96B_F446VE/hal_tick.c
@@ -124,6 +124,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F401VC/hal_tick.c
@@ -109,6 +109,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/hal_tick.c
@@ -122,6 +122,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/hal_tick.h
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F429ZI/hal_tick.h
@@ -51,6 +51,8 @@
 
 #define HAL_TICK_DELAY (1000) // 1 ms
 
+void HAL_SuspendTick(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_DISCO_F469NI/hal_tick.c
@@ -110,6 +110,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_ELMO_F411RE/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_DRAGONFLY_F411RE/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F405RG/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_MTS_MDOT_F411RE/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F401RE/hal_tick.c
@@ -109,6 +109,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F410RB/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F411RE/hal_tick.c
@@ -108,6 +108,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F429ZI/hal_tick.c
@@ -122,6 +122,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_NUCLEO_F446RE/hal_tick.c
@@ -124,6 +124,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_STM32F407VG/hal_tick.c
@@ -110,6 +110,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F4/TARGET_UBLOX_C029/hal_tick.c
@@ -106,6 +106,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_DISCO_F746NG/hal_tick.c
@@ -126,6 +126,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+__INLINE void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+__INLINE void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F7/TARGET_NUCLEO_F746ZG/hal_tick.c
@@ -126,6 +126,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+__INLINE void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+__INLINE void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_DISCO_L053C8/hal_tick.c
@@ -131,6 +131,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L011K4/hal_tick.c
@@ -140,6 +140,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L031K6/hal_tick.c
@@ -131,6 +131,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L053R8/hal_tick.c
@@ -131,6 +131,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L0/TARGET_NUCLEO_L073RZ/hal_tick.c
@@ -131,6 +131,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_MOTE_L152RC/hal_tick.c
@@ -107,6 +107,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NUCLEO_L152RE/hal_tick.c
@@ -107,6 +107,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L1/TARGET_NZ32_SC151/hal_tick.c
@@ -107,6 +107,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_DISCO_L476VG/hal_tick.c
@@ -107,6 +107,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32L4/TARGET_NUCLEO_L476RG/hal_tick.c
@@ -107,6 +107,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+}
 /**
   * @}
   */

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F0/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F0/sleep.c
@@ -29,27 +29,12 @@
  */
 #include "sleep_api.h"
 
+
 #if DEVICE_SLEEP
 
 #include "cmsis.h"
 
-#if defined(TARGET_STM32F070RB)
-void sleep(void) {
-    TIM_HandleTypeDef TimMasterHandle;
 
-    TimMasterHandle.Instance = TIM1;
-
-    // Disable HAL tick and us_ticker update interrupts
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
-
-    // Request to enter SLEEP mode
-    HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick and us_ticker update interrupts
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
-}
-
-#elif defined(TARGET_STM32F030R8) || defined (TARGET_STM32F051R8)
 void sleep(void) {
     // Stop HAL systick
     HAL_SuspendTick();
@@ -59,22 +44,6 @@ void sleep(void) {
     HAL_ResumeTick();
 }
 
-#else
-static TIM_HandleTypeDef TimMasterHandle;
-
-void sleep(void) {
-    TimMasterHandle.Instance = TIM2;
-
-    // Disable HAL tick interrupt
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-
-    // Request to enter SLEEP mode
-    HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-}
-#endif
 
 #if defined(TARGET_STM32F030R8) || defined (TARGET_STM32F051R8)
 void deepsleep(void) {

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F1/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F1/sleep.c
@@ -34,20 +34,13 @@
 #include "cmsis.h"
 #include "hal_tick.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
-
-void sleep(void)
-{
-    TimMasterHandle.Instance = TIM_MST;
-
-    // Disable HAL tick and us_ticker update interrupts
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick and us_ticker update interrupts
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 void deepsleep(void)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F3/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F3/sleep.c
@@ -33,21 +33,16 @@
 
 #include "cmsis.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
 
-void sleep(void)
-{
-    TimMasterHandle.Instance = TIM2;
-
-    // Disable HAL tick interrupt
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
+
 
 void deepsleep(void)
 {

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F4/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F4/sleep.c
@@ -28,25 +28,18 @@
  *******************************************************************************
  */
 #include "sleep_api.h"
-
 #if DEVICE_SLEEP
 
 #include "cmsis.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
 
-void sleep(void)
-{
-    TimMasterHandle.Instance = TIM5;
-
-    // Disable HAL tick interrupt
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 void deepsleep(void)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32F7/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32F7/sleep.c
@@ -33,20 +33,13 @@
 
 #include "cmsis.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
-
-void sleep(void)
-{
-    TimMasterHandle.Instance = TIM5;
-
-    // Disable HAL tick interrupt
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 void deepsleep(void)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L0/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L0/sleep.c
@@ -33,20 +33,14 @@
 
 #include "cmsis.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
 
-void sleep(void)
-{
-    TimMasterHandle.Instance = TIM21;
-
-    // Disable HAL tick interrupt
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 void deepsleep(void)

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L1/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L1/sleep.c
@@ -28,6 +28,7 @@
  *******************************************************************************
  */
 #include "sleep_api.h"
+#include "hal_tick.h"
 
 #if DEVICE_SLEEP
 
@@ -35,18 +36,15 @@
 
 static TIM_HandleTypeDef TimMasterHandle;
 
-void sleep(void)
-{
-    // Disable HAL tick interrupt
-    TimMasterHandle.Instance = TIM5;
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
+
 
 void deepsleep(void)
 {
@@ -54,9 +52,8 @@ void deepsleep(void)
     int8_t STOPEntry = PWR_STOPENTRY_WFI;
 #endif
 
-    // Disable HAL tick interrupt
-    TimMasterHandle.Instance = TIM5;
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Stop HAL systick
+    TimMasterHandle.Instance = TIM_MST;
 
 #if defined(TARGET_MOTE_L152RC)
     /* Select the regulator state in Stop mode: Set PDDS and LPSDSR bit according to PWR_Regulator value */
@@ -91,8 +88,8 @@ void deepsleep(void)
     // After wake-up from STOP reconfigure the PLL
     SetSysClock();
 
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 #endif

--- a/hal/targets/hal/TARGET_STM/TARGET_STM32L4/sleep.c
+++ b/hal/targets/hal/TARGET_STM/TARGET_STM32L4/sleep.c
@@ -32,28 +32,20 @@
 #if DEVICE_SLEEP
 
 #include "cmsis.h"
-#include "hal_tick.h"
 
-static TIM_HandleTypeDef TimMasterHandle;
-
-void sleep(void)
-{
-    // Disable HAL tick interrupt
-    TimMasterHandle.Instance = TIM_MST;
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
-
+void sleep(void) {
+    // Stop HAL systick
+    HAL_SuspendTick();
     // Request to enter SLEEP mode
     HAL_PWR_EnterSLEEPMode(PWR_MAINREGULATOR_ON, PWR_SLEEPENTRY_WFI);
-
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 void deepsleep(void)
 {
-    // Disable HAL tick interrupt
-    TimMasterHandle.Instance = TIM_MST;
-    __HAL_TIM_DISABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Stop HAL systick
+    HAL_SuspendTick();
 
     // Request to enter STOP mode with regulator in low power mode
     HAL_PWR_EnterSTOPMode(PWR_LOWPOWERREGULATOR_ON, PWR_STOPENTRY_WFI);
@@ -61,8 +53,8 @@ void deepsleep(void)
     // After wake-up from STOP reconfigure the PLL
     SetSysClock();
 
-    // Enable HAL tick interrupt
-    __HAL_TIM_ENABLE_IT(&TimMasterHandle, TIM_IT_CC2);
+    // Restart HAL systick
+    HAL_ResumeTick();
 }
 
 #endif


### PR DESCRIPTION
Rework of sleep.c file across all STM32 families.
Aim was to correct sleep bug in DISCO_F469NI, not entering sleep mode due to use of wrong timer.
In the same time I took opportunity to refactor sleep code taking advantage of hal_tick.c functions.

STM32F7xxx code benefits from __INLINE, which is not compiling on other families for ARM and uARM toolchains (not compatible with __weak as per keil documentation).