### PR TITLE
Introduce a SDCard backed Storage driver

### DIFF
--- a/features/storage/sdcard_driver/SDCardBlock.cpp
+++ b/features/storage/sdcard_driver/SDCardBlock.cpp
@@ -1,0 +1,462 @@
+/*
+ * Copyright (c) 2006-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/* Introduction
+ * ------------
+ * SD and MMC cards support a number of interfaces, but common to them all
+ * is one based on SPI. This is the one I'm implmenting because it means
+ * it is much more portable even though not so performant, and we already
+ * have the mbed SPI Interface!
+ *
+ * The main reference I'm using is Chapter 7, "SPI Mode" of:
+ *  http://www.sdcard.org/developers/tech/sdcard/pls/Simplified_Physical_Layer_Spec.pdf
+ *
+ * SPI Startup
+ * -----------
+ * The SD card powers up in SD mode. The SPI interface mode is selected by
+ * asserting CS low and sending the reset command (CMD0). The card will
+ * respond with a (R1) response.
+ *
+ * CMD8 is optionally sent to determine the voltage range supported, and
+ * indirectly determine whether it is a version 1.x SD/non-SD card or
+ * version 2.x. I'll just ignore this for now.
+ *
+ * ACMD41 is repeatedly issued to initialise the card, until "in idle"
+ * (bit 0) of the R1 response goes to '0', indicating it is initialised.
+ *
+ * You should also indicate whether the host supports High Capicity cards,
+ * and check whether the card is high capacity - i'll also ignore this
+ *
+ * SPI Protocol
+ * ------------
+ * The SD SPI protocol is based on transactions made up of 8-bit words, with
+ * the host starting every bus transaction by asserting the CS signal low. The
+ * card always responds to commands, data blocks and errors.
+ *
+ * The protocol supports a CRC, but by default it is off (except for the
+ * first reset CMD0, where the CRC can just be pre-calculated, and CMD8)
+ * I'll leave the CRC off I think!
+ *
+ * Standard capacity cards have variable data block sizes, whereas High
+ * Capacity cards fix the size of data block to 512 bytes. I'll therefore
+ * just always use the Standard Capacity cards with a block size of 512 bytes.
+ * This is set with CMD16.
+ *
+ * You can read and write single blocks (CMD17, CMD25) or multiple blocks
+ * (CMD18, CMD25). For simplicity, I'll just use single block accesses. When
+ * the card gets a read command, it responds with a response token, and then
+ * a data token or an error.
+ *
+ * SPI Command Format
+ * ------------------
+ * Commands are 6-bytes long, containing the command, 32-bit argument, and CRC.
+ *
+ * +---------------+------------+------------+-----------+----------+--------------+
+ * | 01 | cmd[5:0] | arg[31:24] | arg[23:16] | arg[15:8] | arg[7:0] | crc[6:0] | 1 |
+ * +---------------+------------+------------+-----------+----------+--------------+
+ *
+ * As I'm not using CRC, I can fix that byte to what is needed for CMD0 (0x95)
+ *
+ * All Application Specific commands shall be preceded with APP_CMD (CMD55).
+ *
+ * SPI Response Format
+ * -------------------
+ * The main response format (R1) is a status byte (normally zero). Key flags:
+ *  idle - 1 if the card is in an idle state/initialising
+ *  cmd  - 1 if an illegal command code was detected
+ *
+ *    +-------------------------------------------------+
+ * R1 | 0 | arg | addr | seq | crc | cmd | erase | idle |
+ *    +-------------------------------------------------+
+ *
+ * R1b is the same, except it is followed by a busy signal (zeros) until
+ * the first non-zero byte when it is ready again.
+ *
+ * Data Response Token
+ * -------------------
+ * Every data block written to the card is acknowledged by a byte
+ * response token
+ *
+ * +----------------------+
+ * | xxx | 0 | status | 1 |
+ * +----------------------+
+ *              010 - OK!
+ *              101 - CRC Error
+ *              110 - Write Error
+ *
+ * Single Block Read and Write
+ * ---------------------------
+ *
+ * Block transfers have a byte header, followed by the data, followed
+ * by a 16-bit CRC. In our case, the data will always be 512 bytes.
+ *
+ * +------+---------+---------+- -  - -+---------+-----------+----------+
+ * | 0xFE | data[0] | data[1] |        | data[n] | crc[15:8] | crc[7:0] |
+ * +------+---------+---------+- -  - -+---------+-----------+----------+
+ */
+
+#if DEVICE_STORAGE_SDCARD
+
+#include "SDCardBlock.h"
+#include "mbed_debug.h"
+
+#define SD_COMMAND_TIMEOUT 5000
+
+#define SD_DBG             0
+
+SDCardBlock::SDCardBlock(PinName mosi, PinName miso, PinName sclk, PinName cs)
+    :   _spi(mosi, miso, sclk),
+        _cs(cs)
+{
+    _cs = 1;
+}
+
+#define R1_IDLE_STATE           (1 << 0)
+#define R1_ERASE_RESET          (1 << 1)
+#define R1_ILLEGAL_COMMAND      (1 << 2)
+#define R1_COM_CRC_ERROR        (1 << 3)
+#define R1_ERASE_SEQUENCE_ERROR (1 << 4)
+#define R1_ADDRESS_ERROR        (1 << 5)
+#define R1_PARAMETER_ERROR      (1 << 6)
+
+// Types
+#define SDCARD_FAIL 0 //!< v1.x Standard Capacity
+#define SDCARD_V1   1 //!< v2.x Standard Capacity
+#define SDCARD_V2   2 //!< v2.x High Capacity
+#define SDCARD_V2HC 3 //!< Not recognised as an SD Card
+
+int SDCardBlock::initialise_card() {
+    // Set to 100kHz for initialisation, and clock card with cs = 1
+    _spi.frequency(100000);
+    _cs = 1;
+    for (int i = 0; i < 16; i++) {
+        _spi.write(0xFF);
+    }
+
+    // send CMD0, should return with all zeros except IDLE STATE set (bit 0)
+    if (_cmd(0, 0) != R1_IDLE_STATE) {
+        debug("No disk, or could not put SD card in to SPI idle state\n");
+        return SDCARD_FAIL;
+    }
+
+    // send CMD8 to determine whther it is ver 2.x
+    int r = _cmd8();
+    if (r == R1_IDLE_STATE) {
+        return initialise_card_v2();
+    } else if (r == (R1_IDLE_STATE | R1_ILLEGAL_COMMAND)) {
+        return initialise_card_v1();
+    } else {
+        debug("Not in idle state after sending CMD8 (not an SD card?)\n");
+        return SDCARD_FAIL;
+    }
+}
+
+int SDCardBlock::initialise_card_v1() {
+    for (int i = 0; i < SD_COMMAND_TIMEOUT; i++) {
+        _cmd(55, 0);
+        if (_cmd(41, 0) == 0) {
+            cdv = 512;
+            debug_if(SD_DBG, "\n\rInit: SEDCARD_V1\n\r");
+            return SDCARD_V1;
+        }
+    }
+
+    debug("Timeout waiting for v1.x card\n");
+    return SDCARD_FAIL;
+}
+
+int SDCardBlock::initialise_card_v2() {
+    for (int i = 0; i < SD_COMMAND_TIMEOUT; i++) {
+        wait_ms(50);
+        _cmd58();
+        _cmd(55, 0);
+        if (_cmd(41, 0x40000000) == 0) {
+            _cmd58();
+            debug_if(SD_DBG, "\n\rInit: SDCARD_V2\n\r");
+            cdv = 1;
+            return SDCARD_V2;
+        }
+    }
+
+    debug("Timeout waiting for v2.x card\n");
+    return SDCARD_FAIL;
+}
+
+int SDCardBlock::disk_initialize() {
+    int i = initialise_card();
+    debug_if(SD_DBG, "init card = %d\n", i);
+    _sectors = _sd_sectors();
+
+    // Set block length to 512 (CMD16)
+    if (_cmd(16, 512) != 0) {
+        debug("Set 512-byte block timed out\n");
+        return 1;
+    }
+
+    _spi.frequency(1000000); // Set to 1MHz for data transfer
+    return 0;
+}
+
+int SDCardBlock::disk_write(const uint8_t *buffer, uint64_t block_number) {
+    // set write address for single block (CMD24)
+    if (_cmd(24, block_number * cdv) != 0) {
+        return 1;
+    }
+
+    // send the data block
+    _write(buffer, 512);
+    return 0;
+}
+
+int SDCardBlock::disk_read(uint8_t *buffer, uint64_t block_number) {
+    // set read address for single block (CMD17)
+    if (_cmd(17, block_number * cdv) != 0) {
+        return 1;
+    }
+
+    // receive the data
+    _read(buffer, 512);
+    return 0;
+}
+
+uint64_t SDCardBlock::disk_sectors() { return _sectors; }
+
+
+// PRIVATE FUNCTIONS
+int SDCardBlock::_cmd(int cmd, int arg) {
+    _cs = 0;
+
+    // send a command
+    _spi.write(0x40 | cmd);
+    _spi.write(arg >> 24);
+    _spi.write(arg >> 16);
+    _spi.write(arg >> 8);
+    _spi.write(arg >> 0);
+    _spi.write(0x95);
+
+    // wait for the repsonse (response[7] == 0)
+    for (int i = 0; i < SD_COMMAND_TIMEOUT; i++) {
+        int response = _spi.write(0xFF);
+        if (!(response & 0x80)) {
+            _cs = 1;
+            _spi.write(0xFF);
+            return response;
+        }
+    }
+    _cs = 1;
+    _spi.write(0xFF);
+    return -1; // timeout
+}
+int SDCardBlock::_cmdx(int cmd, int arg) {
+    _cs = 0;
+
+    // send a command
+    _spi.write(0x40 | cmd);
+    _spi.write(arg >> 24);
+    _spi.write(arg >> 16);
+    _spi.write(arg >> 8);
+    _spi.write(arg >> 0);
+    _spi.write(0x95);
+
+    // wait for the repsonse (response[7] == 0)
+    for (int i = 0; i < SD_COMMAND_TIMEOUT; i++) {
+        int response = _spi.write(0xFF);
+        if (!(response & 0x80)) {
+            return response;
+        }
+    }
+    _cs = 1;
+    _spi.write(0xFF);
+    return -1; // timeout
+}
+
+
+int SDCardBlock::_cmd58() {
+    _cs = 0;
+    int arg = 0;
+
+    // send a command
+    _spi.write(0x40 | 58);
+    _spi.write(arg >> 24);
+    _spi.write(arg >> 16);
+    _spi.write(arg >> 8);
+    _spi.write(arg >> 0);
+    _spi.write(0x95);
+
+    // wait for the repsonse (response[7] == 0)
+    for (int i = 0; i < SD_COMMAND_TIMEOUT; i++) {
+        int response = _spi.write(0xFF);
+        if (!(response & 0x80)) {
+            int ocr = _spi.write(0xFF) << 24;
+            ocr |= _spi.write(0xFF) << 16;
+            ocr |= _spi.write(0xFF) << 8;
+            ocr |= _spi.write(0xFF) << 0;
+            _cs = 1;
+            _spi.write(0xFF);
+            return response;
+        }
+    }
+    _cs = 1;
+    _spi.write(0xFF);
+    return -1; // timeout
+}
+
+int SDCardBlock::_cmd8() {
+    _cs = 0;
+
+    // send a command
+    _spi.write(0x40 | 8); // CMD8
+    _spi.write(0x00);     // reserved
+    _spi.write(0x00);     // reserved
+    _spi.write(0x01);     // 3.3v
+    _spi.write(0xAA);     // check pattern
+    _spi.write(0x87);     // crc
+
+    // wait for the repsonse (response[7] == 0)
+    for (int i = 0; i < SD_COMMAND_TIMEOUT * 1000; i++) {
+        char response[5];
+        response[0] = _spi.write(0xFF);
+        if (!(response[0] & 0x80)) {
+            for (int j = 1; j < 5; j++) {
+                response[i] = _spi.write(0xFF);
+            }
+            _cs = 1;
+            _spi.write(0xFF);
+            return response[0];
+        }
+    }
+    _cs = 1;
+    _spi.write(0xFF);
+    return -1; // timeout
+}
+
+int SDCardBlock::_read(uint8_t *buffer, uint32_t length) {
+    _cs = 0;
+
+    // read until start byte (0xFF)
+    while (_spi.write(0xFF) != 0xFE);
+
+    // read data
+    for (uint32_t i = 0; i < length; i++) {
+        buffer[i] = _spi.write(0xFF);
+    }
+    _spi.write(0xFF); // checksum
+    _spi.write(0xFF);
+
+    _cs = 1;
+    _spi.write(0xFF);
+    return 0;
+}
+
+int SDCardBlock::_write(const uint8_t*buffer, uint32_t length) {
+    _cs = 0;
+
+    // indicate start of block
+    _spi.write(0xFE);
+
+    // write the data
+    for (uint32_t i = 0; i < length; i++) {
+        _spi.write(buffer[i]);
+    }
+
+    // write the checksum
+    _spi.write(0xFF);
+    _spi.write(0xFF);
+
+    // check the response token
+    if ((_spi.write(0xFF) & 0x1F) != 0x05) {
+        _cs = 1;
+        _spi.write(0xFF);
+        return 1;
+    }
+
+    // wait for write to finish
+    while (_spi.write(0xFF) == 0);
+
+    _cs = 1;
+    _spi.write(0xFF);
+    return 0;
+}
+
+static uint32_t ext_bits(unsigned char *data, int msb, int lsb) {
+    uint32_t bits = 0;
+    uint32_t size = 1 + msb - lsb;
+    for (uint32_t i = 0; i < size; i++) {
+        uint32_t position = lsb + i;
+        uint32_t byte = 15 - (position >> 3);
+        uint32_t bit = position & 0x7;
+        uint32_t value = (data[byte] >> bit) & 1;
+        bits |= value << i;
+    }
+    return bits;
+}
+
+uint64_t SDCardBlock::_sd_sectors() {
+    uint32_t c_size, c_size_mult, read_bl_len;
+    uint32_t block_len, mult, blocknr, capacity;
+    uint32_t hc_c_size;
+    uint64_t blocks;
+
+    // CMD9, Response R2 (R1 byte + 16-byte block read)
+    if (_cmdx(9, 0) != 0) {
+        debug("Didn't get a response from the disk\n");
+        return 0;
+    }
+
+    uint8_t csd[16];
+    if (_read(csd, 16) != 0) {
+        debug("Couldn't read csd response from disk\n");
+        return 0;
+    }
+
+    // csd_structure : csd[127:126]
+    // c_size        : csd[73:62]
+    // c_size_mult   : csd[49:47]
+    // read_bl_len   : csd[83:80] - the *maximum* read block length
+
+    int csd_structure = ext_bits(csd, 127, 126);
+
+    switch (csd_structure) {
+        case 0:
+            cdv = 512;
+            c_size = ext_bits(csd, 73, 62);
+            c_size_mult = ext_bits(csd, 49, 47);
+            read_bl_len = ext_bits(csd, 83, 80);
+
+            block_len = 1 << read_bl_len;
+            mult = 1 << (c_size_mult + 2);
+            blocknr = (c_size + 1) * mult;
+            capacity = blocknr * block_len;
+            blocks = capacity / 512;
+            debug_if(SD_DBG, "\n\rSDCard\n\rc_size: %d \n\rcapacity: %ld \n\rsectors: %lld\n\r", c_size, capacity, blocks);
+            break;
+
+        case 1:
+            cdv = 1;
+            hc_c_size = ext_bits(csd, 63, 48);
+            blocks = (hc_c_size+1)*1024;
+            debug_if(SD_DBG, "\n\rSDHC Card \n\rhc_c_size: %d\n\rcapacity: %lld \n\rsectors: %lld\n\r", hc_c_size, blocks*512, blocks);
+            break;
+
+        default:
+            debug("CSD struct unsupported\r\n");
+            return 0;
+    };
+    return blocks;
+}
+
+#endif /* #if DEVICE_STORAGE_SDCARD */

--- a/features/storage/sdcard_driver/SDCardBlock.h
+++ b/features/storage/sdcard_driver/SDCardBlock.h
@@ -1,0 +1,80 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2012 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+#ifndef __SD_CARD_BLOCK_H__
+#define __SD_CARD_BLOCK_H__
+
+#include "SDCardInterface.h"
+#include "mbed-drivers/mbed.h"
+
+/** Access the filesystem on an SD Card using SPI
+ *
+ * @code
+ * #include "mbed.h"
+ * #include "SDFileSystem.h"
+ *
+ * SDFileSystem sd(p5, p6, p7, p12, "sd"); // MOSI, MISO, SCLK, SSEL
+ *
+ * int main() {
+ *     FILE *fp = fopen("/sd/mbed.txt", "w");
+ *     fprintf(fp, "Hello World!\n");
+ *     fclose(fp);
+ * }
+ * @endcode
+ */
+class SDCardBlock : public SDCardInterface {
+public:
+
+    /** Create the File System for accessing an SD Card using SPI
+     *
+     * @param mosi SPI mosi pin connected to SD Card
+     * @param miso SPI miso pin conencted to SD Card
+     * @param sclk SPI sclk pin connected to SD Card
+     * @param cs   DigitalOut pin used as SD Card chip select
+     */
+    SDCardBlock(PinName mosi, PinName miso, PinName sclk, PinName cs);
+
+    int disk_initialize();
+    int disk_read(uint8_t * buffer, uint64_t block_number);
+    int disk_write(const uint8_t * buffer, uint64_t block_number);
+    uint64_t disk_sectors();
+
+protected:
+
+    int _cmd(int cmd, int arg);
+    int _cmdx(int cmd, int arg);
+    int _cmd8();
+    int _cmd58();
+    int initialise_card();
+    int initialise_card_v1();
+    int initialise_card_v2();
+
+    int _read(uint8_t * buffer, uint32_t length);
+    int _write(const uint8_t *buffer, uint32_t length);
+    uint64_t _sd_sectors();
+    uint64_t _sectors;
+
+    SPI _spi;
+    DigitalOut _cs;
+    int cdv;
+};
+
+#endif // __SD_CARD_BLOCK_H__

--- a/features/storage/sdcard_driver/SDCardImpl.cpp
+++ b/features/storage/sdcard_driver/SDCardImpl.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (c) 2006-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if DEVICE_STORAGE_SDCARD
+
+#include "SDCardBlock.h"
+
+#ifndef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_MOSI
+    #ifdef TARGET_K64F
+    	#define MOSI PTE3
+    #else
+    	#error "Please define the MOSI GPIO connecting from the MCU to the SDCard"
+    #endif
+#else
+	#define MOSI DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_MOSI
+#endif
+
+#ifndef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_MISO
+    #ifdef TARGET_K64F
+    	#define MISO PTE1
+    #else
+    	#error "Please define the MISO GPIO connecting from the MCU to the SDCard"
+    #endif
+#else
+	#define MISO DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_MISO
+#endif
+
+#ifndef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_SCK
+    #ifdef TARGET_K64F
+    	#define SCK  PTE2
+    #else
+    	#error "Please define the serial-clock GPIO connecting from the MCU to the SDCard"
+    #endif
+#else
+	#define SCK  DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_SCK
+#endif
+
+#ifndef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_CS
+    #ifdef TARGET_K64F
+	   #define CS   PTE4
+    #else
+    	#error "Please define the chip-select GPIO connecting from the MCU to the SDCard"
+    #endif
+#else
+	#define CS   DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_CS
+#endif
+
+SDCardBlock _sd(MOSI, MISO, SCK, CS); // MOSI, MISO, SCK, CS
+SDCardInterface &sd = _sd;
+
+#endif /* #if DEVICE_STORAGE_SDCARD */

--- a/features/storage/sdcard_driver/SDCardInterface.h
+++ b/features/storage/sdcard_driver/SDCardInterface.h
@@ -1,0 +1,60 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2012 ARM Limited
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+#ifndef __SD_CARD_INTERFACE_H__
+#define __SD_CARD_INTERFACE_H__
+
+#include <stdint.h>
+
+class SDCardInterface {
+public:
+    /**
+     * Initialize the SD Card in SPI mode.
+     * @return 0 upon success
+     */
+    virtual int      disk_initialize();
+
+    /**
+     * Read a single sector from a given sector-aligned address.
+     * @param  buffer
+     * @param  addr
+     *           Address at which to read a sector from.
+     * @return 0 upon success.
+     */
+    virtual int      disk_read(uint8_t* buffer, uint64_t addr);
+
+    /**
+     * Write a single sector at a given sector-aligned address.
+     * @param  buffer
+     * @param  addr
+     *           Address at which to write data.
+     * @return 0 upon success.
+     */
+    virtual int      disk_write(const uint8_t* buffer, uint64_t addr);
+
+    /**
+     * @return the number of sectors available in the hardware.
+     */
+    virtual uint64_t disk_sectors();
+};
+
+#endif /* #if __SD_CARD_INTERFACE_H__ */

--- a/features/storage/sdcard_driver/storage_mtd_sdcard.cpp
+++ b/features/storage/sdcard_driver/storage_mtd_sdcard.cpp
@@ -1,0 +1,431 @@
+/*
+ * Copyright (c) 2006-2016, ARM Limited, All Rights Reserved
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may
+ * not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#if DEVICE_STORAGE_SDCARD
+
+#include "SDCardBlock.h"
+#include "Driver_Storage.h"
+
+#include <string.h>
+
+/*
+ * Global state for the driver.
+ */
+extern SDCardInterface &sd;
+
+static bool            initialized = false;
+ARM_POWER_STATE        powerState  = ARM_POWER_OFF;
+
+#define SECTOR_SIZE 512UL
+static uint8_t buffer[SECTOR_SIZE];
+
+/* Set storage size. If set to 0 the value is taken from the SD card. */
+#ifndef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_SIZE
+#define STORAGE_SIZE         (1024UL * 1024UL)
+#else
+#define STORAGE_SIZE         DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_SIZE
+#endif
+
+#ifndef DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_START_ADDR
+#define STORAGE_START_ADDR   (0x00000UL)
+#else
+#defien STORAGE_START_ADDR DEVICE_STORAGE_CONFIG_HARDWARE_MTD_SDCARD_START_ADDR
+#endif
+
+#define ERASE_UNIT           (SECTOR_SIZE)
+#define PROGRAM_UNIT         (SECTOR_SIZE)
+#define OPTIMAL_PROGRAM_UNIT (SECTOR_SIZE)
+
+static const ARM_DRIVER_VERSION version = {
+    .api = ARM_STORAGE_API_VERSION,
+    .drv = ARM_DRIVER_VERSION_MAJOR_MINOR(1,00)
+};
+
+static const ARM_STORAGE_CAPABILITIES caps = {
+    /**< Signal Flash Ready event. In other words, can APIs like initialize,
+     *   read, erase, program, etc. operate in asynchronous mode?
+     *   Setting this bit to 1 means that the driver is capable of launching
+     *   asynchronous operations; command completion is signaled by the
+     *   generation of an event or the invocation of a completion callback
+     *   (depending on how the flash controller has been initialized). If set to
+     *   1, drivers may still complete asynchronous operations synchronously as
+     *   necessary--in which case they return a positive error code to indicate
+     *   synchronous completion. */
+    asynchronous_ops : 0,
+
+    /* Enable chip-erase functionality if we own all of block-1. */
+    erase_all        : 0,    /**< Supports EraseChip operation. */
+    reserved         : 0
+};
+
+static ARM_STORAGE_INFO info = {
+    total_storage        : STORAGE_SIZE, /**< Total available storage, in units of octets. */
+
+    program_unit         : PROGRAM_UNIT,
+    optimal_program_unit : OPTIMAL_PROGRAM_UNIT,
+
+    program_cycles       : ARM_STORAGE_PROGRAM_CYCLES_INFINITE, /**< A measure of endurance for reprogramming.
+                                                                 *   Use ARM_STOR_PROGRAM_CYCLES_INFINITE for infinite or unknown endurance. */
+    erased_value         : 0x1,  /**< Contents of erased memory (1 to indicate erased octets with state 0xFF). */
+    memory_mapped        : 0,
+
+    programmability      : ARM_STORAGE_PROGRAMMABILITY_ERASABLE, /**< A value of type enum ARM_STOR_PROGRAMMABILITY. */
+    retention_level      : ARM_RETENTION_NVM,
+
+    reserved             : 0,
+
+    security : {
+        acls                 : 0, /**< against internal software attacks using ACLs. */
+        rollback_protection  : 0, /**< roll-back protection. */
+        tamper_proof         : 0, /**< tamper-proof memory (will be deleted on tamper-attempts using board level or chip level sensors). */
+        internal_flash       : 0, /**< Internal flash. */
+        reserved1            : 0,
+
+        software_attacks     : 0,
+        board_level_attacks  : 0,
+        chip_level_attacks   : 0,
+        side_channel_attacks : 0,
+        reserved2            : 0,
+    }
+};
+
+static ARM_DRIVER_VERSION getVersion(void)
+{
+    return version;
+}
+
+static ARM_STORAGE_CAPABILITIES getCapabilities(void)
+{
+    return caps;
+}
+
+static int32_t initialize(ARM_Storage_Callback_t callback)
+{
+    if (!initialized) {
+        if (sd.disk_initialize() != 0) {
+            return ARM_DRIVER_ERROR;
+        }
+        initialized = true;
+
+        /* If storage size 0, use full SD card size. */
+        if (STORAGE_SIZE == 0) {
+            info.total_storage = sd.disk_sectors() * SECTOR_SIZE;
+        }
+    }
+
+    return 1;
+}
+
+static int32_t uninitialize(void)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (initialized) {
+        initialized = false;
+        result      = 1;
+    }
+
+    return result;
+}
+
+static int32_t powerControl(ARM_POWER_STATE state)
+{
+    powerState = state;
+
+    return 1;
+}
+
+static int32_t readData(uint64_t addr, void *data, uint32_t size)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (!initialized) {
+        result = ARM_DRIVER_ERROR; /* illegal */
+    }
+    /* Argument validation. */
+    else if ((data == NULL) || (size == 0)) {
+        result = ARM_DRIVER_ERROR_PARAMETER; /* illegal */
+    } else {
+        /* Set return value to be "success". */
+        result = size;
+
+        /* Start sector. This is incremented in each loop. */
+        uint32_t sector_start = addr / SECTOR_SIZE;
+
+        /* Start offset. This is only non-zero in the first loop. */
+        uint32_t sector_alignment = addr % SECTOR_SIZE;
+
+        /* Remaining data size. Decremented with SECTOR_SIZE in each loop. */
+        uint32_t read_remaining = size;
+
+        /* Index pointing to the current write location in the output buffer. */
+        uint32_t read_index = 0;
+
+        /* Loop until all bytes have been read. */
+        while (read_remaining > 0) {
+            /* Read full sector into temporary buffer. */
+            int result = sd.disk_read(buffer, sector_start);
+            if (result == 0) {
+                /* Data size from offset to end of sector. */
+                uint32_t sector_remaining = SECTOR_SIZE - sector_alignment;
+
+                /* Ensure we don't read more than what is remaining. */
+                if (read_remaining < sector_remaining) {
+                    sector_remaining = read_remaining;
+                }
+
+                /* Copy data from temporary buffer to output buffer. */
+                memcpy(&((uint8_t *)data)[read_index], &buffer[sector_alignment], sector_remaining);
+
+                /* Update loop variables. */
+                sector_start++;
+                sector_alignment = 0;
+                read_remaining  -= sector_remaining;
+                read_index      += sector_remaining;
+            } else {
+                result = ARM_DRIVER_ERROR;
+                break;
+            }
+        }
+    }
+
+    return result;
+}
+
+static int32_t programData(uint64_t addr, const void *data, uint32_t size)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (!initialized) {
+        result = (int32_t) ARM_DRIVER_ERROR; /* illegal */
+    }
+    /* argument validation */
+    else if ((data == NULL) || (size == 0)) {
+        result = ARM_DRIVER_ERROR_PARAMETER; /* illegal */
+    } else if (((addr % PROGRAM_UNIT) != 0) || ((size % PROGRAM_UNIT) != 0))   {
+        result = ARM_DRIVER_ERROR_PARAMETER;
+    } else {
+        /* Set return value to be "success". */
+        result = size;
+
+        /* Start sector. This is incremented in each loop. */
+        uint32_t sector_start = addr / SECTOR_SIZE;
+
+        /* Remaining data size. Decremented with SECTOR_SIZE in each loop. */
+        uint32_t write_remaining = size;
+
+        /* Index pointing to the current read location in the input buffer. */
+        uint32_t write_index = 0;
+
+        /* Loop until all bytes have been read. */
+        while (write_remaining > 0) {
+            int result = sd.disk_write(&((uint8_t *)data)[write_index], sector_start);
+            if (result == 0) {
+                /* Update loop variables. */
+                sector_start++;
+                write_index     += SECTOR_SIZE;
+                write_remaining -= SECTOR_SIZE;
+            } else {
+                result = ARM_DRIVER_ERROR;
+                break;
+            }
+        }
+    }
+
+    return result;
+}
+
+static int32_t erase(uint64_t addr, uint32_t size)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (!initialized) {
+        result = (int32_t) ARM_DRIVER_ERROR; /* illegal */
+    }
+    /* argument validation */
+    else if (size == 0) {
+        result = ARM_DRIVER_ERROR_PARAMETER;
+    }
+    /* alignment */
+    else if (((addr % ERASE_UNIT) != 0) || ((size % ERASE_UNIT) != 0)) {
+        result = ARM_DRIVER_ERROR_PARAMETER;
+    } else {
+        /* Set return value to be "success". */
+        result = size;
+
+        /* Start sector. This is incremented in each loop. */
+        uint32_t sector_start = addr / ERASE_UNIT;
+
+        /* Remaining erase size. Set to at least ERASE_UNIT. */
+        uint32_t erase_remaining = (size < ERASE_UNIT) ? ERASE_UNIT : size;
+
+        /* Fill temporary buffer with erase value. */
+        memset(buffer, info.erased_value * 0xFF, ERASE_UNIT);
+
+        /* Write temporary buffer to emulate erasing. */
+        while (erase_remaining > 0) {
+            int result = sd.disk_write(buffer, sector_start);
+            if (result == 0) {
+                /* Update loop variables. */
+                sector_start++;
+                erase_remaining -= ERASE_UNIT;
+            } else {
+                result = ARM_DRIVER_ERROR;
+                break;
+            }
+        }
+    }
+
+    return result;
+}
+
+static int32_t eraseAll(void)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (!initialized) {
+        result = (int32_t) ARM_DRIVER_ERROR; /* illegal */
+    } else {
+        /* Emulate eraseAll by calling normal erase with the whole range. */
+        result = erase(STORAGE_START_ADDR, info.total_storage);
+        if (result > 0) {
+            result = 1; // return value 1 means success
+        } else {
+            result = ARM_DRIVER_ERROR;
+        }
+    }
+
+    return result;
+}
+
+static ARM_STORAGE_STATUS getStatus(void)
+{
+    ARM_STORAGE_STATUS status = {
+        .busy  = 0,
+        .error = 0,
+    };
+
+    if (!initialized) {
+        status.error = 1;
+    }
+
+    return status;
+}
+
+static int32_t getInfo(ARM_STORAGE_INFO *infoP)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (!initialized) {
+        initialize(NULL);
+    }
+
+    if (infoP) {
+        memcpy(infoP, &info, sizeof(ARM_STORAGE_INFO));
+        result = ARM_DRIVER_OK;
+    }
+
+    return result;
+}
+
+static uint32_t resolveAddress(uint64_t addr)
+{
+    (void) addr;
+
+    return ARM_DRIVER_ERROR_UNSUPPORTED;
+}
+
+int32_t nextBlock(const ARM_STORAGE_BLOCK *prevP, ARM_STORAGE_BLOCK *nextP)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if (prevP == NULL) {
+        /* fetching the first block (instead of next) */
+        if (nextP) {
+            nextP->addr                       = STORAGE_START_ADDR;
+            nextP->size                       = info.total_storage;
+            nextP->attributes.erasable        = 1;
+            nextP->attributes.programmable    = 1;
+            nextP->attributes.executable      = 0;
+            nextP->attributes.protectable     = 0;
+            nextP->attributes.reserved        = 0;
+            nextP->attributes.erase_unit      = ERASE_UNIT;
+            nextP->attributes.protection_unit = 0;
+
+            result = ARM_DRIVER_OK;
+        }
+    } else {
+        if (nextP) {
+            nextP->addr = ARM_STORAGE_INVALID_OFFSET;
+            nextP->size = 0;
+
+            result = ARM_DRIVER_OK;
+        }
+    }
+
+    return result;
+}
+
+int32_t getBlock(uint64_t addr, ARM_STORAGE_BLOCK *blockP)
+{
+    int32_t result = ARM_DRIVER_ERROR;
+
+    if ((STORAGE_START_ADDR <= addr) && (addr < (STORAGE_START_ADDR + info.total_storage))) {
+        /* fetching the first block (instead of next) */
+        if (blockP) {
+            blockP->addr                       = STORAGE_START_ADDR;
+            blockP->size                       = info.total_storage;
+            blockP->attributes.erasable        = 1;
+            blockP->attributes.programmable    = 1;
+            blockP->attributes.executable      = 0;
+            blockP->attributes.protectable     = 0;
+            blockP->attributes.reserved        = 0;
+            blockP->attributes.erase_unit      = ERASE_UNIT;
+            blockP->attributes.protection_unit = 0;
+
+            result = ARM_DRIVER_OK;
+        }
+    } else {
+        if (blockP) {
+            blockP->addr = ARM_STORAGE_INVALID_OFFSET;
+            blockP->size = 0;
+
+            result = ARM_DRIVER_OK;
+        }
+    }
+
+    return result;
+}
+
+extern "C" ARM_DRIVER_STORAGE ARM_Driver_Storage_MTD_SPI_SDCard = {
+    .GetVersion      = getVersion,
+    .GetCapabilities = getCapabilities,
+    .Initialize      = initialize,
+    .Uninitialize    = uninitialize,
+    .PowerControl    = powerControl,
+    .ReadData        = readData,
+    .ProgramData     = programData,
+    .Erase           = erase,
+    .EraseAll        = eraseAll,
+    .GetStatus       = getStatus,
+    .GetInfo         = getInfo,
+    .ResolveAddress  = resolveAddress,
+    .GetNextBlock    = nextBlock,
+    .GetBlock        = getBlock
+};
+
+#endif /* #if DEVICE_STORAGE_SDCARD */


### PR DESCRIPTION
This driver can be used as an extension to the on-chip NV Storage.

Available only when DEVICE_STORAGE_SDCARD is defined.

review: @0xc0170 @sg-
notify: @mjs-arm @simonqhughes
