### PR TITLE
Enforcing 'standard' build for version 5 release

### DIFF
--- a/hal/targets.json
+++ b/hal/targets.json
@@ -220,7 +220,7 @@
         "detect_code": ["1168"],
         "device_has": ["ANALOGIN", "ERROR_RED", "I2C", "I2CSLAVE", "INTERRUPTIN", "PWMOUT", "RTC", "SERIAL", "SLEEP", "SPI"],
         "default_build": "small",
-        "release_versions": ["2", "5"]
+        "release_versions": ["2"]
     },
     "LPC1347": {
         "inherits": ["LPCTarget"],
@@ -1118,7 +1118,7 @@
         "detect_code": ["4100"],
         "device_has": ["ANALOGIN", "ANALOGOUT", "I2C", "I2CSLAVE", "INTERRUPTIN", "PORTIN", "PORTINOUT", "PORTOUT", "PWMOUT", "RTC", "RTC_LSI", "SERIAL", "SLEEP", "SPI", "SPISLAVE", "STDIO_MESSAGES"],
         "default_build": "small",
-        "release_versions": ["2", "5"]
+        "release_versions": ["2"]
     },
     "DISCO_F401VC": {
         "inherits": ["Target"],

--- a/tools/build_api.py
+++ b/tools/build_api.py
@@ -156,6 +156,14 @@ def is_official_target(target_name, version):
                     (("official release: %s" + linesep) % ", ".join(required_toolchains_sorted)) + \
                     ("Currently it is only configured to support the ") + \
                     ("following toolchains: %s" % ", ".join(supported_toolchains_sorted))
+
+            elif not target.default_build == 'standard':
+                result = False
+                reason = ("Target '%s' must set the 'default_build' " % target.name) + \
+                    ("to 'standard' to be included in the mbed OS 5.0 ") + \
+                    ("official release." + linesep) + \
+                    ("Currently it is set to '%s'" % target.default_build)
+
         else:
             result = False
             reason = ("Target '%s' has set an invalid release version of '%s'" % version) + \


### PR DESCRIPTION
This PR enforces that the `default_build` in a target's definition in `hal/targets.json` is set to `standard` to be included in the version 5 release.

This is being enforced because `small` builds do not support multi-threading. This makes the capabilities more consistent across all boards in the version 5 release.

NOTE: This removes the MOTE_L152RC and the LPC11U68
from the version 5 release list because the 'default_build' for these
targets is currently set to 'small'.