### PR TITLE
[BEETLE] Add comment to clarify LEDs Emulation

### DIFF
--- a/hal/targets/hal/TARGET_ARM_SSG/TARGET_BEETLE/PinNames.h
+++ b/hal/targets/hal/TARGET_ARM_SSG/TARGET_BEETLE/PinNames.h
@@ -127,6 +127,15 @@ typedef enum {
     SENSOR_SCL = 507,
 
     // Emulated LEDS
+    /*
+     * Beetle board is built to optimize power consumption therefore does not
+     * provide on-board LEDs. The configuration below is provided only for
+     * compatibility purposes with MBED test suite.
+     * The LEDs [1:4] are emulated and trapped in our GPIO driver.
+     * For more details on how to use a Led on an external PIN via GPIO
+     * configuration please refer to the connected community page below:
+     * https://community.arm.com/docs/DOC-11713
+     */
     LED1 = 1001,
     LED2 = 1002,
     LED3 = 1003,


### PR DESCRIPTION
Beetle board is built to optimize power consumption therefore does not
provide on-board LEDs.

This patch adds a comment in PinNames in order to clarify that the
Emulated LEDs are provided for compatibility reasons with the MBED test
suite.

Signed-off-by: Vincenzo Frascino <vincenzo.frascino@arm.com>