### PR TITLE
[tools] Modified config to aggregate cumulative overrides against targets

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -149,7 +149,7 @@ class ConfigCumulativeOverride:
     def remove_cumulative_overrides(self, overrides):
         for override in overrides:
             if override in self.additions:
-                raise ConfigException("Configuration conflict. The %s %s both added and removed." % (self.name, override))
+                raise ConfigException("Configuration conflict. The %s %s both added and removed." % (self.name[:-1], override))
 
         self.removals |= set(overrides)
 
@@ -157,7 +157,7 @@ class ConfigCumulativeOverride:
     def add_cumulative_overrides(self, overrides):
         for override in overrides:
             if (override in self.removals or (self.strict and override not in self.additions)):
-                raise ConfigException("Configuration conflict. The %s %s both added and removed." % (self.name, override))
+                raise ConfigException("Configuration conflict. The %s %s both added and removed." % (self.name[:-1], override))
 
         self.additions |= set(overrides)
 

--- a/tools/test/config_test/test23/test_data.py
+++ b/tools/test/config_test/test23/test_data.py
@@ -3,6 +3,6 @@
 expected_results = {
     "K64F": {
         "desc": "test feature collisions",
-        "exception_msg": "Configuration conflict. Feature IPV4 both added and removed." 
+        "exception_msg": "Configuration conflict. The feature IPV4 both added and removed." 
     }
 }

--- a/tools/test/config_test/test25/test_data.py
+++ b/tools/test/config_test/test25/test_data.py
@@ -3,6 +3,6 @@
 expected_results = {
     "K64F": {
         "desc": "test recursive feature collisions",
-        "exception_msg": "Configuration conflict. Feature UVISOR both added and removed." 
+        "exception_msg": "Configuration conflict. The feature UVISOR both added and removed." 
     }
 }


### PR DESCRIPTION
Modified '_process_config_and_overrides' to update cumulative attributes based on cumulative overrides found during walking config files.

This should remove most of the disparity between the config target cumulative overrides and cumulative attributes set in targets.json. These cumulative overrides are updated after the global target
instantiation though, which may cause internal build tool state dependent on cumulative attributes to not correctly reflect all cumulative overrides.

Example:
``` json
{
  "target_overrides": {
    "K64F": {
      "target.features_add": ["COOL_THING"],
      "target.extra_labels_add": ["COOL_THING_SUPPORTED"],
      "target.macros_add": ["COOL_THING_IS_HERE"],
      "target.device_has_add": ["COOL_THING_YES"]
    }
  }
}
```

cc @sg-, @screamerbg, @theotherjimmy
related #2209