### PR TITLE
[LPC15XX] Fixed µs_ticker implementation

### DIFF
--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/pwmout_api.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/pwmout_api.c
@@ -27,7 +27,7 @@ static LPC_SCT0_Type *SCTs[4] = {
 };
 
 // bit flags for used SCTs
-static unsigned char sct_used = 0;
+static unsigned char sct_used = (1 << 3);
 static int get_available_sct(void) {
     int i;
     for (i=0; i<4; i++) {

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
@@ -61,12 +61,11 @@ uint32_t us_ticker_read() {
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {
     // Set SCT3 match register 0 (critical section)
-    int wasMasked = __disable_irq();
+    __disable_irq();
     LPC_SCT3->CTRL |= (1 << 2);
     LPC_SCT3->MATCH0 = (uint32_t)timestamp;
     LPC_SCT3->CTRL &= ~(1 << 2);
-    if (!wasMasked)
-        __enable_irq();
+    __enable_irq();
 
     // Enable interrupt on SCT3 event 0
     LPC_SCT3->EVEN = (1 << 0);

--- a/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
+++ b/hal/targets/hal/TARGET_NXP/TARGET_LPC15XX/us_ticker.c
@@ -16,6 +16,7 @@
 #include <stddef.h>
 #include "us_ticker_api.h"
 #include "PeripheralNames.h"
+#include "critical.h"
 
 #define US_TICKER_TIMER_IRQn     SCT3_IRQn
 
@@ -61,11 +62,11 @@ uint32_t us_ticker_read() {
 
 void us_ticker_set_interrupt(timestamp_t timestamp) {
     // Set SCT3 match register 0 (critical section)
-    __disable_irq();
+    core_util_critical_section_enter();
     LPC_SCT3->CTRL |= (1 << 2);
     LPC_SCT3->MATCH0 = (uint32_t)timestamp;
     LPC_SCT3->CTRL &= ~(1 << 2);
-    __enable_irq();
+    core_util_critical_section_exit();
 
     // Enable interrupt on SCT3 event 0
     LPC_SCT3->EVEN = (1 << 0);


### PR DESCRIPTION
Re-wrote µs_ticker implementation to use SCT3 instead of RIT in order to fix a serious rollover bug at 1:11:34 (#1699).