### PR TITLE
Fix RTC test for LPC and STM families on GCC

### DIFF
--- a/hal/api/AnalogIn.h
+++ b/hal/api/AnalogIn.h
@@ -22,6 +22,7 @@
 
 #include "analogin_api.h"
 #include "SingletonPtr.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/AnalogOut.h
+++ b/hal/api/AnalogOut.h
@@ -21,6 +21,7 @@
 #if DEVICE_ANALOGOUT
 
 #include "analogout_api.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/BusIn.h
+++ b/hal/api/BusIn.h
@@ -18,6 +18,7 @@
 
 #include "platform.h"
 #include "DigitalIn.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/BusInOut.h
+++ b/hal/api/BusInOut.h
@@ -17,6 +17,7 @@
 #define MBED_BUSINOUT_H
 
 #include "DigitalInOut.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/BusOut.h
+++ b/hal/api/BusOut.h
@@ -17,6 +17,7 @@
 #define MBED_BUSOUT_H
 
 #include "DigitalOut.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/CAN.h
+++ b/hal/api/CAN.h
@@ -23,6 +23,7 @@
 #include "can_api.h"
 #include "can_helper.h"
 #include "Callback.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/FileBase.h
+++ b/hal/api/FileBase.h
@@ -42,6 +42,7 @@ typedef long off_t;
 
 #include "platform.h"
 #include "SingletonPtr.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/I2C.h
+++ b/hal/api/I2C.h
@@ -22,6 +22,7 @@
 
 #include "i2c_api.h"
 #include "SingletonPtr.h"
+#include "PlatformMutex.h"
 
 #if DEVICE_I2C_ASYNCH
 #include "CThunk.h"

--- a/hal/api/InterruptManager.h
+++ b/hal/api/InterruptManager.h
@@ -1,10 +1,9 @@
 #ifndef MBED_INTERRUPTMANAGER_H
 #define MBED_INTERRUPTMANAGER_H
 
-#include "platform.h"
-
 #include "cmsis.h"
 #include "CallChain.h"
+#include "PlatformMutex.h"
 #include <string.h>
 
 namespace mbed {

--- a/hal/api/LocalFileSystem.h
+++ b/hal/api/LocalFileSystem.h
@@ -21,6 +21,7 @@
 #if DEVICE_LOCALFILESYSTEM
 
 #include "FileSystemLike.h"
+#include "PlatformMutex.h"
 
 namespace mbed {
 

--- a/hal/api/PlatformMutex.h
+++ b/hal/api/PlatformMutex.h
@@ -13,16 +13,34 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#ifndef MBED_PLATFORM_H
-#define MBED_PLATFORM_H
+#ifndef PLATFORM_MUTEX_H
+#define PLATFORM_MUTEX_H
 
-#include "device.h"
-#include "PinNames.h"
-#include "PeripheralNames.h"
+#ifdef MBED_CONF_RTOS_PRESENT
+#include "Mutex.h"
+typedef rtos::Mutex PlatformMutex;
+#else
+/** A stub mutex for when an RTOS is not present
+*/
+class PlatformMutex {
+public:
+    PlatformMutex() {
+        // Stub
 
-#include <cstddef>
-#include <cstdlib>
-#include <cstdio>
-#include <cstring>
+    }
+    ~PlatformMutex() {
+        // Stub
+    }
+
+    void lock() {
+        // Do nothing
+    }
+
+    void unlock() {
+        // Do nothing
+    }
+};
+
+#endif
 
 #endif

--- a/hal/api/SPI.h
+++ b/hal/api/SPI.h
@@ -20,6 +20,7 @@
 
 #if DEVICE_SPI
 
+#include "PlatformMutex.h"
 #include "spi_api.h"
 
 #if DEVICE_SPI_ASYNCH

--- a/hal/api/Serial.h
+++ b/hal/api/Serial.h
@@ -22,6 +22,7 @@
 
 #include "Stream.h"
 #include "SerialBase.h"
+#include "PlatformMutex.h"
 #include "serial_api.h"
 
 namespace mbed {

--- a/hal/common/retarget.cpp
+++ b/hal/common/retarget.cpp
@@ -22,6 +22,7 @@
 #include "semihost_api.h"
 #include "mbed_interface.h"
 #include "SingletonPtr.h"
+#include "PlatformMutex.h"
 #if DEVICE_STDIO_MESSAGES
 #include <stdio.h>
 #endif

--- a/libraries/fs/fat/FATDirHandle.h
+++ b/libraries/fs/fat/FATDirHandle.h
@@ -23,7 +23,7 @@
 #define MBED_FATDIRHANDLE_H
 
 #include "DirHandle.h"
-#include "platform.h"
+#include "PlatformMutex.h"
 
 using namespace mbed;
 

--- a/libraries/fs/fat/FATFileHandle.h
+++ b/libraries/fs/fat/FATFileHandle.h
@@ -23,7 +23,7 @@
 #define MBED_FATFILEHANDLE_H
 
 #include "FileHandle.h"
-#include "platform.h"
+#include "PlatformMutex.h"
 
 using namespace mbed;
 

--- a/libraries/fs/fat/FATFileSystem.h
+++ b/libraries/fs/fat/FATFileSystem.h
@@ -26,7 +26,7 @@
 #include "FileHandle.h"
 #include "ff.h"
 #include <stdint.h>
-#include "platform.h"
+#include "PlatformMutex.h"
 
 using namespace mbed;
 


### PR DESCRIPTION
Remove the critical section in mbed_rtc_time.c and instead use a
mutex to protect this. This function does not need to be interrupt
safe, just thread safe.

This fixes crashes on the GCC_ARM toolchain on the RTC test due to
trying to lock the GCC environment mutex while in a critical section.
Prior to this patch, this failure was likely to occur on STM and LPC
processor families.