### PR TITLE
Setting NRF51 targets to standard build

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1203,7 +1203,6 @@
             "toolchains": ["ARM_STD", "GCC_ARM"]
         },
         "program_cycle_s": 6,
-        "default_build": "small",
         "features": ["BLE"]
     },
     "MCU_NRF51_16K_BASE": {


### PR DESCRIPTION
This PR sets all NRF51 based targets to a standard build. This will enable float support for `printf` and `scanf` and the use of the full standard library at the expense of taking up more memory.

cc @pan- @sg- @c1728p9 