### PR TITLE
[nsapi] Fixed iar compilation issue with value initializer

### DIFF
--- a/features/net/network-socket/SocketAddress.cpp
+++ b/features/net/network-socket/SocketAddress.cpp
@@ -182,7 +182,7 @@ void SocketAddress::set_ip_address(const char *addr)
         _addr.version = NSAPI_IPv6;
         ipv6_from_address(_addr.bytes, addr);
     } else {
-        _addr = (nsapi_addr_t){};
+        _addr = nsapi_addr_t();
     }
 }
 
@@ -275,7 +275,7 @@ void SocketAddress::_SocketAddress(NetworkStack *iface, const char *host, uint16
         // DNS lookup
         int err = iface->gethostbyname(this, host);
         if (err) {
-            _addr = (nsapi_addr_t){};
+            _addr = nsapi_addr_t();
             _port = 0;
         }
     }

--- a/features/net/network-socket/SocketAddress.h
+++ b/features/net/network-socket/SocketAddress.h
@@ -53,7 +53,7 @@ public:
      *  @param addr     Raw IP address
      *  @param port     Optional 16-bit port
      */
-    SocketAddress(nsapi_addr_t addr = (nsapi_addr_t){}, uint16_t port = 0);
+    SocketAddress(nsapi_addr_t addr = nsapi_addr_t(), uint16_t port = 0);
 
     /** Create a SocketAddress from an IP address and port
      *


### PR DESCRIPTION
Expression needed to init to zero a simple POD struct:

``` cpp
// Before (valid in C99/C++11/G++)
nsapi_addr_t addr = (nsapi_addr_t){}
// After (valid in C++03, invalid in C)
nsapi_addr_t addr = nsapi_addr_t()
```

cc @sg-, @c1728p9, @bridadan