### PR TITLE
Change default_build from small to standard on NRF based targets with at least 32K of RAM.

### DIFF
--- a/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/basic/main.cpp
@@ -24,7 +24,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
 #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-#define STACK_SIZE 512
+#define STACK_SIZE 768
 #else
 #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/isr/main.cpp
@@ -27,7 +27,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mail/main.cpp
@@ -35,7 +35,7 @@ typedef struct {
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/mutex/main.cpp
@@ -37,7 +37,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 1024
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/queue/main.cpp
@@ -35,7 +35,7 @@ typedef struct {
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/semaphore/main.cpp
@@ -40,7 +40,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
+++ b/TESTS/mbedmicro-rtos-mbed/signals/main.cpp
@@ -26,7 +26,7 @@ const int SIGNAL_HANDLE_DELEY = 25;
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822) || defined(TARGET_MCU_NRF52832)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/hal/targets.json
+++ b/hal/targets.json
@@ -1195,14 +1195,14 @@
             "toolchains": ["ARM_STD", "GCC_ARM"]
         },
         "program_cycle_s": 6,
-        "default_build": "small",
         "features": ["BLE"]
     },
     "MCU_NRF51_16K_BASE": {
         "inherits": ["MCU_NRF51"],
         "extra_labels_add": ["MCU_NORDIC_16K", "MCU_NRF51_16K"],
         "macros_add": ["TARGET_MCU_NORDIC_16K", "TARGET_MCU_NRF51_16K"],
-        "public": false
+        "public": false,
+        "default_build": "small"
     },
     "MCU_NRF51_16K_BOOT_BASE": {
         "inherits": ["MCU_NRF51_16K_BASE"],
@@ -1860,7 +1860,6 @@
             "toolchains": ["ARM_STD", "GCC_ARM", "IAR"]
         },
         "program_cycle_s": 6,
-        "default_build": "small",
         "features": ["BLE"],
         "config":{
             "lf_clock_src": {
@@ -1912,8 +1911,7 @@
                 "value": "NRF_LF_SRC_XTAL",
                 "macro_name": "MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC"
             }
-        },
-        "default_build": "small"
+        }
     },
     "NRF52_DK": {
         "supported_form_factors": ["ARDUINO"],

--- a/libraries/tests/rtos/mbed/basic/main.cpp
+++ b/libraries/tests/rtos/mbed/basic/main.cpp
@@ -24,7 +24,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/libraries/tests/rtos/mbed/isr/main.cpp
+++ b/libraries/tests/rtos/mbed/isr/main.cpp
@@ -27,7 +27,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/libraries/tests/rtos/mbed/mail/main.cpp
+++ b/libraries/tests/rtos/mbed/mail/main.cpp
@@ -35,7 +35,7 @@ typedef struct {
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/libraries/tests/rtos/mbed/mutex/main.cpp
+++ b/libraries/tests/rtos/mbed/mutex/main.cpp
@@ -37,7 +37,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/libraries/tests/rtos/mbed/queue/main.cpp
+++ b/libraries/tests/rtos/mbed/queue/main.cpp
@@ -35,7 +35,7 @@ typedef struct {
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/libraries/tests/rtos/mbed/semaphore/main.cpp
+++ b/libraries/tests/rtos/mbed/semaphore/main.cpp
@@ -40,7 +40,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif

--- a/libraries/tests/rtos/mbed/signals/main.cpp
+++ b/libraries/tests/rtos/mbed/signals/main.cpp
@@ -26,7 +26,7 @@
 #elif (defined(TARGET_EFM32GG_STK3700)) && !defined(TOOLCHAIN_ARM_MICRO)
     #define STACK_SIZE 1536
 #elif defined(TARGET_MCU_NRF51822)
-    #define STACK_SIZE 512
+    #define STACK_SIZE 768
 #else
     #define STACK_SIZE DEFAULT_STACK_SIZE
 #endif


### PR DESCRIPTION
NRF targets with 16K of RAM keep their default_build configuration set to small.
Enabling standard build consume 5K of RAM which is huge on a platform with only 6K of RAM usable.

This PR is a follow up to #2258 