### PR TITLE
Improvements to k64 internal-flash storage driver

### DIFF
--- a/hal/hal/storage_abstraction/Driver_Storage.h
+++ b/hal/hal/storage_abstraction/Driver_Storage.h
@@ -42,6 +42,7 @@ extern "C" {
 #define ARM_STORAGE_ERROR_NOT_ERASABLE      (ARM_DRIVER_ERROR_SPECIFIC - 1) ///< Part (or all) of the range provided to Erase() isn't erasable.
 #define ARM_STORAGE_ERROR_NOT_PROGRAMMABLE  (ARM_DRIVER_ERROR_SPECIFIC - 2) ///< Part (or all) of the range provided to ProgramData() isn't programmable.
 #define ARM_STORAGE_ERROR_PROTECTED         (ARM_DRIVER_ERROR_SPECIFIC - 3) ///< Part (or all) of the range to Erase() or ProgramData() is protected.
+#define ARM_STORAGE_ERROR_RUNTIME_OR_INTEGRITY_FAILURE (ARM_DRIVER_ERROR_SPECIFIC - 4) ///< Runtime or sanity-check failure.
 
 /**
  * \brief Attributes of the storage range within a storage block.

--- a/hal/hal/storage_abstraction/Driver_Storage.h
+++ b/hal/hal/storage_abstraction/Driver_Storage.h
@@ -18,6 +18,8 @@
 #ifndef __DRIVER_STORAGE_H
 #define __DRIVER_STORAGE_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif // __cplusplus

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -17,8 +17,6 @@
 
 #if DEVICE_STORAGE
 
-#include <string.h>
-
 #include "Driver_Storage.h"
 #include "cmsis_nvic.h"
 #include "MK64F12.h"
@@ -30,8 +28,10 @@
 #ifndef USING_KSDK2
 #include "device/MK64F12/MK64F12_ftfe.h"
 #else
-#include "drivers/fsl_flash.h"
+#include "fsl_flash.h"
 #endif
+
+#include <string.h>
 
 #ifdef USING_KSDK2
 /*!

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -591,7 +591,7 @@ static int32_t executeCommand(struct mtd_k64f_data *context)
             return ARM_DRIVER_ERROR_PARAMETER;
         }
         if (failedWithRunTimeError()) {
-            return ARM_DRIVER_ERROR; /* unspecified runtime error. */
+            return ARM_STORAGE_ERROR_RUNTIME_OR_INTEGRITY_FAILURE;
         }
 
         /* signal synchronous completion. */
@@ -638,7 +638,7 @@ static void ftfe_ccie_irq_handler(void)
     }
     if (failedWithRunTimeError()) {
         if (context->commandCompletionCallback) {
-            context->commandCompletionCallback(ARM_DRIVER_ERROR, context->currentCommand);
+            context->commandCompletionCallback(ARM_STORAGE_ERROR_RUNTIME_OR_INTEGRITY_FAILURE, context->currentCommand);
         }
         return;
     }

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -169,16 +169,16 @@ struct mtd_k64f_data {
 static const ARM_STORAGE_BLOCK blockTable[] = {
     {
         /**< This is the start address of the flash block. */
-#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR
-        .addr       = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR,
+#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_START_ADDR
+        .addr       = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_START_ADDR,
 #else
         .addr       = BLOCK1_START_ADDR,
 #endif
 
         /**< This is the size of the flash block, in units of bytes.
          *   Together with addr, it describes a range [addr, addr+size). */
-#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE
-        .size       = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE,
+#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_SIZE
+        .size       = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_SIZE,
 #else
         .size       = BLOCK1_SIZE,
 #endif
@@ -200,7 +200,7 @@ static const ARM_DRIVER_VERSION version = {
 };
 
 
-#if (!defined(DEVICE_STORAGE_CONFIG_HARDWARE_MTD_ASYNC_OPS) || DEVICE_STORAGE_CONFIG_HARDWARE_MTD_ASYNC_OPS)
+#if (!defined(DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_ASYNC_OPS) || DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_ASYNC_OPS)
 #define ASYNC_OPS 1
 #else
 #define ASYNC_OPS 0
@@ -219,8 +219,8 @@ static const ARM_STORAGE_CAPABILITIES caps = {
     .asynchronous_ops = ASYNC_OPS,
 
     /* Enable chip-erase functionality if we own all of block-1. */
-    #if ((!defined (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR) || (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_START_ADDR == BLOCK1_START_ADDR)) && \
-         (!defined (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE)       || (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE == BLOCK1_SIZE)))
+    #if ((!defined (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_START_ADDR) || (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_START_ADDR == BLOCK1_START_ADDR)) && \
+         (!defined (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_SIZE)       || (DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_SIZE == BLOCK1_SIZE)))
     .erase_all        = 1,    /**< Supports EraseChip operation. */
     #else
     .erase_all        = 0,    /**< Supports EraseChip operation. */
@@ -228,8 +228,8 @@ static const ARM_STORAGE_CAPABILITIES caps = {
 };
 
 static const ARM_STORAGE_INFO info = {
-#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE
-    .total_storage        = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SIZE, /**< Total available storage, in units of octets. */
+#ifdef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_SIZE
+    .total_storage        = DEVICE_STORAGE_CONFIG_HARDWARE_MTD_K64F_SIZE, /**< Total available storage, in units of octets. */
 #else
     .total_storage        = BLOCK1_SIZE, /**< Total available storage, in units of octets. By default, BLOCK0 is reserved to hold program code. */
 #endif

--- a/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
+++ b/hal/targets/hal/TARGET_Freescale/TARGET_KSDK2_MCUS/TARGET_K64F/storage_driver.c
@@ -15,10 +15,6 @@
  * limitations under the License.
  */
 
-/**
- * This is a mock driver using the flash abstraction layer. It allows for writing tests.
- */
-
 #if DEVICE_STORAGE
 
 #include <string.h>


### PR DESCRIPTION
- Discover flash integrity failures during erase and program
- Optimize away erase when target range is already erased. 
- Switch to using more specific names in DEVICE_STORAGE_CONFIG_*
- Salvage  changes from https://github.com/mbedmicro/mbed/pull/2150 which are still useful

Note: This change-set doesn't have the following (as requested by @mjs-arm):
> - MUST - Hardwire the K64F storage driver to ASYNC only operation (not user  >configurable).

We still need to resolve if ASYNC operation is to be forced since there are some internal use cases which rely upon synchronous operation.

review: @0xc0170 @sg- 
notify: @mjs-arm @marcuschangarm @simonqhughes @meriac 