### PR TITLE
Includre rtos.h in mbed.h if present

### DIFF
--- a/hal/api/mbed.h
+++ b/hal/api/mbed.h
@@ -18,6 +18,10 @@
 
 #define MBED_LIBRARY_VERSION 122
 
+#if MBED_CONF_RTOS_PRESENT
+#include "rtos/rtos.h"
+#endif
+
 #include "toolchain.h"
 #include "platform.h"
 


### PR DESCRIPTION
So that apps don't need to include "rtos.h" explicitly anymore.