### PR TITLE
[RTOS] Updated RtosTimer to use Callback

### DIFF
--- a/rtos/rtos/RtosTimer.cpp
+++ b/rtos/rtos/RtosTimer.cpp
@@ -23,19 +23,21 @@
 
 #include <string.h>
 
+#include "mbed.h"
 #include "cmsis_os.h"
 #include "mbed_error.h"
 
 namespace rtos {
 
-RtosTimer::RtosTimer(void (*periodic_task)(void const *argument), os_timer_type type, void *argument) {
+void RtosTimer::constructor(mbed::Callback<void()> func, os_timer_type type) {
 #ifdef CMSIS_OS_RTX
-    _timer.ptimer = periodic_task;
+    _timer.ptimer = (void (*)(const void *))Callback<void()>::thunk;
 
     memset(_timer_data, 0, sizeof(_timer_data));
     _timer.timer = _timer_data;
 #endif
-    _timer_id = osTimerCreate(&_timer, type, argument);
+    _function = func;
+    _timer_id = osTimerCreate(&_timer, type, &_function);
 }
 
 osStatus RtosTimer::start(uint32_t millisec) {

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -25,6 +25,7 @@
 #include <stdint.h>
 #include "cmsis_os.h"
 #include "Callback.h"
+#include "toolchain.h"
 
 namespace rtos {
 

--- a/rtos/rtos/RtosTimer.h
+++ b/rtos/rtos/RtosTimer.h
@@ -40,6 +40,17 @@ public:
     /** Create timer.
       @param   func      function to be executed by this timer.
       @param   type      osTimerOnce for one-shot or osTimerPeriodic for periodic behaviour. (default: osTimerPeriodic)
+      @param   argument  argument to the timer call back function. (default: NULL)
+      @deprecated Replaced with RtosTimer(Callback<void()>, os_timer_type)
+     */
+    MBED_DEPRECATED("Replaced with RtosTimer(Callback<void()>, os_timer_type)")
+    RtosTimer(void (*func)(void const *argument), os_timer_type type=osTimerPeriodic, void *argument=NULL) {
+        constructor(mbed::Callback<void()>(argument, (void (*)(void *))func), type);
+    }
+    
+    /** Create timer.
+      @param   func      function to be executed by this timer.
+      @param   type      osTimerOnce for one-shot or osTimerPeriodic for periodic behaviour. (default: osTimerPeriodic)
     */
     RtosTimer(mbed::Callback<void()> func, os_timer_type type=osTimerPeriodic) {
         constructor(func, type);


### PR DESCRIPTION
Updated the `RtosTimer` class to use `Callback` in order to be consistent with the updated `Thread` class.