### PR TITLE
Revert "Force installation of dependencies in entry points"

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -26,13 +26,6 @@ from os.path import join, abspath, dirname
 ROOT = abspath(join(dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-from tools.utils import install_from_pip
-with open(join(ROOT, "requirements.txt")) as reqs:
-    for req in reqs:
-        install_from_pip(req)
-
-import site
-reload(site)
 
 from tools.toolchains import TOOLCHAINS
 from tools.toolchains import mbedToolchain

--- a/tools/make.py
+++ b/tools/make.py
@@ -27,14 +27,6 @@ from os.path import join, abspath, dirname, isfile, isdir
 ROOT = abspath(join(dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-from tools.utils import install_from_pip
-with open(join(ROOT, "requirements.txt")) as reqs:
-    for req in reqs:
-        install_from_pip(req)
-
-import site
-reload(site)
-
 from tools.utils import args_error
 from tools.paths import BUILD_DIR
 from tools.paths import RTOS_LIBRARIES
@@ -57,7 +49,6 @@ from utils import argparse_dir_not_parent
 from argparse import ArgumentTypeError
 from tools.toolchains import mbedToolchain
 from tools.settings import CLI_COLOR_MAP
-
 
 if __name__ == '__main__':
     # Parse Options

--- a/tools/project.py
+++ b/tools/project.py
@@ -3,14 +3,6 @@ from os.path import join, abspath, dirname, exists, basename
 ROOT = abspath(join(dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-from tools.utils import install_from_pip
-with open(join(ROOT, "requirements.txt")) as reqs:
-    for req in reqs:
-        install_from_pip(req)
-
-import site
-reload(site)
-
 from shutil import move, rmtree
 from argparse import ArgumentParser
 from os import path

--- a/tools/test.py
+++ b/tools/test.py
@@ -26,14 +26,6 @@ import fnmatch
 ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), ".."))
 sys.path.insert(0, ROOT)
 
-from tools.utils import install_from_pip
-with open(os.path.join(ROOT, "requirements.txt")) as reqs:
-    for req in reqs:
-        install_from_pip(req)
-
-import site
-reload(site)
-
 from tools.test_api import test_path_to_name, find_tests, print_tests, build_tests, test_spec_from_test_builds
 from tools.options import get_default_options_parser
 from tools.build_api import build_project, build_library

--- a/tools/utils.py
+++ b/tools/utils.py
@@ -338,15 +338,3 @@ def argparse_dir_not_parent(other):
         else:
             return not_parent
     return parse_type
-
-def install_from_pip(package):
-    import pkg_resources
-    try:
-        pkg_resources.working_set.require(package)
-    except (pkg_resources.DistributionNotFound, pkg_resources.VersionConflict):
-        import pip
-        try:
-            pip.main(['install', '--user', '-q', package])
-        except IOError as exc:
-            if exc.errno == 13:
-                print "please retry with sudo"


### PR DESCRIPTION
Reverts mbedmicro/mbed#2257

Corner cases around local / global / virtualenv use case needs more attention.