### PR TITLE
[HAL] Modified SPI to use shared mutex

### DIFF
--- a/hal/api/SPI.h
+++ b/hal/api/SPI.h
@@ -21,6 +21,7 @@
 #if DEVICE_SPI
 
 #include "spi_api.h"
+#include "SingletonPtr.h"
 
 #if DEVICE_SPI_ASYNCH
 #include "CThunk.h"
@@ -246,7 +247,7 @@ protected:
 
     void aquire(void);
     static SPI *_owner;
-    PlatformMutex _mutex;
+    static SingletonPtr<PlatformMutex> _mutex;
     int _bits;
     int _mode;
     int _hz;

--- a/hal/common/SPI.cpp
+++ b/hal/common/SPI.cpp
@@ -57,6 +57,7 @@ void SPI::frequency(int hz) {
 }
 
 SPI* SPI::_owner = NULL;
+SingletonPtr<PlatformMutex> SPI::_mutex;
 
 // ignore the fact there are multiple physical spis, and always update if it wasnt us last
 void SPI::aquire() {
@@ -78,11 +79,11 @@ int SPI::write(int value) {
 }
 
 void SPI::lock() {
-    _mutex.lock();
+    _mutex->lock();
 }
 
 void SPI::unlock() {
-    _mutex.unlock();
+    _mutex->unlock();
 }
 
 #if DEVICE_SPI_ASYNCH


### PR DESCRIPTION
Modified the `SPI` class to use a shared mutex for all instances in response to #2276. This is consistent with `I2C` and others.