### PR TITLE
[tools] Fix precedence issue in cumulative attribute set-arithmetic

### DIFF
--- a/tools/config.py
+++ b/tools/config.py
@@ -169,7 +169,8 @@ class ConfigCumulativeOverride:
 
     def update_target(self, target):
         setattr(target, self.name, list(
-                set(getattr(target, self.name, [])) | self.additions - self.removals))
+                (set(getattr(target, self.name, [])) | self.additions) - self.removals))
+
 
 
 # 'Config' implements the mbed configuration mechanism

--- a/tools/test/config_test/test27/lib1/mbed_lib.json
+++ b/tools/test/config_test/test27/lib1/mbed_lib.json
@@ -1,0 +1,8 @@
+{
+    "name": "lib1",
+    "target_overrides": {
+        "*": {
+            "target.features_remove": ["IPV4"]
+        }
+    }
+}

--- a/tools/test/config_test/test27/mbed_app.json
+++ b/tools/test/config_test/test27/mbed_app.json
@@ -1,0 +1,11 @@
+{
+    "custom_targets": {
+        "test_target": {
+            "core": "Cortex-M0",
+            "extra_labels": [],
+            "features": ["IPV4"],
+            "default_build": "standard"
+        }
+    }
+}
+

--- a/tools/test/config_test/test27/test_data.py
+++ b/tools/test/config_test/test27/test_data.py
@@ -1,0 +1,8 @@
+# Testing when adding two features
+
+expected_results = {
+    "test_target": {
+        "desc": "test removing features",
+        "expected_features": []
+    }
+}


### PR DESCRIPTION
Basically this:
```
a | b - c  !=  (a | b) - c
```

Prevented cumulative overrides from being correctly removed.

cc @screamerbg 