### PR TITLE
[nsapi] Fix missing port assignment in DNS constructor for SocketAddress

### DIFF
--- a/features/net/network-socket/SocketAddress.cpp
+++ b/features/net/network-socket/SocketAddress.cpp
@@ -274,6 +274,7 @@ void SocketAddress::_SocketAddress(NetworkStack *iface, const char *host, uint16
     } else {
         // DNS lookup
         int err = iface->gethostbyname(this, host);
+        _port = port;
         if (err) {
             _addr = nsapi_addr_t();
             _port = 0;


### PR DESCRIPTION
_stack->gethostbyname looks deceptively like it completely sets the socket address value, however port is not provided via DNS resolution.

cc @sg-, @c1728p9