### PR TITLE
Fix MAIN_THREAD_ID check

### DIFF
--- a/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
+++ b/rtos/rtx/TARGET_CORTEX_M/cmsis_os.h
@@ -83,10 +83,10 @@
 /* If os timers macro is set to 0, there's no timer thread created, therefore
  * main thread has tid 0x01  
  */
-#if (OS_TIMERS != 0)
-#define MAIN_THREAD_ID 0x02
-#else
+#if defined(OS_TIMERS) && (OS_TIMERS == 0)
 #define MAIN_THREAD_ID 0x01
+#else
+#define MAIN_THREAD_ID 0x02
 #endif
 #endif
 


### PR DESCRIPTION
In cmsis_os.h OS_TIMERS is undefined unless the timer thread is
disabled, in which case it is defined to 0. When comparing against
an undefined value, the undefined value will evaluate as if it were
0. Because of this the MAIN_THREAD_ID was always set to 0x1.
This patch fixes that problem by checking if OS_TIMERS is defined
before comparing it to 0.

This problem only effects IAR since it has a different heap/stack
layout. GCC_ARM and ARM have a dedicated stack region so
the presence of a guard word and stack checking does not cause
problems.

This problem manifested on the NRF51_DK in the pull request
https://github.com/mbedmicro/mbed/pull/2211
as a c_strings test failure on floating point. This is because the
guard word of the main stack overlapped with standard library
data used by sprintf and corrupted it.