### PR TITLE
Fix clock selection used by the softdevice on NRF5 based targets.

### DIFF
--- a/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_clock.h
+++ b/features/FEATURE_BLE/targets/TARGET_NORDIC/TARGET_NRF5/source/btle/btle_clock.h
@@ -72,6 +72,9 @@
 #define DEFAULT_LFCLK_CONF_RC_CTIV 16     // Check temperature every 16 * 250ms.
 #define DEFAULT_LFCLK_CONF_RC_TEMP_CTIV 1 // Only calibrate if temperature has changed.
 
+#define NRF_LF_SRC_XTAL  2 
+#define NRF_LF_SRC_SYNTH 3 
+#define NRF_LF_SRC_RC    4
 
 #if MBED_CONF_NORDIC_NRF_LF_CLOCK_SRC == NRF_LF_SRC_RC
     #define LFCLK_CONF_SOURCE       NRF_CLOCK_LF_SRC_RC


### PR DESCRIPTION
This patch fix the clock selection for the ble stack on NRF51_DK and NRF52_DK.
Without it, ble not work correctly on NRF52.