### PR TITLE
Release versions

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1452,8 +1452,7 @@
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dk"},
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release_versions": ["2"]
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"]
     },
     "NRF51_DK_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1880,7 +1879,8 @@
         "supported_form_factors": ["ARDUINO"],
         "inherits": ["MCU_NRF51_32K_UNIFIED"],
         "progen": {"target": "nrf51-dk"},
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"]
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "release_versions": ["2", "5"]
     },
     "MCU_NRF52": {
         "inherits": ["Target"],
@@ -1940,7 +1940,8 @@
             "NRF52_PAN_62",
             "NRF52_PAN_63"
         ],
-        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"]
+        "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPI_ASYNCH", "SPISLAVE"],
+        "release_versions": ["2", "5"]
     },
     "BLUEPILL_F103C8": {
         "core": "Cortex-M3",

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -10,8 +10,7 @@
         "features": [],
         "detect_code": [],
         "public": false,
-        "default_build": "standard",
-        "release": false
+        "default_build": "standard"
     },
     "CM4_UARM": {
         "inherits": ["Target"],
@@ -19,15 +18,13 @@
         "default_toolchain": "uARM",
         "public": false,
         "supported_toolchains": ["uARM"],
-        "default_build": "small",
-        "release": false
+        "default_build": "small"
     },
     "CM4_ARM": {
         "inherits": ["Target"],
         "core": "Cortex-M4",
         "public": false,
-        "supported_toolchains": ["ARM"],
-        "release": false
+        "supported_toolchains": ["ARM"]
     },
     "CM4F_UARM": {
         "inherits": ["Target"],
@@ -35,21 +32,18 @@
         "default_toolchain": "uARM",
         "public": false,
         "supported_toolchains": ["uARM"],
-        "default_build": "small",
-        "release": false
+        "default_build": "small"
     },
     "CM4F_ARM": {
         "inherits": ["Target"],
         "core": "Cortex-M4F",
         "public": false,
-        "supported_toolchains": ["ARM"],
-        "release": false
+        "supported_toolchains": ["ARM"]
     },
     "LPCTarget": {
         "inherits": ["Target"],
         "post_binary_hook": {"function": "LPCTargetCode.lpc_patch"},
-        "public": false,
-        "release": false
+        "public": false
     },
     "LPC11C24": {
         "inherits": ["LPCTarget"],
@@ -70,7 +64,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC11U24": {
         "inherits": ["LPCTarget"],
@@ -84,7 +78,7 @@
         "detect_code": ["1040"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "OC_MBUINO": {
         "inherits": ["LPC11U24"],
@@ -94,7 +88,7 @@
         },
         "extra_labels": ["NXP", "LPC11UXX"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "LPC11U24_301": {
         "inherits": ["LPCTarget"],
@@ -116,7 +110,7 @@
         "inherits": ["LPC11U34_421"],
         "macros": ["LPC11U34_421", "APPNEARME_MICRONFCBOARD"],
         "extra_labels_add": ["APPNEARME_MICRONFCBOARD"],
-        "release": true
+        "release": ["2"]
     },
     "LPC11U35_401": {
         "inherits": ["LPCTarget"],
@@ -129,7 +123,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC11U35_501": {
         "inherits": ["LPCTarget"],
@@ -142,7 +136,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC11U35_501_IBDAP": {
         "inherits": ["LPCTarget"],
@@ -167,7 +161,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC11U35_Y5_MBUG": {
         "inherits": ["LPCTarget"],
@@ -211,7 +205,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC11U68": {
         "supported_form_factors": ["ARDUINO"],
@@ -226,7 +220,7 @@
         "detect_code": ["1168"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI"],
         "default_build": "small",
-        "release": true
+        "release": ["2", "5"]
     },
     "LPC1347": {
         "inherits": ["LPCTarget"],
@@ -235,7 +229,7 @@
         "extra_labels": ["NXP", "LPC13XX"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "LPC1549": {
         "supported_form_factors": ["ARDUINO"],
@@ -250,7 +244,7 @@
         "detect_code": ["1549"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC1768": {
         "inherits": ["LPCTarget"],
@@ -260,7 +254,7 @@
         "progen": {"target": "mbed-lpc1768"},
         "detect_code": ["1010"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "ARCH_PRO": {
         "supported_form_factors": ["ARDUINO"],
@@ -271,7 +265,7 @@
         "inherits": ["LPCTarget"],
         "progen": {"target": "arch-pro"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "UBLOX_C027": {
         "supported_form_factors": ["ARDUINO"],
@@ -282,7 +276,7 @@
         "inherits": ["LPCTarget"],
         "progen": {"target": "ublox-c027"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_RED", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "XBED_LPC1768": {
         "inherits": ["LPCTarget"],
@@ -300,8 +294,7 @@
         "progen": {"target": "lpc2368"},
         "extra_labels": ["NXP", "LPC23XX"],
         "supported_toolchains": ["GCC_ARM", "GCC_CR"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
     },
     "LPC2460": {
         "inherits": ["LPCTarget"],
@@ -309,8 +302,7 @@
         "progen": {"target": "lpc2460"},
         "extra_labels": ["NXP", "LPC2460"],
         "supported_toolchains": ["GCC_ARM"],
-        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"]
     },
     "LPC810": {
         "inherits": ["LPCTarget"],
@@ -339,7 +331,7 @@
         "detect_code": ["1050"],
         "device_has": ["ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC824": {
         "supported_form_factors": ["ARDUINO"],
@@ -354,7 +346,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "SSCI824": {
         "inherits": ["LPCTarget"],
@@ -368,7 +360,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "LPC4088": {
         "inherits": ["LPCTarget"],
@@ -382,11 +374,11 @@
         },
         "progen": {"target": "lpc4088"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "LPC4088_DM": {
         "inherits": ["LPC4088"],
-        "release": true
+        "release": ["2", "5"]
     },
     "LPC4330_M4": {
         "inherits": ["LPCTarget"],
@@ -410,7 +402,7 @@
         "extra_labels": ["NXP", "LPC43XX", "LPC4337"],
         "supported_toolchains": ["ARM"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "DEBUG_AWARENESS", "ERROR_RED", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "LPC1800": {
         "inherits": ["LPCTarget"],
@@ -431,7 +423,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "ELEKTOR_COCORICO": {
         "core": "Cortex-M0+",
@@ -459,7 +451,7 @@
         },
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "KL25Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -471,7 +463,7 @@
         "progen": {"target": "frdm-kl25z"},
         "detect_code": ["0200"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "KL26Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -492,7 +484,7 @@
         "inherits": ["Target"],
         "progen": {"target": "frdm-kl43z"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "KL46Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -504,7 +496,7 @@
         "progen": {"target": "frdm-kl46z"},
         "detect_code": ["0220"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "K20D50M": {
         "inherits": ["Target"],
@@ -515,7 +507,7 @@
         "progen": {"target": "frdm-k20d50m"},
         "detect_code": ["0230"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "TEENSY3_1": {
         "inherits": ["Target"],
@@ -531,7 +523,7 @@
         "progen": {"target": "teensy-31"},
         "detect_code": ["0230"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "K22F": {
         "supported_form_factors": ["ARDUINO"],
@@ -544,7 +536,7 @@
         "progen": {"target": "frdm-k22f"},
         "detect_code": ["0231"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "KL27Z": {
         "inherits": ["Target"],
@@ -559,7 +551,7 @@
         "progen_target": {"target": "frdm-kl27z"},
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "standard",
-        "release": true
+        "release": ["2"]
     },
     "K64F": {
         "supported_form_factors": ["ARDUINO"],
@@ -573,7 +565,7 @@
         "detect_code": ["0240"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "STORAGE"],
         "features": ["IPV4", "STORAGE"],
-        "release": true
+        "release": ["2", "5"]
     },
     "MTS_GAMBIT": {
         "inherits": ["Target"],
@@ -608,7 +600,7 @@
         "progen": {"target": "nucleo-f030r8"},
         "detect_code": ["0725"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F031K6": {
         "supported_form_factors": ["ARDUINO"],
@@ -621,7 +613,7 @@
         "detect_code": ["0791"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F042K6": {
         "supported_form_factors": ["ARDUINO"],
@@ -634,7 +626,7 @@
         "detect_code": ["0785"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F070RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -646,7 +638,7 @@
         "progen": {"target": "nucleo-f070rb"},
         "detect_code": ["0755"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F072RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -658,7 +650,7 @@
         "progen": {"target": "nucleo-f072rb"},
         "detect_code": ["0730"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F091RC": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -670,7 +662,7 @@
         "progen": {"target": "nucleo-f091rc"},
         "detect_code": ["0750"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F103RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -682,7 +674,7 @@
         "progen": {"target": "nucleo-f103rb"},
         "detect_code": ["0700"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F207ZG": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -694,7 +686,7 @@
         "progen": {"target": "nucleo-f207zg"},
         "detect_code": ["0835"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F302R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -706,7 +698,7 @@
         "progen": {"target": "nucleo-f302r8"},
         "detect_code": ["0705"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F303K8": {
         "supported_form_factors": ["ARDUINO"],
@@ -718,7 +710,7 @@
         "progen": {"target": "nucleo-f303k8"},
         "detect_code": ["0775"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F303RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -730,7 +722,7 @@
         "progen": {"target": "nucleo-f303re"},
         "detect_code": ["0745"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F334R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -742,7 +734,7 @@
         "progen": {"target": "nucleo-f334r8"},
         "detect_code": ["0735"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F401RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -754,7 +746,7 @@
         "progen": {"target": "nucleo-f401re"},
         "detect_code": ["0720"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F410RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -766,7 +758,7 @@
         "progen": {"target": "nucleo-f410rb"},
         "detect_code": ["0740"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F411RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -778,7 +770,7 @@
         "progen": {"target": "nucleo-f411re"},
         "detect_code": ["0740"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "ELMO_F411RE": {
         "supported_form_factors": ["ARDUINO"],
@@ -790,7 +782,7 @@
         "detect_code": ["----"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F429ZI": {
         "inherits": ["Target"],
@@ -801,7 +793,7 @@
         "progen": {"target": "nucleo-f429zi"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "detect_code": ["0796"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_F446RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -813,7 +805,7 @@
         "progen": {"target": "nucleo-f446re"},
         "detect_code": ["0777"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F446ZE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -825,7 +817,7 @@
         "progen": {"target": "nucleo-f446ze"},
         "detect_code": ["0778"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
 
     "B96B_F446VE": {
@@ -837,7 +829,7 @@
         "inherits": ["Target"],
         "detect_code": ["0840"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_ASYNCH_DMA", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F746ZG": {
         "inherits": ["Target"],
@@ -855,7 +847,7 @@
         "detect_code": ["0816"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["IPV4"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_F767ZI": {
         "inherits": ["Target"],
@@ -866,7 +858,7 @@
         "progen": {"target": "nucleo-f767zi"},
         "detect_code": ["0818"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release":true
+        "release": ["2", "5"]
     },
     "NUCLEO_L011K4": {
         "inherits": ["Target"],
@@ -879,7 +871,7 @@
         "progen": {"target":"nucleo-l011k4"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
 
     "NUCLEO_L031K6": {
@@ -893,7 +885,7 @@
         "progen": {"target": "nucleo-l031k6"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_L053R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -905,7 +897,7 @@
         "progen": {"target": "nucleo-l053r8"},
         "detect_code": ["0715"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "NUCLEO_L073RZ": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -917,7 +909,7 @@
         "progen": {"target": "nucleo-l073rz"},
         "detect_code": ["0760"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_L152RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -929,7 +921,7 @@
         "progen": {"target": "nucleo-l152re"},
         "detect_code": ["0710"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_L432KC": {
         "supported_form_factors": ["ARDUINO"],
@@ -941,7 +933,7 @@
         "progen": {"target": "nucleo-l432kc"},
         "detect_code": ["0770"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "CAN", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "NUCLEO_L476RG": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -953,7 +945,7 @@
         "progen": {"target": "nucleo-l476rg"},
         "detect_code": ["0765"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "STM32F3XX": {
         "inherits": ["Target"],
@@ -978,7 +970,7 @@
         "inherits": ["Target"],
         "progen": {"target": "arch-max"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "DISCO_F051R8": {
         "inherits": ["Target"],
@@ -1013,7 +1005,7 @@
         "progen": {"target": "disco-f334c8"},
         "detect_code": ["0810"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "DISCO_F407VG": {
         "inherits": ["Target"],
@@ -1031,7 +1023,7 @@
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "progen": {"target": "disco-f429zi"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "DISCO_F469NI": {
         "supported_form_factors": ["ARDUINO"],
@@ -1043,7 +1035,7 @@
         "progen": {"target": "disco-f469ni"},
         "detect_code": ["0788"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "DISCO_L053C8": {
         "inherits": ["Target"],
@@ -1053,7 +1045,7 @@
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
         "progen": {"target": "disco-l053c8"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "DISCO_F746NG": {
         "inherits": ["Target"],
@@ -1064,7 +1056,7 @@
         "progen": {"target": "disco-f746ng"},
         "detect_code": ["0815"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "DISCO_L476VG": {
         "inherits": ["Target"],
@@ -1075,7 +1067,7 @@
         "progen": {"target": "disco-l476vg"},
         "detect_code": ["0820"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "MTS_MDOT_F405RG": {
         "inherits": ["Target"],
@@ -1086,7 +1078,7 @@
         "macros": ["HSE_VALUE=26000000", "OS_CLOCK=48000000"],
         "progen": {"target": "mts-mdot-f405rg"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "MTS_MDOT_F411RE": {
         "inherits": ["Target"],
@@ -1100,7 +1092,7 @@
         },
         "progen": {"target": "mts-mdot-f411re"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "MTS_DRAGONFLY_F411RE": {
         "inherits": ["Target"],
@@ -1114,7 +1106,7 @@
         },
         "progen": {"target": "mts-dragonfly-f411re"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "MOTE_L152RC": {
         "inherits": ["Target"],
@@ -1126,7 +1118,7 @@
         "detect_code": ["4100"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": true
+        "release": ["2", "5"]
     },
     "DISCO_F401VC": {
         "inherits": ["Target"],
@@ -1299,7 +1291,7 @@
         "extra_labels_add": ["NRF51822", "NRF51822_MKIT"],
         "macros_add": ["TARGET_NRF51822_MKIT"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "NRF51822_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1318,7 +1310,7 @@
         "inherits": ["MCU_NRF51_16K"],
         "progen": {"target": "arch-ble"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "ARCH_BLE_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1354,7 +1346,7 @@
         "inherits": ["MCU_NRF51_16K"],
         "progen": {"target": "seed-tinyble"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "SEEED_TINY_BLE_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1371,7 +1363,7 @@
         "progen": {"target": "hrm1017"},
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "HRM1017_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1388,7 +1380,7 @@
         "inherits": ["MCU_NRF51_16K"],
         "progen": {"target": "rblab-nrf51822"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "RBLAB_NRF51822_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1405,7 +1397,7 @@
     "RBLAB_BLENANO": {
         "inherits": ["MCU_NRF51_16K"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "RBLAB_BLENANO_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1424,7 +1416,7 @@
     "WALLBOT_BLE": {
         "inherits": ["MCU_NRF51_16K"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "WALLBOT_BLE_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1442,7 +1434,7 @@
         "progen": {"target": "dfcm-nnn40"},
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "DEBUG_AWARENESS", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "DELTA_DFCM_NNN40_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],
@@ -1461,7 +1453,7 @@
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dk"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "NRF51_DK_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1479,7 +1471,7 @@
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dongle"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "NRF51_DONGLE_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],
@@ -1495,7 +1487,7 @@
         "inherits": ["MCU_NRF51_16K_S110"],
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "NRF51_MICROBIT_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT_S110"],
@@ -1512,7 +1504,7 @@
         "extra_labels_add": ["NRF51_MICROBIT"],
         "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "NRF51_MICROBIT_B_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1528,7 +1520,7 @@
         "inherits": ["MCU_NRF51_32K"],
         "macros_add": ["TARGET_NRF_32MHZ_XTAL"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": true
+        "release": ["2"]
     },
     "TY51822R3_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],
@@ -1552,7 +1544,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0"],
         "macros": ["CMSDK_CM0"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": true
+        "release": ["2"]
     },
     "ARM_MPS2_M0P": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1561,7 +1553,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0P"],
         "macros": ["CMSDK_CM0plus"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": true
+        "release": ["2"]
     },
     "ARM_MPS2_M1": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1578,7 +1570,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M3"],
         "macros": ["CMSDK_CM3"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": true
+        "release": ["2"]
     },
     "ARM_MPS2_M4": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1587,7 +1579,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M4"],
         "macros": ["CMSDK_CM4"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": true
+        "release": ["2"]
     },
     "ARM_MPS2_M7": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1596,7 +1588,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M7"],
         "macros": ["CMSDK_CM7"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": true
+        "release": ["2"]
     },
     "ARM_IOTSS_Target": {
         "inherits": ["Target"],
@@ -1610,7 +1602,7 @@
         "extra_labels": ["ARM_SSG", "IOTSS", "IOTSS_BEID"],
         "macros": ["CMSDK_BEID"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": true
+        "release": ["2"]
     },
     "ARM_BEETLE_SOC": {
         "inherits": ["ARM_IOTSS_Target"],
@@ -1627,7 +1619,7 @@
         },
         "device_has": ["ANALOGIN", "CLCD", "I2C", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI"],
 	"features": ["BLE"],
-        "release": true
+        "release": ["2"]
     },
     "RZ_A1H": {
         "supported_form_factors": ["ARDUINO"],
@@ -1644,7 +1636,7 @@
         },
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "features": ["IPV4"],
-        "release": true
+        "release": ["2"]
     },
     "VK_RZ_A1H": {
         "inherits": ["Target"],
@@ -1670,7 +1662,7 @@
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
         "progen": {"target": "maxwsnenv"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "MAX32600MBED": {
         "inherits": ["Target"],
@@ -1680,7 +1672,7 @@
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
         "progen": {"target": "max32600mbed"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2", "5"]
     },
     "EFM32GG_STK3700": {
         "inherits": ["Target"],
@@ -1691,7 +1683,7 @@
         "progen": {"target": "efm32gg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": true
+        "release": ["2"]
     },
     "EFM32LG_STK3600": {
         "inherits": ["Target"],
@@ -1702,7 +1694,7 @@
         "progen": {"target": "efm32lg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": true
+        "release": ["2"]
     },
     "EFM32WG_STK3800": {
         "inherits": ["Target"],
@@ -1713,7 +1705,7 @@
         "progen": {"target": "efm32wg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": true
+        "release": ["2"]
     },
     "EFM32ZG_STK3200": {
         "inherits": ["Target"],
@@ -1728,7 +1720,7 @@
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "default_build": "small",
         "forced_reset_timeout": 2,
-        "release": true
+        "release": ["2"]
     },
     "EFM32HG_STK3400": {
         "inherits": ["Target"],
@@ -1743,7 +1735,7 @@
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "default_build": "small",
         "forced_reset_timeout": 2,
-        "release": true
+        "release": ["2"]
     },
     "EFM32PG_STK3401": {
         "inherits": ["Target"],
@@ -1754,7 +1746,7 @@
         "progen": {"target": "efm32pg-stk"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": true
+        "release": ["2", "5"]
     },
     "WIZWIKI_W7500": {
         "supported_form_factors": ["ARDUINO"],
@@ -1764,7 +1756,7 @@
         "inherits": ["Target"],
         "progen": {"target": "wizwiki-w7500"},
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "WIZWIKI_W7500P": {
         "supported_form_factors": ["ARDUINO"],
@@ -1774,7 +1766,7 @@
         "inherits": ["Target"],
         "progen": {"target": "wizwiki-w7500p"},
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "WIZWIKI_W7500ECO": {
         "inherits": ["Target"],
@@ -1783,7 +1775,7 @@
         "extra_labels": ["WIZNET", "W7500x", "WIZwiki_W7500ECO"],
         "supported_toolchains": ["uARM", "ARM"],
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": true
+        "release": ["2"]
     },
     "SAMR21G18A": {
         "inherits": ["Target"],
@@ -1793,7 +1785,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
         "progen": {"target": "samr21g18a"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "release": true
+        "release": ["2"]
     },
     "SAMD21J18A": {
         "inherits": ["Target"],
@@ -1803,7 +1795,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
         "progen": {"target": "samd21j18a"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "release": true
+        "release": ["2"]
     },
     "SAMD21G18A": {
         "inherits": ["Target"],
@@ -1813,7 +1805,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
         "progen": {"target": "samd21g18a"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "release": true
+        "release": ["2"]
     },
     "SAML21J18A": {
         "inherits": ["Target"],

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -64,7 +64,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U24": {
         "inherits": ["LPCTarget"],
@@ -78,7 +78,7 @@
         "detect_code": ["1040"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "OC_MBUINO": {
         "inherits": ["LPC11U24"],
@@ -88,7 +88,7 @@
         },
         "extra_labels": ["NXP", "LPC11UXX"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U24_301": {
         "inherits": ["LPCTarget"],
@@ -110,7 +110,7 @@
         "inherits": ["LPC11U34_421"],
         "macros": ["LPC11U34_421", "APPNEARME_MICRONFCBOARD"],
         "extra_labels_add": ["APPNEARME_MICRONFCBOARD"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U35_401": {
         "inherits": ["LPCTarget"],
@@ -123,7 +123,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U35_501": {
         "inherits": ["LPCTarget"],
@@ -136,7 +136,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U35_501_IBDAP": {
         "inherits": ["LPCTarget"],
@@ -161,7 +161,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U35_Y5_MBUG": {
         "inherits": ["LPCTarget"],
@@ -205,7 +205,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC11U68": {
         "supported_form_factors": ["ARDUINO"],
@@ -220,7 +220,7 @@
         "detect_code": ["1168"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI"],
         "default_build": "small",
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "LPC1347": {
         "inherits": ["LPCTarget"],
@@ -229,7 +229,7 @@
         "extra_labels": ["NXP", "LPC13XX"],
         "supported_toolchains": ["ARM", "GCC_ARM", "IAR"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC1549": {
         "supported_form_factors": ["ARDUINO"],
@@ -244,7 +244,7 @@
         "detect_code": ["1549"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC1768": {
         "inherits": ["LPCTarget"],
@@ -254,7 +254,7 @@
         "progen": {"target": "mbed-lpc1768"},
         "detect_code": ["1010"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOCALFILESYSTEM", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "ARCH_PRO": {
         "supported_form_factors": ["ARDUINO"],
@@ -265,7 +265,7 @@
         "inherits": ["LPCTarget"],
         "progen": {"target": "arch-pro"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "UBLOX_C027": {
         "supported_form_factors": ["ARDUINO"],
@@ -276,7 +276,7 @@
         "inherits": ["LPCTarget"],
         "progen": {"target": "ublox-c027"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_RED", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "XBED_LPC1768": {
         "inherits": ["LPCTarget"],
@@ -331,7 +331,7 @@
         "detect_code": ["1050"],
         "device_has": ["ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC824": {
         "supported_form_factors": ["ARDUINO"],
@@ -346,7 +346,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "SSCI824": {
         "inherits": ["LPCTarget"],
@@ -360,7 +360,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC4088": {
         "inherits": ["LPCTarget"],
@@ -374,11 +374,11 @@
         },
         "progen": {"target": "lpc4088"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "DEBUG_AWARENESS", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "LPC4088_DM": {
         "inherits": ["LPC4088"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "LPC4330_M4": {
         "inherits": ["LPCTarget"],
@@ -402,7 +402,7 @@
         "extra_labels": ["NXP", "LPC43XX", "LPC4337"],
         "supported_toolchains": ["ARM"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "DEBUG_AWARENESS", "ERROR_RED", "ETHERNET", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "LPC1800": {
         "inherits": ["LPCTarget"],
@@ -423,7 +423,7 @@
         },
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ELEKTOR_COCORICO": {
         "core": "Cortex-M0+",
@@ -451,7 +451,7 @@
         },
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "KL25Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -463,7 +463,7 @@
         "progen": {"target": "frdm-kl25z"},
         "detect_code": ["0200"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "KL26Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -484,7 +484,7 @@
         "inherits": ["Target"],
         "progen": {"target": "frdm-kl43z"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "KL46Z": {
         "supported_form_factors": ["ARDUINO"],
@@ -496,7 +496,7 @@
         "progen": {"target": "frdm-kl46z"},
         "detect_code": ["0220"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "K20D50M": {
         "inherits": ["Target"],
@@ -507,7 +507,7 @@
         "progen": {"target": "frdm-k20d50m"},
         "detect_code": ["0230"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "TEENSY3_1": {
         "inherits": ["Target"],
@@ -523,7 +523,7 @@
         "progen": {"target": "teensy-31"},
         "detect_code": ["0230"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SEMIHOST", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "K22F": {
         "supported_form_factors": ["ARDUINO"],
@@ -536,7 +536,7 @@
         "progen": {"target": "frdm-k22f"},
         "detect_code": ["0231"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "KL27Z": {
         "inherits": ["Target"],
@@ -551,7 +551,7 @@
         "progen_target": {"target": "frdm-kl27z"},
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "standard",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "K64F": {
         "supported_form_factors": ["ARDUINO"],
@@ -565,7 +565,7 @@
         "detect_code": ["0240"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES", "STORAGE"],
         "features": ["IPV4", "STORAGE"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "MTS_GAMBIT": {
         "inherits": ["Target"],
@@ -600,7 +600,7 @@
         "progen": {"target": "nucleo-f030r8"},
         "detect_code": ["0725"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F031K6": {
         "supported_form_factors": ["ARDUINO"],
@@ -613,7 +613,7 @@
         "detect_code": ["0791"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F042K6": {
         "supported_form_factors": ["ARDUINO"],
@@ -626,7 +626,7 @@
         "detect_code": ["0785"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F070RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -638,7 +638,7 @@
         "progen": {"target": "nucleo-f070rb"},
         "detect_code": ["0755"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F072RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -650,7 +650,7 @@
         "progen": {"target": "nucleo-f072rb"},
         "detect_code": ["0730"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F091RC": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -662,7 +662,7 @@
         "progen": {"target": "nucleo-f091rc"},
         "detect_code": ["0750"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F103RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -674,7 +674,7 @@
         "progen": {"target": "nucleo-f103rb"},
         "detect_code": ["0700"],
         "device_has": ["ANALOGIN", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F207ZG": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -686,7 +686,7 @@
         "progen": {"target": "nucleo-f207zg"},
         "detect_code": ["0835"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F302R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -698,7 +698,7 @@
         "progen": {"target": "nucleo-f302r8"},
         "detect_code": ["0705"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F303K8": {
         "supported_form_factors": ["ARDUINO"],
@@ -710,7 +710,7 @@
         "progen": {"target": "nucleo-f303k8"},
         "detect_code": ["0775"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F303RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -722,7 +722,7 @@
         "progen": {"target": "nucleo-f303re"},
         "detect_code": ["0745"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F334R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -734,7 +734,7 @@
         "progen": {"target": "nucleo-f334r8"},
         "detect_code": ["0735"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F401RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -746,7 +746,7 @@
         "progen": {"target": "nucleo-f401re"},
         "detect_code": ["0720"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F410RB": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -758,7 +758,7 @@
         "progen": {"target": "nucleo-f410rb"},
         "detect_code": ["0740"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F411RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -770,7 +770,7 @@
         "progen": {"target": "nucleo-f411re"},
         "detect_code": ["0740"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "ELMO_F411RE": {
         "supported_form_factors": ["ARDUINO"],
@@ -782,7 +782,7 @@
         "detect_code": ["----"],
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F429ZI": {
         "inherits": ["Target"],
@@ -793,7 +793,7 @@
         "progen": {"target": "nucleo-f429zi"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "detect_code": ["0796"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_F446RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -805,7 +805,7 @@
         "progen": {"target": "nucleo-f446re"},
         "detect_code": ["0777"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F446ZE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -817,7 +817,7 @@
         "progen": {"target": "nucleo-f446ze"},
         "detect_code": ["0778"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
 
     "B96B_F446VE": {
@@ -829,7 +829,7 @@
         "inherits": ["Target"],
         "detect_code": ["0840"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_ASYNCH_DMA", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F746ZG": {
         "inherits": ["Target"],
@@ -847,7 +847,7 @@
         "detect_code": ["0816"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "features": ["IPV4"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_F767ZI": {
         "inherits": ["Target"],
@@ -858,7 +858,7 @@
         "progen": {"target": "nucleo-f767zi"},
         "detect_code": ["0818"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_L011K4": {
         "inherits": ["Target"],
@@ -871,7 +871,7 @@
         "progen": {"target":"nucleo-l011k4"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
 
     "NUCLEO_L031K6": {
@@ -885,7 +885,7 @@
         "progen": {"target": "nucleo-l031k6"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_L053R8": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -897,7 +897,7 @@
         "progen": {"target": "nucleo-l053r8"},
         "detect_code": ["0715"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NUCLEO_L073RZ": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -909,7 +909,7 @@
         "progen": {"target": "nucleo-l073rz"},
         "detect_code": ["0760"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_L152RE": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -921,7 +921,7 @@
         "progen": {"target": "nucleo-l152re"},
         "detect_code": ["0710"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_L432KC": {
         "supported_form_factors": ["ARDUINO"],
@@ -933,7 +933,7 @@
         "progen": {"target": "nucleo-l432kc"},
         "detect_code": ["0770"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "CAN", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "NUCLEO_L476RG": {
         "supported_form_factors": ["ARDUINO", "MORPHO"],
@@ -945,7 +945,7 @@
         "progen": {"target": "nucleo-l476rg"},
         "detect_code": ["0765"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "STM32F3XX": {
         "inherits": ["Target"],
@@ -970,7 +970,7 @@
         "inherits": ["Target"],
         "progen": {"target": "arch-max"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "DISCO_F051R8": {
         "inherits": ["Target"],
@@ -1005,7 +1005,7 @@
         "progen": {"target": "disco-f334c8"},
         "detect_code": ["0810"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "DISCO_F407VG": {
         "inherits": ["Target"],
@@ -1023,7 +1023,7 @@
         "supported_toolchains": ["ARM", "uARM", "GCC_ARM", "IAR"],
         "progen": {"target": "disco-f429zi"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "DISCO_F469NI": {
         "supported_form_factors": ["ARDUINO"],
@@ -1035,7 +1035,7 @@
         "progen": {"target": "disco-f469ni"},
         "detect_code": ["0788"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "DISCO_L053C8": {
         "inherits": ["Target"],
@@ -1045,7 +1045,7 @@
         "supported_toolchains": ["ARM", "uARM", "IAR", "GCC_ARM"],
         "progen": {"target": "disco-l053c8"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "DISCO_F746NG": {
         "inherits": ["Target"],
@@ -1056,7 +1056,7 @@
         "progen": {"target": "disco-f746ng"},
         "detect_code": ["0815"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "DISCO_L476VG": {
         "inherits": ["Target"],
@@ -1067,7 +1067,7 @@
         "progen": {"target": "disco-l476vg"},
         "detect_code": ["0820"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "CAN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "MTS_MDOT_F405RG": {
         "inherits": ["Target"],
@@ -1078,7 +1078,7 @@
         "macros": ["HSE_VALUE=26000000", "OS_CLOCK=48000000"],
         "progen": {"target": "mts-mdot-f405rg"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "MTS_MDOT_F411RE": {
         "inherits": ["Target"],
@@ -1092,7 +1092,7 @@
         },
         "progen": {"target": "mts-mdot-f411re"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "MTS_DRAGONFLY_F411RE": {
         "inherits": ["Target"],
@@ -1106,7 +1106,7 @@
         },
         "progen": {"target": "mts-dragonfly-f411re"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "MOTE_L152RC": {
         "inherits": ["Target"],
@@ -1118,7 +1118,7 @@
         "detect_code": ["4100"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "DISCO_F401VC": {
         "inherits": ["Target"],
@@ -1291,7 +1291,7 @@
         "extra_labels_add": ["NRF51822", "NRF51822_MKIT"],
         "macros_add": ["TARGET_NRF51822_MKIT"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NRF51822_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1310,7 +1310,7 @@
         "inherits": ["MCU_NRF51_16K"],
         "progen": {"target": "arch-ble"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARCH_BLE_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1346,7 +1346,7 @@
         "inherits": ["MCU_NRF51_16K"],
         "progen": {"target": "seed-tinyble"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "SEEED_TINY_BLE_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1363,7 +1363,7 @@
         "progen": {"target": "hrm1017"},
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "HRM1017_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1380,7 +1380,7 @@
         "inherits": ["MCU_NRF51_16K"],
         "progen": {"target": "rblab-nrf51822"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "RBLAB_NRF51822_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1397,7 +1397,7 @@
     "RBLAB_BLENANO": {
         "inherits": ["MCU_NRF51_16K"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "RBLAB_BLENANO_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1416,7 +1416,7 @@
     "WALLBOT_BLE": {
         "inherits": ["MCU_NRF51_16K"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "WALLBOT_BLE_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1434,7 +1434,7 @@
         "progen": {"target": "dfcm-nnn40"},
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "DEBUG_AWARENESS", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "DELTA_DFCM_NNN40_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],
@@ -1453,7 +1453,7 @@
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dk"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NRF51_DK_BOOT": {
         "supported_form_factors": ["ARDUINO"],
@@ -1471,7 +1471,7 @@
         "inherits": ["MCU_NRF51_32K"],
         "progen": {"target": "nrf51-dongle"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NRF51_DONGLE_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],
@@ -1487,7 +1487,7 @@
         "inherits": ["MCU_NRF51_16K_S110"],
         "macros_add": ["TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NRF51_MICROBIT_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT_S110"],
@@ -1504,7 +1504,7 @@
         "extra_labels_add": ["NRF51_MICROBIT"],
         "macros_add": ["TARGET_NRF51_MICROBIT", "TARGET_NRF_LFCLK_RC"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "NRF51_MICROBIT_B_BOOT": {
         "inherits": ["MCU_NRF51_16K_BOOT"],
@@ -1520,7 +1520,7 @@
         "inherits": ["MCU_NRF51_32K"],
         "macros_add": ["TARGET_NRF_32MHZ_XTAL"],
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "SERIAL", "SLEEP", "SPI", "SPISLAVE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "TY51822R3_BOOT": {
         "inherits": ["MCU_NRF51_32K_BOOT"],
@@ -1544,7 +1544,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0"],
         "macros": ["CMSDK_CM0"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARM_MPS2_M0P": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1553,7 +1553,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M0P"],
         "macros": ["CMSDK_CM0plus"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARM_MPS2_M1": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1570,7 +1570,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M3"],
         "macros": ["CMSDK_CM3"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARM_MPS2_M4": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1579,7 +1579,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M4"],
         "macros": ["CMSDK_CM4"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARM_MPS2_M7": {
         "inherits": ["ARM_MPS2_Target"],
@@ -1588,7 +1588,7 @@
         "extra_labels": ["ARM_SSG", "MPS2", "MPS2_M7"],
         "macros": ["CMSDK_CM7"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARM_IOTSS_Target": {
         "inherits": ["Target"],
@@ -1602,7 +1602,7 @@
         "extra_labels": ["ARM_SSG", "IOTSS", "IOTSS_BEID"],
         "macros": ["CMSDK_BEID"],
         "device_has": ["AACI", "ANALOGIN", "CLCD", "ETHERNET", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SERIAL_FC", "SPI", "SPISLAVE", "TSC"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "ARM_BEETLE_SOC": {
         "inherits": ["ARM_IOTSS_Target"],
@@ -1619,7 +1619,7 @@
         },
         "device_has": ["ANALOGIN", "CLCD", "I2C", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "SERIAL", "SPI"],
 	"features": ["BLE"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "RZ_A1H": {
         "supported_form_factors": ["ARDUINO"],
@@ -1636,7 +1636,7 @@
         },
         "device_has": ["ANALOGIN", "CAN", "ERROR_PATTERN", "ETHERNET", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "features": ["IPV4"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "VK_RZ_A1H": {
         "inherits": ["Target"],
@@ -1662,7 +1662,7 @@
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
         "progen": {"target": "maxwsnenv"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "MAX32600MBED": {
         "inherits": ["Target"],
@@ -1672,7 +1672,7 @@
         "supported_toolchains": ["GCC_ARM", "IAR", "ARM"],
         "progen": {"target": "max32600mbed"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_FC", "SLEEP", "SPI", "STDIO_MESSAGES"],
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "EFM32GG_STK3700": {
         "inherits": ["Target"],
@@ -1683,7 +1683,7 @@
         "progen": {"target": "efm32gg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "EFM32LG_STK3600": {
         "inherits": ["Target"],
@@ -1694,7 +1694,7 @@
         "progen": {"target": "efm32lg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "EFM32WG_STK3800": {
         "inherits": ["Target"],
@@ -1705,7 +1705,7 @@
         "progen": {"target": "efm32wg-stk"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "EFM32ZG_STK3200": {
         "inherits": ["Target"],
@@ -1720,7 +1720,7 @@
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "default_build": "small",
         "forced_reset_timeout": 2,
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "EFM32HG_STK3400": {
         "inherits": ["Target"],
@@ -1735,7 +1735,7 @@
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "default_build": "small",
         "forced_reset_timeout": 2,
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "EFM32PG_STK3401": {
         "inherits": ["Target"],
@@ -1746,7 +1746,7 @@
         "progen": {"target": "efm32pg-stk"},
         "device_has": ["ANALOGIN", "ERROR_PATTERN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "LOWPOWERTIMER", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH", "STDIO_MESSAGES"],
         "forced_reset_timeout": 2,
-        "release": ["2", "5"]
+        "release_versions": ["2", "5"]
     },
     "WIZWIKI_W7500": {
         "supported_form_factors": ["ARDUINO"],
@@ -1756,7 +1756,7 @@
         "inherits": ["Target"],
         "progen": {"target": "wizwiki-w7500"},
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "WIZWIKI_W7500P": {
         "supported_form_factors": ["ARDUINO"],
@@ -1766,7 +1766,7 @@
         "inherits": ["Target"],
         "progen": {"target": "wizwiki-w7500p"},
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "WIZWIKI_W7500ECO": {
         "inherits": ["Target"],
@@ -1775,7 +1775,7 @@
         "extra_labels": ["WIZNET", "W7500x", "WIZwiki_W7500ECO"],
         "supported_toolchains": ["uARM", "ARM"],
         "device_has": ["ANALOGIN", "I2C", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "SAMR21G18A": {
         "inherits": ["Target"],
@@ -1785,7 +1785,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
         "progen": {"target": "samr21g18a"},
         "device_has": ["ANALOGIN", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "SAMD21J18A": {
         "inherits": ["Target"],
@@ -1795,7 +1795,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
         "progen": {"target": "samd21j18a"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "SAMD21G18A": {
         "inherits": ["Target"],
@@ -1805,7 +1805,7 @@
         "supported_toolchains": ["GCC_ARM", "ARM", "uARM"],
         "progen": {"target": "samd21g18a"},
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "I2C_ASYNCH", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "SERIAL", "SERIAL_ASYNCH", "SERIAL_FC", "SLEEP", "SPI", "SPISLAVE", "SPI_ASYNCH"],
-        "release": ["2"]
+        "release_versions": ["2"]
     },
     "SAML21J18A": {
         "inherits": ["Target"],

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -127,7 +127,7 @@ def is_official_target(target_name, version):
     reason = None
     target = TARGET_MAP[target_name]
     
-    if hasattr(target, 'release') and version in target.release:
+    if hasattr(target, 'release_versions') and version in target.release_versions:
         if version == '2':
             # For version 2, either ARM or uARM toolchain support is required
             required_toolchains = set(['ARM', 'uARM'])
@@ -163,10 +163,10 @@ def is_official_target(target_name, version):
 
     else:
         result = False
-        if not hasattr(target, 'release'):
-            reason = "Target '%s' does not have the 'release' key set" % target.name
-        elif not version in target.release:
-            reason = "Target '%s' does not contain the version '%s' in its 'release' key" % (target.name, version)
+        if not hasattr(target, 'release_versions'):
+            reason = "Target '%s' does not have the 'release_versions' key set" % target.name
+        elif not version in target.release_versions:
+            reason = "Target '%s' does not contain the version '%s' in its 'release_versions' key" % (target.name, version)
     
     return result, reason
 
@@ -200,7 +200,7 @@ def get_mbed_official_release(version):
                     TARGET_MAP[target].name,
                     tuple(transform_release_toolchains(TARGET_MAP[target].supported_toolchains, version))
                 ]
-            ) for target in TARGET_NAMES if (hasattr(TARGET_MAP[target], 'release') and version in TARGET_MAP[target].release)
+            ) for target in TARGET_NAMES if (hasattr(TARGET_MAP[target], 'release_versions') and version in TARGET_MAP[target].release_versions)
         )
     )
     

--- a/tools/build_release.py
+++ b/tools/build_release.py
@@ -28,6 +28,7 @@ sys.path.insert(0, ROOT)
 
 from tools.build_api import build_mbed_libs
 from tools.build_api import write_build_report
+from tools.build_api import get_mbed_official_release
 from tools.targets import TARGET_MAP, TARGET_NAMES
 from tools.test_exporters import ReportExporter, ResultExporterType
 from tools.test_api import SingleTestRunner
@@ -35,10 +36,7 @@ from tools.test_api import singletest_in_cli_mode
 from tools.paths import TEST_DIR, MBED_LIBRARIES
 from tools.tests import TEST_MAP
 
-OFFICIAL_MBED_LIBRARY_BUILD = (
-    tuple(tuple([TARGET_MAP[target].name, tuple(TARGET_MAP[target].supported_toolchains)]) for target in TARGET_NAMES if TARGET_MAP[target].release)
-)
-
+OFFICIAL_MBED_LIBRARY_BUILD = get_mbed_official_release('2')
 
 if __name__ == '__main__':
     parser = OptionParser()

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -167,6 +167,9 @@ class ToolException(Exception):
 class NotSupportedException(Exception):
     pass
 
+class InvalidReleaseTargetException(Exception):
+    pass
+
 def split_path(path):
     base, file = split(path)
     name, ext = splitext(file)


### PR DESCRIPTION
# Intro
This introduces the concept of "release versions" to the tools.

Previously, the condition for including a target in a release was decided by a `release` key being set to `true` in `hal/targets.json`. This doesn't have enough granularity when we release multiple versions of mbed.

# Todo
- [ ]  Review by @screamerbg 

# Code Changes
This PR changes the `release` key in `hal/targets.json` to an array of strings, where each member is a version that the target supports. Currently the valid versions are `"2"` and `"5"`.

You can now build up lists of these release configurations by calling the new function `get_mbed_official_release` in `build_api.py`. This function add checks for invalid target configurations in a release. This is enforced whenever it is called, preventing invalid targets from coming into the release.

It updates the `build_release.py` script to use `get_mbed_official_release` for fetching release targets.

It modifies the behavior of `mcu_toolchain_matrix` in `build_api.py`. It now prints release version support in the matrix. It also defaults to only showing targets supported by mbed OS 5. You can still show older release versions by modifying the `release_version` parameter of `mcu_toolchain_matrix`.


# Public facing changes

## New format of `release` key in `hal/targets.json`
Old
```
...

"LPC1768": {
        ...  
        "release": true
    },

...
```

New
```
...

"LPC1768": {
        ...
        "release": ["2", "5"]
    },

...
```

## Removal of LPC2460 and XBED_LPC1768 from `build_release.py`
These two platforms do not support the `ARM` or `uARM` toolchain, so they are not supported by the version 2 release.

## Version 5 supports only `ARM`, `GCC_ARM`, and `IAR` toolchains
Even if a platform supports `uARM` or `GCC_CR`, only `ARM`, `GCC_ARM`, and `IAR` will be returned in the release target tuple returned by `get_mbed_official_release`.

## MCU-Toolchain matrix
Old output of `python tools\make.py -S`:
```
+-----------------------+-----------+-----------+-----------+-----------+-----------+
| Target                |    ARM    |  GCC_ARM  |    uARM   |   GCC_CR  |    IAR    |
+-----------------------+-----------+-----------+-----------+-----------+-----------+
| ARCH_BLE              | Supported | Supported |     -     |     -     |     -     |
| ARCH_BLE_BOOT         | Supported | Supported |     -     |     -     |     -     |

...

+----------------------+-----------+-----------+-----------+-----------+-----------+
Supported targets: N
```

New output of `python tools\make.py -S`:
```
+----------------------+-----------+-----------+-----------+-----------+-----------+
| Target               | mbed OS 2 | mbed OS 5 |    ARM    |  GCC_ARM  |    IAR    |
+----------------------+-----------+-----------+-----------+-----------+-----------+
| TARGET1              | Supported | Supported | Supported | Supported | Supported |
| TARGET2              | Supported | Supported | Supported | Supported | Supported |

...

+----------------------+-----------+-----------+-----------+-----------+-----------+
Supported targets: N
```

## Enforcement of valid release target configurations

For the following examples, I removed both `ARM` and `uARM` from the LPC11U68 `supported_toolchains` key.

```
C:\Users\bridan01\Documents\dev\m_mbed\mbed>python tools\build_release.py -L
Traceback (most recent call last):
  File "tools\build_release.py", line 39, in <module>
    OFFICIAL_MBED_LIBRARY_BUILD = get_mbed_official_release('2')
  File "C:\Users\bridan01\Documents\dev\m_mbed\mbed\tools\build_api.py", line 183, in get_mbed_official_release
    raise InvalidReleaseTargetException(reason)
tools.utils.InvalidReleaseTargetException: Target 'LPC11U68' must support one of the folowing toolchains to be included in the mbed 2.0 official release: uARM, ARM
Currently it is only configured to support the following toolchains: GCC_CR, GCC_ARM, IAR



C:\Users\bridan01\Documents\dev\m_mbed\mbed>python tools\build_release.py -L
Traceback (most recent call last):
  File "tools\build_release.py", line 39, in <module>
    OFFICIAL_MBED_LIBRARY_BUILD = get_mbed_official_release('5')
  File "C:\Users\bridan01\Documents\dev\m_mbed\mbed\tools\build_api.py", line 183, in get_mbed_official_release
    raise InvalidReleaseTargetException(reason)
tools.utils.InvalidReleaseTargetException: Target 'LPC11U68' must support ALL of the folowing toolchains to be included in the mbed OS 5.0 official release: ARM, GCC_ARM, IAR
Currently it is only configured to support the following toolchains: GCC_ARM, GCC_CR, IAR
```

cc @0xc0170 @bogdanm 