### PR TITLE
[BLUEPILL_F103C8] Sleep code refactor

### DIFF
--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/hal_tick.c
@@ -138,16 +138,14 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
-void HAL_SuspendTick(void)
-{
+void HAL_SuspendTick(void) {
     TimMasterHandle.Instance = TIM_MST;
 
     // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
     __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
 }
 
-void HAL_ResumeTick(void)
-{
+void HAL_ResumeTick(void) {
     TimMasterHandle.Instance = TIM_MST;
 
 	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)

--- a/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/hal_tick.c
+++ b/hal/targets/cmsis/TARGET_STM/TARGET_STM32F1/TARGET_BLUEPILL_F103C8/hal_tick.c
@@ -138,6 +138,21 @@ HAL_StatusTypeDef HAL_InitTick(uint32_t TickPriority) {
     return HAL_OK;
 }
 
+void HAL_SuspendTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+    // Disable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+    __HAL_TIM_DISABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
+
+void HAL_ResumeTick(void)
+{
+    TimMasterHandle.Instance = TIM_MST;
+
+	// Enable HAL tick and us_ticker update interrupts (used for 32 bit counter)
+	__HAL_TIM_ENABLE_IT(&TimMasterHandle, (TIM_IT_CC2 | TIM_IT_UPDATE));
+}
 /**
   * @}
   */


### PR DESCRIPTION
This commit adds to TARGET_BLUEPILL_F103C8 changes that have been introduced with PR #2192 for other STM32_F1 targets, specifically in https://github.com/mbedmicro/mbed/commit/a227a9438c834032beb292a06a62b471eb487a02